### PR TITLE
Enable caching for webp MIME type

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -123,6 +123,7 @@ class BrowserCache_Environment {
 		unset( $other_compression['png'] );
 		unset( $other_compression['ra|ram'] );
 		unset( $other_compression['tar'] );
+		unset( $other_compression['webp'] );
 		unset( $other_compression['wma'] );
 		unset( $other_compression['zip'] );
 


### PR DESCRIPTION
Currently, webp is included in the "other_compression" MIME type list, which
results in the ETag and Last-Modified headers being unset in the generated
.htaccess Browser Cache configuration.

This change removes webp from the "other_compression" mime type and enables
webp images to be probably cached by the browser.