### PR TITLE
Fix for PageSpeed authroization via MultiSite installation

### DIFF
--- a/PageSpeed_Widget_View.php
+++ b/PageSpeed_Widget_View.php
@@ -30,5 +30,5 @@ if ( ! defined( 'W3TC' ) ) {
 </div>
 <div class="w3tcps_buttons w3tc_none">
 	<input class="button w3tcps_refresh" type="button" value="<?php esc_html_e( 'Refresh Analysis', 'w3-total-cache' ); ?>" />
-	<a href="<?php echo esc_url( admin_url( 'admin.php?page=w3tc_pagespeed' ) ); ?>" class="button"><?php esc_html_e( 'View All Results', 'w3-total-cache' ); ?></a>
+	<a href="<?php echo esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_pagespeed' ) ); ?>" class="button"><?php esc_html_e( 'View All Results', 'w3-total-cache' ); ?></a>
 </div>

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -687,7 +687,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		$w3_pagespeed      = new PageSpeed_Api( $access_token_json );
 
 		$site_id            = Util_Http::generate_site_id();
-		$return_url         = admin_url( 'admin.php?page=w3tc_general' );
+		$return_url         = Util_Ui::admin_url( 'admin.php?page=w3tc_general' );
 		$w3tc_pagespeed_key = ! empty( $this->_config->get_string( 'widget.pagespeed.w3tc_pagespeed_key' ) ) ? $this->_config->get_string( 'widget.pagespeed.w3tc_pagespeed_key' ) : '';
 		$auth_url           = $w3_pagespeed->client->createAuthUrl();
 


### PR DESCRIPTION
Without this fix the authorization process via the Performance -> General Settings -> PageSpeed settings section on the network administration dashboard would return with a "Sorry, you are not allowed to access this page." message upon the authorization return.