### PR TITLE
Multiple fixes/enhancments for PageSpeed 2.3.0

### DIFF
--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -185,7 +185,7 @@ class Generic_Plugin_Admin {
 
 		// Support page.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_support',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_support',
 			array(
 				'\W3TC\Support_Page',
 				'admin_print_scripts_w3tc_support',
@@ -194,7 +194,7 @@ class Generic_Plugin_Admin {
 
 		// Minify.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_general',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_general',
 			array(
 				'\W3TC\Minify_Plugin_Admin',
 				'admin_print_scripts_w3tc_general',
@@ -203,7 +203,7 @@ class Generic_Plugin_Admin {
 
 		// PageCache.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_pgcache',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_pgcache',
 			array(
 				'\W3TC\PgCache_Page',
 				'admin_print_scripts_w3tc_pgcache',
@@ -212,7 +212,7 @@ class Generic_Plugin_Admin {
 
 		// Extensions.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_extensions',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_extensions',
 			array(
 				'\W3TC\Extension_CloudFlare_Page',
 				'admin_print_scripts_w3tc_extensions',
@@ -221,7 +221,7 @@ class Generic_Plugin_Admin {
 
 		// Usage Statistics.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_stats',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_stats',
 			array(
 				'\W3TC\UsageStatistics_Page',
 				'admin_print_scripts_w3tc_stats',
@@ -235,7 +235,7 @@ class Generic_Plugin_Admin {
 		// CDN.
 		if ( 'google_drive' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_GoogleDrive_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -243,7 +243,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'highwinds' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_Highwinds_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -251,7 +251,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'limelight' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_LimeLight_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -259,7 +259,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'rackspace_cdn' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_RackSpaceCdn_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -267,7 +267,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'rscf' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_RackSpaceCloudFiles_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -275,7 +275,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'stackpath' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_StackPath_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -283,7 +283,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'stackpath2' === $cdn_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdn_StackPath2_Page',
 					'admin_print_scripts_w3tc_cdn',
@@ -294,7 +294,7 @@ class Generic_Plugin_Admin {
 		// CDNFSD.
 		if ( 'cloudflare' === $cdnfsd_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Extension_CloudFlare_Page',
 					'admin_print_scripts_w3tc_extensions',
@@ -302,7 +302,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'cloudfront' === $cdnfsd_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdnfsd_CloudFront_Page',
 					'admin_print_scripts_performance_page_w3tc_cdn',
@@ -310,7 +310,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'limelight' === $cdnfsd_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdnfsd_LimeLight_Page',
 					'admin_print_scripts_performance_page_w3tc_cdn',
@@ -318,7 +318,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'stackpath' === $cdnfsd_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdnfsd_StackPath_Page',
 					'admin_print_scripts_performance_page_w3tc_cdn',
@@ -326,7 +326,7 @@ class Generic_Plugin_Admin {
 			);
 		} elseif ( 'stackpath2' === $cdnfsd_engine ) {
 			add_action(
-				'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
+				'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_cdn',
 				array(
 					'\W3TC\Cdnfsd_StackPath2_Page',
 					'admin_print_scripts_performance_page_w3tc_cdn',
@@ -336,7 +336,7 @@ class Generic_Plugin_Admin {
 
 		// PageSpeed page/widget.
 		add_action(
-			'admin_print_scripts-' . sanitize_title( __( 'performance', 'w3-total-cache' ) ) . '_page_w3tc_pagespeed',
+			'admin_print_scripts-' . sanitize_title( __( 'Performance', 'w3-total-cache' ) ) . '_page_w3tc_pagespeed',
 			array(
 				'\W3TC\PageSpeed_Page',
 				'admin_print_scripts_w3tc_pagespeed',

--- a/PageSpeed_Instructions.php
+++ b/PageSpeed_Instructions.php
@@ -126,7 +126,7 @@ class PageSpeed_Instructions {
 						'<p>' . sprintf(
 							// translators: 1 W3TC plugin name, opening HTML a tag to Image Service extension, 3 closing HTML a tag.
 							esc_html__(
-								'Use %1$s $2$sImage Service%3$s to convert media library images to WebP.',
+								'Use %1$s %2$sImage Service%3$s to convert media library images to WebP.',
 								'w3-total-cache'
 							),
 							'W3 Total Cache',

--- a/PageSpeed_Page_View.css
+++ b/PageSpeed_Page_View.css
@@ -55,6 +55,7 @@
 .w3tcps_breakdown_items_container {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	grid-row-gap: .75em;
 	grid-column-gap: .75em;
 	padding: .75em;
@@ -62,7 +63,8 @@
 
 .w3tcps_breakdown_items_container .w3tcps_breakdown_items_table,
 .w3tcps_breakdown_items_container .w3tcps_instruction {
-	flex: 50%;
+	flex: 49%;
+	flex-grow: 1;
 	align-self: flex-start;
 	border: 1px solid #ccd0d4;
 	border-collapse: collapse;

--- a/PageSpeed_Page_View.php
+++ b/PageSpeed_Page_View.php
@@ -27,7 +27,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 				sprintf(
 					// translators: 1 cache lifetime.
 					__(
-						'This tool will analyze your website\'s homepage using the Google PageSpeed Insights API to gather desktop/mobile performance metrics. Additionally for each metric W3 Total Cache will include an explaination of the metric and our recommendation for achieving improvments via W3 Total Cache features/extensions if available. Results will be cached for of %1$s but will forcibly refresh via the "Refresh Analysis" button.',
+						'This tool will analyze your website\'s homepage using the Google PageSpeed Insights API to gather desktop/mobile performance metrics. Additionally for each metric W3 Total Cache will include an explaination of the metric and our recommendation for achieving improvments via W3 Total Cache features/extensions if available. Results will be cached for %1$s but will forcibly refresh via the "Refresh Analysis" button.',
 						'w3-total-cache'
 					),
 					Util_PageSpeed::seconds_to_str( Util_PageSpeed::get_cache_life() )

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -278,9 +278,17 @@ class Util_PageSpeed {
 				if ( isset( $item['url'] ) ) {
 					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
 					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
-						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . wp_parse_url( $item['url'] )['path'] . '" target="_blank" title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</a></td>';
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . esc_url( $item['url'] ) . '" target="_blank" title="' . esc_url( $item['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['url'] )['path'] ) . '</a></td>';
 					} else {
 						$items   .= '<td>' . $item['url'] . '</td>';
+					}
+				}
+				if ( isset( $item['source'] ) ) {
+					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
+					if ( filter_var( $item['source']['url'], FILTER_VALIDATE_URL ) !== false ) {
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['source']['url'] ) . '"></span><a href="' . esc_url( $item['source']['url'] ) . '" target="_blank" title="' . esc_url( $item['source']['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['source']['url'] )['path'] ) . '</a></td>';
+					} else {
+						$items   .= '<td>' . $item['source']['url'] . '</td>';
 					}
 				}
 				if ( isset( $item['totalBytes'] ) ) {
@@ -446,12 +454,20 @@ class Util_PageSpeed {
 			foreach ( $diagnostic['details'] as $item ) {
 				$headers = '';
 				$items  .= '<tr class="w3tcps_passed_audit_item">';
-				if ( isset( $item['url'] ) && filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
+				if ( isset( $item['url'] ) ) {
 					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
 					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
-						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . wp_parse_url( $item['url'] )['path'] . '" target="_blank" title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</a></td>';
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . esc_url( $item['url'] ) . '" target="_blank" title="' . esc_url( $item['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['url'] )['path'] ) . '</a></td>';
 					} else {
 						$items   .= '<td>' . $item['url'] . '</td>';
+					}
+				}
+				if ( isset( $item['source'] ) ) {
+					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
+					if ( filter_var( $item['source']['url'], FILTER_VALIDATE_URL ) !== false ) {
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['source']['url'] ) . '"></span><a href="' . esc_url( $item['source']['url'] ) . '" target="_blank" title="' . esc_url( $item['source']['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['source']['url'] )['path'] ) . '</a></td>';
+					} else {
+						$items   .= '<td>' . $item['source']['url'] . '</td>';
 					}
 				}
 				if ( isset( $item['totalBytes'] ) ) {
@@ -672,6 +688,7 @@ class Util_PageSpeed {
 				'href'   => array(),
 				'target' => array(),
 				'rel'    => array(),
+				'title'  => array(),
 			),
 			'link'  => array(
 				'id'    => array(),

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -277,7 +277,11 @@ class Util_PageSpeed {
 				$items  .= '<tr class="w3tcps_passed_audit_item">';
 				if ( isset( $item['url'] ) ) {
 					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . $item['url'] . '"></span><span title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</span></td>';
+					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . wp_parse_url( $item['url'] )['path'] . '" target="_blank" title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</a></td>';
+					} else {
+						$items   .= '<td>' . $item['url'] . '</td>';
+					}
 				}
 				if ( isset( $item['totalBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total Bytes', 'w3-total-cache' ) . '</th>';
@@ -379,8 +383,7 @@ class Util_PageSpeed {
 									<div class="w3tc_fancy_header">
 										<img class="w3tc_fancy_icon" src="' . esc_url( plugins_url( '/w3-total-cache/pub/img/w3tc_cube-shadow.png' ) ) . '" />
 										<div class="w3tc_fancy_title">
-											<span>' . esc_html__( 'TOTAL', 'w3-total-cache' ) . '</span>
-											<span>' . esc_html__( 'CACHE', 'w3-total-cache' ) . '</span>
+											<span>Total Cache</span>
 											<span>:</span>
 											<span>' . esc_html__( 'Tips', 'w3-total-cache' ) . '</span>
 										</div>
@@ -404,8 +407,7 @@ class Util_PageSpeed {
 									<div class="w3tc_fancy_header">
 										<img class="w3tc_fancy_icon" src="' . esc_url( plugins_url( '/w3-total-cache/pub/img/w3tc_cube-shadow.png' ) ) . '" />
 										<div class="w3tc_fancy_title">
-											<span>' . esc_html__( 'TOTAL', 'w3-total-cache' ) . '</span>
-											<span>' . esc_html__( 'CACHE', 'w3-total-cache' ) . '</span>
+											<span>Total Cache</span>
 											<span>:</span>
 											<span>' . esc_html__( 'Tips', 'w3-total-cache' ) . '</span>
 										</div>
@@ -444,9 +446,13 @@ class Util_PageSpeed {
 			foreach ( $diagnostic['details'] as $item ) {
 				$headers = '';
 				$items  .= '<tr class="w3tcps_passed_audit_item">';
-				if ( isset( $item['url'] ) ) {
+				if ( isset( $item['url'] ) && filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
 					$headers .= '<th>' . esc_html__( 'URL', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . $item['url'] . '"></span><span title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</span></td>';
+					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
+						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . wp_parse_url( $item['url'] )['path'] . '" target="_blank" title="' . $item['url'] . '"> ...' . wp_parse_url( $item['url'] )['path'] . '</a></td>';
+					} else {
+						$items   .= '<td>' . $item['url'] . '</td>';
+					}
 				}
 				if ( isset( $item['totalBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total Bytes', 'w3-total-cache' ) . '</th>';
@@ -548,8 +554,7 @@ class Util_PageSpeed {
 									<div class="w3tc_fancy_header">
 										<img class="w3tc_fancy_icon" src="' . esc_url( plugins_url( '/w3-total-cache/pub/img/w3tc_cube-shadow.png' ) ) . '" />
 										<div class="w3tc_fancy_title">
-											<span>' . esc_html__( 'TOTAL', 'w3-total-cache' ) . '</span>
-											<span>' . esc_html__( 'CACHE', 'w3-total-cache' ) . '</span>
+											<span>Total Cache</span>
 											<span>:</span>
 											<span>' . esc_html__( 'Tips', 'w3-total-cache' ) . '</span>
 										</div>
@@ -573,8 +578,7 @@ class Util_PageSpeed {
 									<div class="w3tc_fancy_header">
 										<img class="w3tc_fancy_icon" src="' . esc_url( plugins_url( '/w3-total-cache/pub/img/w3tc_cube-shadow.png' ) ) . '" />
 										<div class="w3tc_fancy_title">
-											<span>' . esc_html__( 'TOTAL', 'w3-total-cache' ) . '</span>
-											<span>' . esc_html__( 'CACHE', 'w3-total-cache' ) . '</span>
+											<span>Total Cache</span>
 											<span>:</span>
 											<span>' . esc_html__( 'Tips', 'w3-total-cache' ) . '</span>
 										</div>

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -280,6 +280,7 @@ class Util_PageSpeed {
 					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
 						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . esc_url( $item['url'] ) . '" target="_blank" title="' . esc_url( $item['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['url'] )['path'] ) . '</a></td>';
 					} else {
+						// For certain metrics Google uses the 'url' field for non-URL values. These are often HTML/CSS that shouldn't be escaped and will be displayed as plain text.
 						$items   .= '<td>' . $item['url'] . '</td>';
 					}
 				}
@@ -288,6 +289,7 @@ class Util_PageSpeed {
 					if ( filter_var( $item['source']['url'], FILTER_VALIDATE_URL ) !== false ) {
 						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['source']['url'] ) . '"></span><a href="' . esc_url( $item['source']['url'] ) . '" target="_blank" title="' . esc_url( $item['source']['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['source']['url'] )['path'] ) . '</a></td>';
 					} else {
+						// For certain metrics Google uses the 'url' field for non-URL values. These are often HTML/CSS that shouldn't be escaped and will be displayed as plain text.
 						$items   .= '<td>' . $item['source']['url'] . '</td>';
 					}
 				}
@@ -459,6 +461,7 @@ class Util_PageSpeed {
 					if ( filter_var( $item['url'], FILTER_VALIDATE_URL ) !== false ) {
 						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['url'] ) . '"></span><a href="' . esc_url( $item['url'] ) . '" target="_blank" title="' . esc_url( $item['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['url'] )['path'] ) . '</a></td>';
 					} else {
+						// For certain metrics Google uses the 'url' field for non-URL values. These are often HTML/CSS that shouldn't be escaped and will be displayed as plain text.
 						$items   .= '<td>' . $item['url'] . '</td>';
 					}
 				}
@@ -467,6 +470,7 @@ class Util_PageSpeed {
 					if ( filter_var( $item['source']['url'], FILTER_VALIDATE_URL ) !== false ) {
 						$items   .= '<td><span class="copyurl dashicons dashicons-admin-page" title="' . esc_attr__( 'Copy Full URL', 'w3-total-cache' ) . '" copyurl="' . esc_url( $item['source']['url'] ) . '"></span><a href="' . esc_url( $item['source']['url'] ) . '" target="_blank" title="' . esc_url( $item['source']['url'] ) . '"> ...' . esc_url( wp_parse_url( $item['source']['url'] )['path'] ) . '</a></td>';
 					} else {
+						// For certain metrics Google uses the 'url' field for non-URL values. These are often HTML/CSS that shouldn't be escaped and will be displayed as plain text.
 						$items   .= '<td>' . $item['source']['url'] . '</td>';
 					}
 				}


### PR DESCRIPTION
Fixed several translation related issues with grammar, broken placeholders, and an issue with script localization. Also fixed breakdown/recommendation block widths if data tables required too much space. Lastly added links to all breakdown data URLs to allow users to view the reported URL/file.

One important note, the script localization issue actually affected other scripts queued in the same manner. As it turns out the menu item title and hook suffix needed to match 100% including capitalization. All hook suffixes were lower case which caused the hooks to fail under translation. This PR will fix those as well