### PR TITLE
Fixes conflict with GuzzleHttp 6.x library in Azure CDN library and a…

### DIFF
--- a/lib/Azure/GuzzleHttp/functions_include.php
+++ b/lib/Azure/GuzzleHttp/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\uri_template')) {
+if (!function_exists('GuzzleHttp\describe_type')) {
     require __DIR__ . '/functions.php';
 }


### PR DESCRIPTION
…ny guzzle 7.x library loaded in other plugins

Similar fix is in guzzle 7.0.1: https://github.com/guzzle/guzzle/pull/2699/files

Fixes #642 