### PR TITLE
Update w3tc_modify_query_obj()

### DIFF
--- a/Root_Loader.php
+++ b/Root_Loader.php
@@ -235,15 +235,14 @@ class Root_Loader {
 			return;
 		}
 
-		$query->set(
-			'meta_query',
-			array(
-				array(
-					'key'     => 'w3tc_imageservice_file',
-					'compare' => 'NOT EXISTS',
-				),
-			)
+		// Get the existing meta query array, add ours, and then save it.
+		$meta_query   = (array) $query->get( 'meta_query' );
+		$meta_query[] = array(
+			'key'     => 'w3tc_imageservice_file',
+			'compare' => 'NOT EXISTS',
 		);
+
+		$query->set( 'meta_query', $meta_query );
 	}
 
 	/**


### PR DESCRIPTION
To test: Install https://wordpress.org/plugins/video-embed-thumbnail-generator/ to create attachments that the plugin hides in the Media Library.  Activate the W3TC Image Service extension, and optimize/convert an image.  All conversions/copies of image attachments should be hidden.
Fixes #651

Dev notes:
When debugging while having only W3TC activated, the `$query->get( 'meta_query' )` call returned an empty string.  That's why I type-casted it to an array since its use always requires an array.  