### PR TITLE
Fix for symlinked cache directory causing folder/file creation to partially fail

### DIFF
--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -170,6 +170,7 @@ class Minify_Plugin {
 		$embed_extsrcjs = false;
 		$buffer = apply_filters( 'w3tc_minify_before', $buffer );
 
+		// If the minify cache folder is missing minify fails. This will generate the minify folder path if missing.
 		$minify_environment = Dispatcher::component( 'Minify_Environment' );
 		try {
 			$minify_environment->fix_on_wpadmin_request( $this->_config, true );

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -170,7 +170,10 @@ class Minify_Plugin {
 		$embed_extsrcjs = false;
 		$buffer = apply_filters( 'w3tc_minify_before', $buffer );
 
-
+		$minify_environment = Dispatcher::component( 'Minify_Environment' );
+		try {
+			$minify_environment->fix_on_wpadmin_request( $this->_config, true );
+		} catch ( \Exception $e ) {}
 
 		if ( $this->_config->get_boolean( 'minify.auto' ) ) {
 			if ( $js_enable ) {

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -141,17 +141,26 @@ class Util_Environment {
 		 * Using wp-content instead of document_root as known dir since dirbased
 		 * multisite wp adds blogname to the path inside site_url.
 		 */
-		if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) !== WP_CONTENT_DIR ) {
+		if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) === WP_CONTENT_DIR ) {
+			// This is the default location of the wp-content/cache directory.
+			$location = WP_CONTENT_DIR;
+		} else if ( substr( $filename, 0, strlen( W3TC_CACHE_DIR ) ) === W3TC_CACHE_DIR ) {
+			// This is needed in the event the cache directory is moved outside of wp-content and replace with a symbolic link.
+			$location = substr( W3TC_CACHE_DIR, 0, -strlen( '/cache' ) );
+		} else if ( substr( $filename, 0, strlen( W3TC_CONFIG_DIR ) ) === W3TC_CONFIG_DIR ) {
+			// This is needed in the event the cache directory is moved outside of wp-content and replace with a symbolic link.
+			$location = substr( W3TC_CONFIG_DIR, 0, -strlen( '/w3tc-config' ) );
+		} else {
 			return '';
 		}
 
-		$uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
+		$uri_from_location = substr( $filename, strlen( $location ) );
 
 		if ( DIRECTORY_SEPARATOR != '/' ) {
-			$uri_from_wp_content = str_replace( DIRECTORY_SEPARATOR, '/', $uri_from_wp_content );
+			$uri_from_location = str_replace( DIRECTORY_SEPARATOR, '/', $uri_from_location );
 		}
 
-		$url = content_url( $uri_from_wp_content );
+		$url = content_url( $uri_from_location );
 		$url = apply_filters( 'w3tc_filename_to_url', $url );
 
 		return $url;

--- a/tests/admin/class-w3tc-admin-base-test.php
+++ b/tests/admin/class-w3tc-admin-base-test.php
@@ -9,6 +9,8 @@
  * @link       https://www.boldgrid.com/w3-total-cache/
  */
 
+declare( strict_types = 1 );
+
 /**
  * Class: W3tc_Admin_Base_Test
  *
@@ -131,6 +133,32 @@ class W3tc_Admin_Base_Test extends WP_UnitTestCase {
 		foreach ( $definitions as $definition ) {
 			$this->assertTrue( defined( $definition ) );
 		}
+	}
+
+	/**
+	 * Test for the WP_CONTENT_DIR constant.
+	 *
+	 * @since 2.3.2
+	 */
+	public function test_contentdir() {
+		$this->expectOutputRegex( '~.+/wp-content$~' );
+
+		print WP_CONTENT_DIR; // phpcs:ignore
+
+		fwrite( STDERR, 'WP_CONTENT_DIR: ' . WP_CONTENT_DIR . PHP_EOL );
+	}
+
+	/**
+	 * Test for the WP_CONTENT_DIR constant with realpath().
+	 *
+	 * @since 2.3.2
+	 */
+	public function test_contentdir_realpath() {
+		$this->expectOutputRegex( '~.+/wp-content$~' );
+
+		print realpath( WP_CONTENT_DIR ); // phpcs:ignore
+
+		fwrite( STDERR, 'realpath( WP_CONTENT_DIR ): ' . realpath( WP_CONTENT_DIR ) . PHP_EOL );
 	}
 
 	/**

--- a/tests/admin/class-w3tc-admin-util-file-test.php
+++ b/tests/admin/class-w3tc-admin-util-file-test.php
@@ -9,6 +9,8 @@
  * @link       https://www.boldgrid.com/w3-total-cache/
  */
 
+declare( strict_types = 1 );
+
 /**
  * Class: W3tc_Admin_Util_File_Test
  *

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -72,11 +72,11 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 }
 
 if ( ! defined( 'W3TC_CACHE_DIR' ) ) {
-	define( 'W3TC_CACHE_DIR', WP_CONTENT_DIR . '/cache' );
+	define( 'W3TC_CACHE_DIR', realpath( WP_CONTENT_DIR . '/cache' ) );
 }
 
 if ( ! defined( 'W3TC_CONFIG_DIR' ) ) {
-	define( 'W3TC_CONFIG_DIR', WP_CONTENT_DIR . '/w3tc-config' );
+	define( 'W3TC_CONFIG_DIR', realpath( WP_CONTENT_DIR . '/w3tc-config' ) );
 }
 
 if ( ! defined( 'W3TC_CACHE_MINIFY_DIR' ) ) {

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -72,11 +72,19 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 }
 
 if ( ! defined( 'W3TC_CACHE_DIR' ) ) {
-	define( 'W3TC_CACHE_DIR', realpath( WP_CONTENT_DIR ) . '/cache' );
+	if ( false !== realpath( WP_CONTENT_DIR . '/cache' ) ) {
+    	define( 'W3TC_CACHE_DIR', realpath( WP_CONTENT_DIR . '/cache' ) );
+	} else {
+    	define( 'W3TC_CACHE_DIR', WP_CONTENT_DIR . '/cache' );
+	}
 }
 
 if ( ! defined( 'W3TC_CONFIG_DIR' ) ) {
-	define( 'W3TC_CONFIG_DIR', realpath( WP_CONTENT_DIR ) . '/w3tc-config' );
+	if ( false !== realpath( WP_CONTENT_DIR . '/w3tc-config' ) ) {
+    	define( 'W3TC_CONFIG_DIR', realpath( WP_CONTENT_DIR . '/w3tc-config' ) );
+	} else {
+    	define( 'W3TC_CONFIG_DIR', WP_CONTENT_DIR . '/w3tc-config' );
+	}
 }
 
 if ( ! defined( 'W3TC_CACHE_MINIFY_DIR' ) ) {

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -72,11 +72,11 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 }
 
 if ( ! defined( 'W3TC_CACHE_DIR' ) ) {
-	define( 'W3TC_CACHE_DIR', realpath( WP_CONTENT_DIR . '/cache' ) );
+	define( 'W3TC_CACHE_DIR', realpath( WP_CONTENT_DIR ) . '/cache' );
 }
 
 if ( ! defined( 'W3TC_CONFIG_DIR' ) ) {
-	define( 'W3TC_CONFIG_DIR', realpath( WP_CONTENT_DIR . '/w3tc-config' ) );
+	define( 'W3TC_CONFIG_DIR', realpath( WP_CONTENT_DIR ) . '/w3tc-config' );
 }
 
 if ( ! defined( 'W3TC_CACHE_MINIFY_DIR' ) ) {


### PR DESCRIPTION
This issue occurs if the cache directory located in wp-content is moved to another location and replaced with a symbolic link. This causes both Minify and PageCache using `file` method to partially fail during the folder/file creation process in that it will only create the first element in the path i.e. `cache/minify/1/287.js` would only create the `cache` directory before failing. This would require refreshing the page or performing an admin action repeatedly until all folders/files are created

Additionally if the minify cache folder is missing it required an admin action to be performed in order for the required minify folder path to be generated which prevented minified files from being served. This appears to only occur if the minify folder fails to generate on admin action or somehow is manually deleted. Performing an admin action resolves this including saving settings or flushing the cache

With this fix applied both single and multisite successfully generate all required folders and files without this partial fail occurring. Additionally this fix will create the required minify folder path via the front end if the folder(s) are missing