### PR TITLE
Redis cluster support

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -331,7 +331,7 @@ class Cache_Redis extends Cache_Base {
 	}
 
 	private function _get_accessor( $key ) {
-		if ( count( $this->_servers ) <= 1 || W3TC_REDIS_CLUSTER )
+		if ( count( $this->_servers ) <= 1 || ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) ) {
 			$index = 0;
 		else {
 			$index = crc32( $key ) % count( $this->_servers );
@@ -344,7 +344,7 @@ class Cache_Redis extends Cache_Base {
 			$this->_accessors[$index] = null;
 		else {
 			try {
-				if ( W3TC_REDIS_CLUSTER === true ) {
+				if ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) {
 					$accessor = new \RedisCluster(NULL, $this->_servers, 1.5, 1.5, $this->_persistent, $this->_password);
 				}
 				else {

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -11,6 +11,7 @@ class Cache_Redis extends Cache_Base {
 	private $_persistent;
 	private $_password;
 	private $_servers;
+	private $_class;
 	private $_dbid;
 
 	/**
@@ -23,6 +24,7 @@ class Cache_Redis extends Cache_Base {
 
 		$this->_persistent = ( isset( $config['persistent'] ) && $config['persistent'] );
 		$this->_servers = (array)$config['servers'];
+		$this->_class = $config['class'];
 		$this->_password = $config['password'];
 		$this->_dbid = $config['dbid'];
 
@@ -333,9 +335,9 @@ class Cache_Redis extends Cache_Base {
 	}
 
 	private function _get_accessor( $key ) {
-		if ( count( $this->_servers ) <= 1 || ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) ) {
+		if ( count( $this->_servers ) <= 1 || strtolower($this->_class) === "rediscluster" ) {
 			$index = 0;
-		else {
+		} else {
 			$index = crc32( $key ) % count( $this->_servers );
 		}
 
@@ -346,7 +348,7 @@ class Cache_Redis extends Cache_Base {
 			$this->_accessors[$index] = null;
 		else {
 			try {
-				if ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) {
+				if ( strtolower($this->_class) === "rediscluster" ) {
 					$accessor = new \RedisCluster(NULL, $this->_servers, 1.5, 1.5, $this->_persistent, $this->_password);
 				} else {
 					

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -298,6 +298,10 @@ $keys = array(
 			'127.0.0.1:6379'
 		)
 	),
+	'objectcache.redis.class' => array(
+		'type' => 'string',
+		'default' => 'redis' // Redis and RedisCluster currently supported
+	),
 	'objectcache.redis.password' => array(
 		'type' => 'string',
 		'default' => ''

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -47,7 +47,7 @@ class Generic_AdminActions_Test {
 		else {
 			$success = true;
 
-			if ( W3TC_REDIS_CLUSTER === true ) {
+			if ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) {
 				
 				$config = array(
 					'servers' => $servers,

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -48,7 +48,6 @@ class Generic_AdminActions_Test {
 			$success = true;
 
 			if ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) {
-				
 				$config = array(
 					'servers' => $servers,
 					'persistent' => false,
@@ -71,8 +70,7 @@ class Generic_AdminActions_Test {
 				if ( $test_value['content'] != $test_string ) {
 					$success = false;
 				}
-			}
-			else {
+			}	else {
 				foreach ( $servers as $server ) {
 					@$cache = Cache::instance( 'redis', array(
 							'servers' => $server,

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -39,15 +39,16 @@ class Generic_AdminActions_Test {
 	 */
 	function w3tc_test_redis() {
 		$servers    = Util_Request::get_array( 'servers' );
-		$password   = Util_Request::get_string('password', '');
+		$password   = Util_Request::get_string( 'password', '' );
 		$dbid       = Util_Request::get_integer( 'dbid', 0 );
+		$class      = Util_Request::get_string( 'class' );
 
 		if ( count( $servers ) <= 0 )
 			$success = false;
 		else {
 			$success = true;
 
-			if ( defined( 'W3TC_REDIS_CLUSTER' ) && W3TC_REDIS_CLUSTER ) {
+			if ( strtolower( $class ) === "rediscluster" ) {
 				$config = array(
 					'servers' => $servers,
 					'persistent' => false,

--- a/ObjectCache_ConfigLabels.php
+++ b/ObjectCache_ConfigLabels.php
@@ -11,6 +11,7 @@ class ObjectCache_ConfigLabels {
 				'objectcache.file.gc' => __( 'Garbage collection interval:', 'w3-total-cache' ),
 				'objectcache.groups.global' => __( 'Global groups:', 'w3-total-cache' ),
 				'objectcache.groups.nonpersistent' => __( 'Non-persistent groups:', 'w3-total-cache' ),
+				'objectcache.redis.class' => __( 'Redis Class', 'w3-total-cache' ),
 				'objectcache.purge.all' => __( 'Flush all cache on post, comment etc changes.', 'w3-total-cache' )
 			) );
 	}

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -320,6 +320,7 @@ class ObjectCache_Plugin {
 		} elseif ( $c->get_string( 'objectcache.engine' ) == 'redis' ) {
 			$sources['redis_servers']['objectcache'] = array(
 				'servers' => $c->get_array( 'objectcache.redis.servers' ),
+				'class' => $c->get_string( 'objectcache.redis.class' ),
 				'username' => $c->get_boolean( 'objectcache.redis.username' ),
 				'dbid' => $c->get_integer( 'objectcache.redis.dbid' ),
 				'password' => $c->get_string( 'objectcache.redis.password' ),

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -23,6 +23,18 @@ if ( !defined( 'W3TC' ) )
 		<p class="description"><?php _e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
+<?php
+Util_Ui::config_item( array(
+		'key' => 'objectcache.redis.class',
+		'control' => 'selectbox',
+		'selectbox_values' => array(
+			'redis' => __( 'Redis', 'w3-total-cache' ),
+			'rediscluster' => __( 'Redis Cluster', 'w3-total-cache' )
+		),
+		'description' => __( 'What Redis Class should be used.',
+			'w3-total-cache' )
+	) );
+?>
 <tr>
 	<th><label><?php _e( 'Use persistent connection:', 'w3-total-cache' ); ?></label></th>
 	<td>

--- a/inc/options/parts/redis_extension.php
+++ b/inc/options/parts/redis_extension.php
@@ -28,6 +28,15 @@ $config = Dispatcher::config();
 <?php
 
 Util_Ui::config_item( array(
+	'key' => array( $module, 'redis.class' ),
+	'label' => __( 'Use Redis Cluster:', 'w3-total-cache' ),
+	'control' => 'checkbox',
+	'checkbox_label' => Util_ConfigLabel::get( 'redis.class' ),
+	'description' =>
+	'Use Redis Cluster'
+) );
+
+Util_Ui::config_item( array(
 		'key' => array( $module, 'redis.persistent' ),
 		'label' => __( 'Use persistent connection:', 'w3-total-cache' ),
 		'control' => 'checkbox',

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -131,6 +131,10 @@ if ( !defined( 'W3TC_FEED_REGEXP' ) ) {
 	define( 'W3TC_FEED_REGEXP', '~/feed(/|$)~' );
 }
 
+	// Set W3TC_REDIS_CLUSTER to true if using Redis in cluster mode 
+	if ( ! defined ( 'W3TC_REDIS_CLUSTER' ) ) {
+		define( 'W3TC_REDIS_CLUSTER', false );
+	}
 
 @ini_set( 'pcre.backtrack_limit', 4194304 );
 @ini_set( 'pcre.recursion_limit', 4194304 );

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -68,11 +68,6 @@ if ( ! defined( 'W3TC_IN_MINIFY' ) ) {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		require_once W3TC_DIR . '/Cli.php';
 	}
-	
-	// Set W3TC_REDIS_CLUSTER to true if using Redis in cluster mode 
-	if ( ! defined ( 'W3TC_REDIS_CLUSTER' ) ) {
-		define( 'W3TC_REDIS_CLUSTER', false );
-	}
 
 	// Include to prevent syntax error for older php.
 	require_once dirname( __FILE__ ) . '/Root_Loader.php';

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -68,6 +68,11 @@ if ( ! defined( 'W3TC_IN_MINIFY' ) ) {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		require_once W3TC_DIR . '/Cli.php';
 	}
+	
+	// Set W3TC_REDIS_CLUSTER to true if using Redis in cluster mode 
+	if ( ! defined ( 'W3TC_REDIS_CLUSTER' ) ) {
+		define( 'W3TC_REDIS_CLUSTER', false );
+	}
 
 	// Include to prevent syntax error for older php.
 	require_once dirname( __FILE__ ) . '/Root_Loader.php';


### PR DESCRIPTION
This PR adds support for Redis running in a cluster mode. This is common when using AWS ElastiCache.

By default, the code will connect to Redis as it did previously. If W3TC_REDIS_CLUSTER is defined and set to true the connection will be made using RedisCluster instead of Redis. When used with AWS ElastiCache, only the Configuration Endpoint is needed.


