### PR TITLE
2.3.0 BrowserCache Environment Rules Fix

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -63,8 +63,9 @@ class BrowserCache_Environment {
 	 * @return array
 	 */
 	public function get_required_rules( $config ) {
-		if ( !$config->get_boolean( 'browsercache.enabled' ) )
-			return null;
+		if ( ! $config->get_boolean( 'browsercache.enabled' ) ) {
+			return array();
+		}
 
 		$mime_types = $this->get_mime_types();
 

--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -69,29 +69,32 @@ class BrowserCache_Environment {
 		$mime_types = $this->get_mime_types();
 
 		switch ( true ) {
-		case Util_Environment::is_apache():
-			$generator_apache = new BrowserCache_Environment_Apache( $config );
-			$rewrite_rules = array(
-				array(
-					'filename' => Util_Rule::get_apache_rules_path(),
-					'content' =>
-						W3TC_MARKER_BEGIN_BROWSERCACHE_CACHE . "\n" .
-						$this->rules_cache_generate_apache( $config ) .
-						$generator_apache->rules_no404wp( $mime_types ) .
-						W3TC_MARKER_END_BROWSERCACHE_CACHE . "\n"
-				)
-			);
-			break;
+			case Util_Environment::is_apache():
+				$generator_apache = new BrowserCache_Environment_Apache( $config );
+				$rewrite_rules = array(
+					array(
+						'filename' => Util_Rule::get_apache_rules_path(),
+						'content' =>
+							W3TC_MARKER_BEGIN_BROWSERCACHE_CACHE . "\n" .
+							$this->rules_cache_generate_apache( $config ) .
+							$generator_apache->rules_no404wp( $mime_types ) .
+							W3TC_MARKER_END_BROWSERCACHE_CACHE . "\n"
+					)
+				);
+				break;
 
-		case Util_Environment::is_litespeed():
-			$generator_litespeed = new BrowserCache_Environment_LiteSpeed( $config );
-			$rewrite_rules = $generator_litespeed->get_required_rules( $mime_types );
-			break;
+			case Util_Environment::is_litespeed():
+				$generator_litespeed = new BrowserCache_Environment_LiteSpeed( $config );
+				$rewrite_rules = $generator_litespeed->get_required_rules( $mime_types );
+				break;
 
-		case Util_Environment::is_nginx():
-			$generator_nginx = new BrowserCache_Environment_Nginx( $config );
-			$rewrite_rules = $generator_nginx->get_required_rules( $mime_types );
-			break;
+			case Util_Environment::is_nginx():
+				$generator_nginx = new BrowserCache_Environment_Nginx( $config );
+				$rewrite_rules = $generator_nginx->get_required_rules( $mime_types );
+				break;
+
+			default:
+				$rewrite_rules = array();
 		}
 
 		return $rewrite_rules;


### PR DESCRIPTION
The get_required_rules method features a switch that checks for the appropriate environment rules, ie apache, nginx, lightspeed, etc. This switch was missing a default which resulted in the $rewrite_rules being null if no match was found resulting in an error.

This PR adds a default switch case that will set $rewire_rules to an empty array if no environment match is found.

Reference topic: [php-error-after-upgrading-2-3-0](https://wordpress.org/support/topic/php-error-after-upgraded-2-3-0/)