### PR TITLE
Release 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,11 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      php: 7.4
+      php: 5.6
   - provider: releases
     api_key: "${GITHUB_TOKEN}"
     file: "w3-total-cache.zip"
     skip_cleanup: true
     on:
       tags: true
-      php: 7.4
+      php: 5.6

--- a/BrowserCache_Page_View_SectionSecurity.php
+++ b/BrowserCache_Page_View_SectionSecurity.php
@@ -892,7 +892,7 @@ $feature_policies = array(
 							'w3-total-cache'
 						),
 						'<acronym title="' . esc_attr__( 'Content Security Policy Report Only', 'w3-total-cache' ) . '">',
-						'</acronym>',
+						'</acronym>'
 					),
 					array(
 						'acronym' => array(

--- a/composer.lock
+++ b/composer.lock
@@ -905,16 +905,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -952,7 +952,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -960,7 +960,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1586,16 +1586,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.4",
+            "version": "9.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9125ee085b6d95e78277dc07aa1f46f9e0607b8d"
+                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9125ee085b6d95e78277dc07aa1f46f9e0607b8d",
-                "reference": "9125ee085b6d95e78277dc07aa1f46f9e0607b8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
                 "shasum": ""
             },
             "require": {
@@ -1628,8 +1628,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1668,7 +1668,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
             },
             "funding": [
                 {
@@ -1684,7 +1684,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-27T13:06:37+00:00"
+            "time": "2023-03-09T06:34:10+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2763,12 +2763,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "546f59c67854589bb8f6b49a30e642e75ff419ad"
+                "reference": "f4d4ff58ddfe1ca79575e60c552543966a5ed7b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/546f59c67854589bb8f6b49a30e642e75ff419ad",
-                "reference": "546f59c67854589bb8f6b49a30e642e75ff419ad",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f4d4ff58ddfe1ca79575e60c552543966a5ed7b2",
+                "reference": "f4d4ff58ddfe1ca79575e60c552543966a5ed7b2",
                 "shasum": ""
             },
             "require": {
@@ -2812,7 +2812,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-01-13T13:37:27+00:00"
+            "time": "2023-03-07T17:51:30+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/languages/w3-total-cache.pot
+++ b/languages/w3-total-cache.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-02-09T21:17:59+00:00\n"
+"POT-Creation-Date: 2023-03-21T21:21:22+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: w3-total-cache\n"
@@ -203,59 +203,123 @@ msgid "Content Security Policy"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:61
-msgid "base-uri:"
+#: BrowserCache_ConfigLabels.php:85
+msgid "report-uri:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:62
-msgid "frame-src:"
+#: BrowserCache_ConfigLabels.php:86
+msgid "report-to:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:63
-msgid "connect-src:"
+#: BrowserCache_ConfigLabels.php:87
+msgid "base-uri:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:64
-msgid "font-src:"
+#: BrowserCache_ConfigLabels.php:88
+msgid "frame-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:65
-msgid "script-src:"
+#: BrowserCache_ConfigLabels.php:89
+msgid "connect-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:66
-msgid "style-src:"
+#: BrowserCache_ConfigLabels.php:90
+msgid "font-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:67
-msgid "img-src:"
+#: BrowserCache_ConfigLabels.php:91
+msgid "script-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:68
-msgid "media-src:"
+#: BrowserCache_ConfigLabels.php:92
+msgid "style-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:69
-msgid "object-src:"
+#: BrowserCache_ConfigLabels.php:93
+msgid "img-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:70
-msgid "plugin-types:"
+#: BrowserCache_ConfigLabels.php:94
+msgid "media-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:71
-msgid "form-action:"
+#: BrowserCache_ConfigLabels.php:95
+msgid "object-src:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:72
-msgid "frame-ancestors:"
+#: BrowserCache_ConfigLabels.php:96
+msgid "plugin-types:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:73
-msgid "sandbox:"
+#: BrowserCache_ConfigLabels.php:97
+msgid "form-action:"
 msgstr ""
 
 #: BrowserCache_ConfigLabels.php:74
+#: BrowserCache_ConfigLabels.php:98
+msgid "frame-ancestors:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:75
+#: BrowserCache_ConfigLabels.php:99
+msgid "sandbox:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:76
+#: BrowserCache_ConfigLabels.php:100
+msgid "child-src:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:77
+#: BrowserCache_ConfigLabels.php:101
+msgid "manifest-src:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:78
+#: BrowserCache_ConfigLabels.php:102
+msgid "script-src-elem:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:79
+#: BrowserCache_ConfigLabels.php:103
+msgid "script-src-attr:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:80
+#: BrowserCache_ConfigLabels.php:104
+msgid "style-src-elem:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:81
+#: BrowserCache_ConfigLabels.php:105
+msgid "style-src-attr:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:82
+#: BrowserCache_ConfigLabels.php:106
+msgid "worker-src:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:83
+#: BrowserCache_ConfigLabels.php:107
 msgid "default-src:"
+msgstr ""
+
+#: BrowserCache_ConfigLabels.php:84
+#: BrowserCache_Page_View_SectionSecurity.php:894
+msgid "Content Security Policy Report Only"
 msgstr ""
 
 #: BrowserCache_Page_View_QuickReference.php:9
@@ -449,8 +513,10 @@ msgstr ""
 
 #: BrowserCache_Page_View_SectionSecurity.php:201
 #: BrowserCache_Page_View_SectionSecurity.php:498
-#: BrowserCache_Page_View_SectionSecurity.php:602
-#: BrowserCache_Page_View_SectionSecurity.php:734
+#: BrowserCache_Page_View_SectionSecurity.php:626
+#: BrowserCache_Page_View_SectionSecurity.php:758
+#: BrowserCache_Page_View_SectionSecurity.php:948
+#: BrowserCache_Page_View_SectionSecurity.php:1080
 #: Generic_Plugin_Admin.php:864
 #: inc/options/browsercache.php:201
 #: inc/options/browsercache.php:473
@@ -598,45 +664,70 @@ msgstr ""
 msgid "The Content Security Policy (%1$sCSP%2$s) header reduces the risk of %3$sXSS%4$s attacks by allowing you to define where resources can be retrieved from, preventing browsers from loading data from any other locations. This makes it harder for an attacker to inject malicious code into your site."
 msgstr ""
 
+#: BrowserCache_Page_View_SectionSecurity.php:592
+#: BrowserCache_Page_View_SectionSecurity.php:914
+msgid "Instructs the user agent to report attempts to violate the Content Security Policy. These violation reports consist of JSON documents sent via an HTTP POST request to the specified URI."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:603
+#: BrowserCache_Page_View_SectionSecurity.php:925
+msgid "Defines a reporting endpoint \"group\" to which violation reports should to be sent."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:605
+#: BrowserCache_Page_View_SectionSecurity.php:927
+msgid "The referenced \"group\" should be defined in either the Report-To or Reporting-Endpoints HTTP headers. These will need to be manually defined either via htaccess or another method of modifying HTTP headers."
+msgstr ""
+
 #. translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
-#: BrowserCache_Page_View_SectionSecurity.php:598
+#: BrowserCache_Page_View_SectionSecurity.php:622
+#: BrowserCache_Page_View_SectionSecurity.php:944
 msgid "Restricts the %1$sURL%2$ss which can be used in a document's &lt;base&gt; element."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:623
+#: BrowserCache_Page_View_SectionSecurity.php:647
+#: BrowserCache_Page_View_SectionSecurity.php:969
 msgid "Limits the origins to which you can connect via XMLHttpRequest, WebSockets, and EventSource."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:633
+#: BrowserCache_Page_View_SectionSecurity.php:657
+#: BrowserCache_Page_View_SectionSecurity.php:979
 msgid "Specifies the origins that can serve web fonts."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:643
+#: BrowserCache_Page_View_SectionSecurity.php:667
+#: BrowserCache_Page_View_SectionSecurity.php:989
 msgid "Restricts from where the protected resource can embed frames."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:653
+#: BrowserCache_Page_View_SectionSecurity.php:677
+#: BrowserCache_Page_View_SectionSecurity.php:999
 msgid "Specifies valid sources for images and favicons."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:663
+#: BrowserCache_Page_View_SectionSecurity.php:687
+#: BrowserCache_Page_View_SectionSecurity.php:1009
 msgid "Specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:673
+#: BrowserCache_Page_View_SectionSecurity.php:697
+#: BrowserCache_Page_View_SectionSecurity.php:1019
 msgid "Allows control over the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements used by Flash and other plugins."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:683
+#: BrowserCache_Page_View_SectionSecurity.php:707
+#: BrowserCache_Page_View_SectionSecurity.php:1029
 msgid "Specifies valid sources for JavaScript."
 msgstr ""
 
 #. translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
-#: BrowserCache_Page_View_SectionSecurity.php:699
+#: BrowserCache_Page_View_SectionSecurity.php:723
+#: BrowserCache_Page_View_SectionSecurity.php:1045
 msgid "Specifies valid sources for %1$sCSS%2$s stylesheets."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:703
+#: BrowserCache_Page_View_SectionSecurity.php:727
+#: BrowserCache_Page_View_SectionSecurity.php:1049
 #: Cdn_GeneralPage_View.php:104
 #: Extension_CloudFlare_Page_View.php:396
 #: inc/options/about.php:78
@@ -666,40 +757,94 @@ msgid "Cascading Style Sheet"
 msgstr ""
 
 #. translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
-#: BrowserCache_Page_View_SectionSecurity.php:730
+#: BrowserCache_Page_View_SectionSecurity.php:754
+#: BrowserCache_Page_View_SectionSecurity.php:1076
 msgid "Restricts the %1$sURL%2$ss which can be used as the target of form submissions from a given context."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:755
+#: BrowserCache_Page_View_SectionSecurity.php:779
+#: BrowserCache_Page_View_SectionSecurity.php:1101
 msgid "Specifies valid parents that may embed a page using &lt;frame&gt;, &lt;iframe&gt;, &lt;object&gt;, &lt;embed&gt;, or &lt;applet&gt;."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:765
+#: BrowserCache_Page_View_SectionSecurity.php:789
+#: BrowserCache_Page_View_SectionSecurity.php:1111
 msgid "Restricts the set of plugins that can be embedded into a document by limiting the types of resources which can be loaded."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:775
+#: BrowserCache_Page_View_SectionSecurity.php:799
+#: BrowserCache_Page_View_SectionSecurity.php:1121
 msgid "This directive operates similarly to the &lt;iframe&gt; sandbox attribute by applying restrictions to a page's actions, including preventing popups, preventing the execution of plugins and scripts, and enforcing a same-origin policy."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:785
+#: BrowserCache_Page_View_SectionSecurity.php:809
+#: BrowserCache_Page_View_SectionSecurity.php:1131
+msgid "Defines the valid sources for web workers and nested browsing contexts loaded using elements such as <frame> and <iframe>. For workers, non-compliant requests are treated as fatal network errors by the user agent."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:819
+#: BrowserCache_Page_View_SectionSecurity.php:1141
+msgid "Specifies which manifest can be applied to the resource."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:829
+#: BrowserCache_Page_View_SectionSecurity.php:1151
+msgid "Specifies valid sources for JavaScript <script> elements."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:839
+#: BrowserCache_Page_View_SectionSecurity.php:1161
+msgid "Specifies valid sources for JavaScript inline event handlers."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:849
+#: BrowserCache_Page_View_SectionSecurity.php:1171
+msgid "Specifies valid sources for stylesheet <style> elements and <link> elements with rel=\"stylesheet\"."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:859
+#: BrowserCache_Page_View_SectionSecurity.php:1181
+msgid "Specifies valid sources for inline styles applied to individual DOM elements."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:869
+#: BrowserCache_Page_View_SectionSecurity.php:1191
+msgid "Specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:879
+#: BrowserCache_Page_View_SectionSecurity.php:1201
 msgid "Defines the defaults for directives you leave unspecified. Generally, this applies to any directive that ends with -src."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:794
+#. translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
+#: BrowserCache_Page_View_SectionSecurity.php:890
+msgid "The Content Security Policy Report Only (%1$sCSPRO%2$s) header allows web developers to experiment with policies by monitoring (but not enforcing) their effects. These violation reports consist of JSON documents sent via an HTTP POST request to the specified URI. This header is applied separately from the Content-Security-Policy and is useful for testing alternative configurations."
+msgstr ""
+
+#: BrowserCache_Page_View_SectionSecurity.php:1210
 msgid "Feature-Policy / Permissions-Policy"
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:795
+#: BrowserCache_Page_View_SectionSecurity.php:1211
 msgid "Allows you to control which origins can use which features."
 msgstr ""
 
-#: BrowserCache_Page_View_SectionSecurity.php:811
+#: BrowserCache_Page_View_SectionSecurity.php:1227
 msgid "One of:"
 msgstr ""
 
-#: BrowserCache_Plugin.php:376
+#: BrowserCache_Plugin.php:380
 msgid "Browser Cache: Update Media Query String"
+msgstr ""
+
+#. translators: 1 opening HTML a tag to Browser Cache CSP-Report-Only settings, 2 closing HTML a tag.
+#: BrowserCache_Plugin.php:484
+msgid "The Content Security Policy - Report Only requires the \"report-uri\" and/or \"report-to\" directives. Please define one or both of these directives %1$shere%2$s."
+msgstr ""
+
+#: BrowserCache_Plugin.php:488
+msgid "Browser Cache Content-Security-Policy-Report-Only Settings"
 msgstr ""
 
 #: CacheGroups_Plugin_Admin.php:42
@@ -2336,8 +2481,8 @@ msgstr ""
 #: UsageStatistics_Page_View.php:203
 #: UsageStatistics_Page_View.php:341
 #: UsageStatistics_Page_View.php:357
-#: Util_PageSpeed.php:307
-#: Util_PageSpeed.php:476
+#: Util_PageSpeed.php:323
+#: Util_PageSpeed.php:506
 msgid "Requests"
 msgstr ""
 
@@ -5404,6 +5549,24 @@ msgid "Clear Log"
 msgstr ""
 
 #: Generic_Plugin.php:238
+#: Generic_Plugin_Admin.php:188
+#: Generic_Plugin_Admin.php:197
+#: Generic_Plugin_Admin.php:206
+#: Generic_Plugin_Admin.php:215
+#: Generic_Plugin_Admin.php:224
+#: Generic_Plugin_Admin.php:238
+#: Generic_Plugin_Admin.php:246
+#: Generic_Plugin_Admin.php:254
+#: Generic_Plugin_Admin.php:262
+#: Generic_Plugin_Admin.php:270
+#: Generic_Plugin_Admin.php:278
+#: Generic_Plugin_Admin.php:286
+#: Generic_Plugin_Admin.php:297
+#: Generic_Plugin_Admin.php:305
+#: Generic_Plugin_Admin.php:313
+#: Generic_Plugin_Admin.php:321
+#: Generic_Plugin_Admin.php:329
+#: Generic_Plugin_Admin.php:339
 #: Root_AdminMenu.php:166
 #: Root_AdminMenu.php:167
 msgid "Performance"
@@ -5460,27 +5623,6 @@ msgstr ""
 msgid "Support Us"
 msgstr ""
 
-#: Generic_Plugin_Admin.php:188
-#: Generic_Plugin_Admin.php:197
-#: Generic_Plugin_Admin.php:206
-#: Generic_Plugin_Admin.php:215
-#: Generic_Plugin_Admin.php:224
-#: Generic_Plugin_Admin.php:238
-#: Generic_Plugin_Admin.php:246
-#: Generic_Plugin_Admin.php:254
-#: Generic_Plugin_Admin.php:262
-#: Generic_Plugin_Admin.php:270
-#: Generic_Plugin_Admin.php:278
-#: Generic_Plugin_Admin.php:286
-#: Generic_Plugin_Admin.php:297
-#: Generic_Plugin_Admin.php:305
-#: Generic_Plugin_Admin.php:313
-#: Generic_Plugin_Admin.php:321
-#: Generic_Plugin_Admin.php:329
-#: Generic_Plugin_Admin.php:339
-msgid "performance"
-msgstr ""
-
 #. translators: 4: HTML line break tag, 5: HTML opening a tag to purge CDN manually, 6: HTML closing a tag.
 #: Generic_Plugin_Admin.php:601
 msgid "Please see %1$sAmazon's CloudFront documentation -- Paying for file invalidation%2$sThe first 1,000 invalidation paths that you submit per month are free; you pay for each invalidation path over 1,000 in a month.%3$sYou can disable automatic purging by enabling %4$sOnly purge CDN manually%5$s."
@@ -5519,7 +5661,9 @@ msgstr ""
 
 #: Generic_Plugin_Admin.php:864
 #: Util_PageSpeed.php:279
-#: Util_PageSpeed.php:448
+#: Util_PageSpeed.php:289
+#: Util_PageSpeed.php:462
+#: Util_PageSpeed.php:472
 msgid "URL"
 msgstr ""
 
@@ -9722,7 +9866,9 @@ msgstr ""
 
 #. translators: 1 W3TC plugin name, opening HTML a tag to Image Service extension, 3 closing HTML a tag.
 #: PageSpeed_Instructions.php:128
-msgid "Use %1$s $2$sImage Service%3$s to convert media library images to WebP."
+#: PageSpeed_Instructions.php:141
+#: PageSpeed_Instructions.php:219
+msgid "Use %1$s %2$sImage Service%3$s to convert media library images to WebP."
 msgstr ""
 
 #: PageSpeed_Instructions.php:133
@@ -9730,12 +9876,6 @@ msgstr ""
 #: PageSpeed_Instructions.php:224
 #: PageSpeed_Instructions.php:298
 msgid "W3TC Extensions"
-msgstr ""
-
-#. translators: 1 W3TC plugin name, opening HTML a tag to Image Service extension, 3 closing HTML a tag.
-#: PageSpeed_Instructions.php:141
-#: PageSpeed_Instructions.php:219
-msgid "Use %1$s %2$sImage Service%3$s to convert media library images to WebP."
 msgstr ""
 
 #. translators: 1 W3TC plugin name, 2 HTML a tag to kjdev php-ext-brotli.
@@ -10337,7 +10477,7 @@ msgstr ""
 
 #. translators: 1 cache lifetime.
 #: PageSpeed_Page_View.php:29
-msgid "This tool will analyze your website's homepage using the Google PageSpeed Insights API to gather desktop/mobile performance metrics. Additionally for each metric W3 Total Cache will include an explaination of the metric and our recommendation for achieving improvments via W3 Total Cache features/extensions if available. Results will be cached for of %1$s but will forcibly refresh via the \"Refresh Analysis\" button."
+msgid "This tool will analyze your website's homepage using the Google PageSpeed Insights API to gather desktop/mobile performance metrics. Additionally for each metric W3 Total Cache will include an explaination of the metric and our recommendation for achieving improvments via W3 Total Cache features/extensions if available. Results will be cached for %1$s but will forcibly refresh via the \"Refresh Analysis\" button."
 msgstr ""
 
 #: PageSpeed_Page_View.php:43
@@ -11709,133 +11849,121 @@ msgstr ""
 msgid "Other Screenshot"
 msgstr ""
 
-#: Util_PageSpeed.php:280
-#: Util_PageSpeed.php:449
+#: Util_PageSpeed.php:282
+#: Util_PageSpeed.php:292
+#: Util_PageSpeed.php:465
+#: Util_PageSpeed.php:475
 msgid "Copy Full URL"
 msgstr ""
 
-#: Util_PageSpeed.php:283
-#: Util_PageSpeed.php:452
+#: Util_PageSpeed.php:299
+#: Util_PageSpeed.php:482
 msgid "Total Bytes"
 msgstr ""
 
-#: Util_PageSpeed.php:287
-#: Util_PageSpeed.php:456
+#: Util_PageSpeed.php:303
+#: Util_PageSpeed.php:486
 msgid "Wasted Bytes"
 msgstr ""
 
-#: Util_PageSpeed.php:291
-#: Util_PageSpeed.php:460
+#: Util_PageSpeed.php:307
+#: Util_PageSpeed.php:490
 msgid "Wasted Percentage"
 msgstr ""
 
-#: Util_PageSpeed.php:295
-#: Util_PageSpeed.php:464
+#: Util_PageSpeed.php:311
+#: Util_PageSpeed.php:494
 msgid "Wasted Miliseconds"
 msgstr ""
 
-#: Util_PageSpeed.php:299
-#: Util_PageSpeed.php:468
+#: Util_PageSpeed.php:315
+#: Util_PageSpeed.php:498
 msgid "Type"
 msgstr ""
 
-#: Util_PageSpeed.php:303
-#: Util_PageSpeed.php:472
+#: Util_PageSpeed.php:319
+#: Util_PageSpeed.php:502
 msgid "Group"
 msgstr ""
 
-#: Util_PageSpeed.php:311
-#: Util_PageSpeed.php:480
+#: Util_PageSpeed.php:327
+#: Util_PageSpeed.php:510
 msgid "Transfer Size"
 msgstr ""
 
-#: Util_PageSpeed.php:315
-#: Util_PageSpeed.php:484
+#: Util_PageSpeed.php:331
+#: Util_PageSpeed.php:514
 msgid "Start Time"
 msgstr ""
 
-#: Util_PageSpeed.php:319
-#: Util_PageSpeed.php:488
+#: Util_PageSpeed.php:335
+#: Util_PageSpeed.php:518
 msgid "Duration"
 msgstr ""
 
-#: Util_PageSpeed.php:323
-#: Util_PageSpeed.php:492
+#: Util_PageSpeed.php:339
+#: Util_PageSpeed.php:522
 msgid "Parse/Compile Time"
 msgstr ""
 
-#: Util_PageSpeed.php:327
-#: Util_PageSpeed.php:496
+#: Util_PageSpeed.php:343
+#: Util_PageSpeed.php:526
 msgid "Execution Time"
 msgstr ""
 
-#: Util_PageSpeed.php:331
-#: Util_PageSpeed.php:500
+#: Util_PageSpeed.php:347
+#: Util_PageSpeed.php:530
 msgid "Total"
 msgstr ""
 
-#: Util_PageSpeed.php:335
-#: Util_PageSpeed.php:504
+#: Util_PageSpeed.php:351
+#: Util_PageSpeed.php:534
 msgid "Cache Lifetime Miliseconds"
 msgstr ""
 
-#: Util_PageSpeed.php:339
-#: Util_PageSpeed.php:508
+#: Util_PageSpeed.php:355
+#: Util_PageSpeed.php:538
 msgid "Cache Hit Probability"
 msgstr ""
 
-#: Util_PageSpeed.php:343
-#: Util_PageSpeed.php:512
+#: Util_PageSpeed.php:359
+#: Util_PageSpeed.php:542
 msgid "Statistic"
 msgstr ""
 
-#: Util_PageSpeed.php:346
-#: Util_PageSpeed.php:357
-#: Util_PageSpeed.php:515
-#: Util_PageSpeed.php:526
+#: Util_PageSpeed.php:362
+#: Util_PageSpeed.php:373
+#: Util_PageSpeed.php:545
+#: Util_PageSpeed.php:556
 msgid "Element"
 msgstr ""
 
-#: Util_PageSpeed.php:354
-#: Util_PageSpeed.php:523
+#: Util_PageSpeed.php:370
+#: Util_PageSpeed.php:553
 msgid "Value"
 msgstr ""
 
-#: Util_PageSpeed.php:366
-#: Util_PageSpeed.php:535
+#: Util_PageSpeed.php:382
+#: Util_PageSpeed.php:565
 msgid "No identified items were provided by Google PageSpeed Insights API for this metric"
 msgstr ""
 
-#: Util_PageSpeed.php:382
-#: Util_PageSpeed.php:407
-#: Util_PageSpeed.php:551
-#: Util_PageSpeed.php:576
-msgid "TOTAL"
-msgstr ""
-
-#: Util_PageSpeed.php:383
-#: Util_PageSpeed.php:408
-#: Util_PageSpeed.php:552
-#: Util_PageSpeed.php:577
-msgid "CACHE"
-msgstr ""
-
-#: Util_PageSpeed.php:385
-#: Util_PageSpeed.php:410
-#: Util_PageSpeed.php:554
-#: Util_PageSpeed.php:579
+#: Util_PageSpeed.php:400
+#: Util_PageSpeed.php:424
+#: Util_PageSpeed.php:583
+#: Util_PageSpeed.php:607
 msgid "Tips"
 msgstr ""
 
-#: Util_PageSpeed.php:594
+#: Util_PageSpeed.php:622
 msgid "Opportunities"
 msgstr ""
 
-#: Util_PageSpeed.php:595
+#: Util_PageSpeed.php:623
 msgid "Diagnostics"
 msgstr ""
 
-#: Util_PageSpeed.php:596
+#: Util_PageSpeed.php:624
 msgid "Passed Audits"
 msgstr ""
 

--- a/qa/env/050-ssh-agent
+++ b/qa/env/050-ssh-agent
@@ -1,5 +1,3 @@
 pkill ssh-agent
 eval `ssh-agent -s`
-
-ssh-add ./key-aws-w3tcqa.pem
 ssh-add ~/.ssh/id_rsa

--- a/qa/env/100-generate-envs
+++ b/qa/env/100-generate-envs
@@ -164,76 +164,29 @@ def generate_box_descriptors(image_name)
 	}
 
 	box_descriptors = multiply(box_descriptors, {
-		#'wp47' => {
-		#	'WP_VERSION' => '4.7',
-		#	'_except_name_contains' => [
-		#		'php53', 'php55', 'php56', 'php71', 'php73',   # no reason to use for all php versions
-		#		'varnish',
-		#		'https'
-		#	]
-		#},
-		#'wp49' => {
-		#	'WP_VERSION' => '4.9.4',
-		#	'_except_name_contains' => [
-		#		'varnish',
-		#		'php53', 'php55',
-		#		'php73', 'php80'  # cause a lot of PHP warnings
-		#	]
-		#},
-		#'wp51' => {   # dont comment out - last env using PHP55 # Stopped using php55.
-		#	'WP_VERSION' => '5.1',
-		#	'_except_name_contains' => [
-		#		'php80'  # not compatible, {} in script-loader fatal
-		#	]
-		#},
-		#'wp52' => {
-		#	'WP_VERSION' => '5.2',
-		#	'_except_name_contains' => [
-		#		'php55'   # wp5.2 requires php>=5.6
-		#	]
-		#},
-		#'wp53' => {
-		#	'WP_VERSION' => '5.3',
-		#	'_except_name_contains' => [
-		#		'php55'   # wp5.3 requires php>=5.6
-		#	]
-		#},
-		#'wp55' => {
-		#	'WP_VERSION' => '5.5',
-		#	'_except_name_contains' => [
-		#		'php55',   # wp5.5 requires php>=5.6
-		#		'php80'  # not compatible, WP_Feed_Cache::create() fatal
-		#	]
-		#},
-		#'wp56' => {
-		#'WP_VERSION' => '5.6',
+		#'wp58' => {
+		#	'WP_VERSION' => '5.8',
 		#	'_except_name_contains' => [
 		#		'litespeed'
 		#	]
 		#},
-		#'wp57' => {
-		#	'WP_VERSION' => '5.7',
-		#	'_except_name_contains' => [
-		#		'litespeed'
-		#	]
-		#},
-		'wp58' => {
-			'WP_VERSION' => '5.8',
-			'_except_name_contains' => [
-				'litespeed'
-			]
-		},
 		'wp59' => {
 			'WP_VERSION' => '5.9'
 		},
-		'wp60' => {
-			'WP_VERSION' => '6.0',
+		#'wp60' => {
+		#	'WP_VERSION' => '6.0',
+		#	'_except_name_contains' => [
+		#		'litespeed'
+		#	]
+		#},
+		'wp61' => {
+			'WP_VERSION' => '6.1',
 			'_except_name_contains' => [
 				'litespeed'
 			]
 		},
-		'wp61' => {
-			'WP_VERSION' => '6.1',
+		'wp62' => {
+			'WP_VERSION' => '6.2-RC3',
 			'_except_name_contains' => [
 				'litespeed'
 			]

--- a/qa/env/scripts/init-image/600-wp-cli.sh
+++ b/qa/env/scripts/init-image/600-wp-cli.sh
@@ -14,7 +14,7 @@ chmod a+x /usr/local/src/wp-cli/bin/wp
 ln -s /usr/local/src/wp-cli/bin/wp /usr/bin/wp
 
 # wp-completion
-curl -L --silent "https://github.com/wp-cli/wp-cli/raw/master/utils/wp-completion.bash" --output /root/.wp-completion.bash
+curl -L --silent "https://raw.githubusercontent.com/wp-cli/wp-cli/main/utils/wp-completion.bash" --output /root/.wp-completion.bash
 echo "source /root/.wp-completion.bash" >> /root/.bashrc
 echo "alias wp=\"/usr/bin/wp --allow-root \"" >> /root/.bash_aliases
 

--- a/qa/env/scripts/restart-http.rb
+++ b/qa/env/scripts/restart-http.rb
@@ -17,7 +17,7 @@ def run
 		system_assert '/etc/init.d/apache2 restart'
 	elsif ENV['W3D_HTTP_SERVER'] == 'litespeed'
 		system_assert 'systemctl restart lsws'
-		system_assert 'chmod 777 /var/www/wp-sandbox/litespeed.conf'
+		system 'chmod 777 /var/www/wp-sandbox/litespeed.conf'
 	else
 		socket_filename = '/tmp/php-fpm.sock'
 		# php first, nginx next - otherwise not stable

--- a/qa/env/w3tc-clone
+++ b/qa/env/w3tc-clone
@@ -1,37 +1,44 @@
 #!/bin/bash
 
+# Create the "working" directory if needed.
 if [ ! -e ./working ]; then
-	mkdir ./working
+    mkdir ./working
 fi
 
-# reports
+# Create the "working/reports" directory if needed.
 if [ ! -e ./working/reports ]; then
-	mkdir ./working/reports
+    mkdir ./working/reports
 fi
 
-chmod 777 ./working/reports
+# Change the mode of "working/reports" to 0777.
+chmod 0777 ./working/reports
 
-# code
+# Clone or pull in the plugin code.
 if [ ! -e ./working/w3tc ]; then
-	mkdir ./working/w3tc
-	git clone $W3TCQA_GIT_URL -b $W3TCQA_GIT_BRANCH ./working/w3tc
+    mkdir ./working/w3tc
+    git clone $W3TCQA_GIT_URL -b $W3TCQA_GIT_BRANCH ./working/w3tc
 else
-	# new git -C can do it, but not everyone has new version installed
-	cd ./working/w3tc
-	git pull
-	cd ../..
+    # New "git -C" can do it, but not everyone has the new version installed.
+    cd ./working/w3tc
+    git pull
+    cd ../..
 fi
 
+# Clone or pull in the Pro plugin code.
 if [ ! -z "$W3TCQA_GIT_URL2" ]; then
-	if [ ! -e ./working/w3tc2 ]; then
-		mkdir ./working/w3tc2
-		git clone $W3TCQA_GIT_URL2 -b master ./working/w3tc2
-	else
-		# new git -C can do it, but not everyone has new version installed
-		cd ./working/w3tc2
-		git pull
-		cd ../..
-	fi
+    if [ ! -e ./working/w3tc2 ]; then
+        mkdir ./working/w3tc2
+        git clone $W3TCQA_GIT_URL2 -b master ./working/w3tc2
+    else
+        # New "git -C" can do it, but not everyone has the new version installed.
+        cd ./working/w3tc2
+        git pull
+        cd ../..
+    fi
 
-	cp -fR ./working/w3tc2/* ./working/w3tc
+    # Copy the Pro plugin code to the main plugin's directory.
+    cp -fR ./working/w3tc2/* ./working/w3tc
 fi
+
+# Install Composer dependencies.
+cd ./working/w3tc && composer update -o --no-dev

--- a/qa/env/w3tc-clone
+++ b/qa/env/w3tc-clone
@@ -41,4 +41,4 @@ if [ ! -z "$W3TCQA_GIT_URL2" ]; then
 fi
 
 # Install Composer dependencies.
-cd ./working/w3tc && composer update -o --no-dev
+cd ./working/w3tc && composer remove -n --no-update --dev yoast/phpunit-polyfills phpunit/phpunit squizlabs/php_codesniffer wp-coding-standards/wpcs && composer update -o --no-dev -n

--- a/qa/env/w3tc-clone
+++ b/qa/env/w3tc-clone
@@ -20,7 +20,7 @@ if [ ! -e ./working/w3tc ]; then
 else
     # New "git -C" can do it, but not everyone has the new version installed.
     cd ./working/w3tc
-    git pull
+    git pull -X theirs
     cd ../..
 fi
 
@@ -32,7 +32,7 @@ if [ ! -z "$W3TCQA_GIT_URL2" ]; then
     else
         # New "git -C" can do it, but not everyone has the new version installed.
         cd ./working/w3tc2
-        git pull
+        git pull -X theirs
         cd ../..
     fi
 

--- a/qa/tests/cdn/file-upload.js
+++ b/qa/tests/cdn/file-upload.js
@@ -57,8 +57,10 @@ describe('check that media library works when CDN is active', function() {
 		await adminPage.waitForSelector('.attachment-preview');
 		let imgs = await dom.listTagAttributes(adminPage, 'img', 'src');
 		for (let url of imgs) {
-			if (url.indexOf("image.jpg") >= 0) {
+			log.log('Found image URL: ' + url);
+			if (url.search(/image(.*?).jpg/) >= 0) {
 				imageUrl = url;
+				log.log('Using URL: ' + url);
 			}
 		}
 	});

--- a/qa/tests/cdn/pull-custom.js
+++ b/qa/tests/cdn/pull-custom.js
@@ -100,8 +100,7 @@ describe('check that media library works when CDN is active', function() {
 			env.blogWpContentUrl + 'themes/' + theme + '/qa/theme-js.js',
 			env.blogWpContentUrl + 'themes/' + theme + '/qa-theme-image2.png',
 			env.blogPluginsUrl + 'test-plugin/plugin-js.js',
-			env.blogPluginsUrl + 'test-plugin/plugin-image1.jpg',
-			imageUrl
+			env.blogPluginsUrl + 'test-plugin/plugin-image1.jpg'
 		];
 
 		let urlsToKeep = [
@@ -114,6 +113,7 @@ describe('check that media library works when CDN is active', function() {
 		let pageContent = await page.content();
 
 		urlsToReplace.forEach(function(url) {
+			log.log('URL to replace host: ' + url);
 			let urlReplaced = url.replace(
 				'://' + env.blogHost + env.wpMaybeColonPort,
 				'://for-tests.sandbox');

--- a/qa/tests/minify/html.js
+++ b/qa/tests/minify/html.js
@@ -135,11 +135,7 @@ describe('minify html', function() {
 		let e6img = await page.$eval('#void6image', (e) => e.alt);
 		expect(e6img).equals('b/');
 
-		if (parseFloat(env.wpVersion) < 6.1) {
-			expect(testPageHtml).contains('id=void-elements6>\n<img\nid=void6image src=a/ alt=b/ >');
-		} else {
-			expect(testPageHtml).contains('id=void-elements6>\n<img\ndecoding=async id=void6image src=a/ alt=b/ >');
-		}
+		expect(testPageHtml).match(/id=void-elements6>\n<img\n(decoding=async )?id=void6image src=a\/ alt=b\/ >/);
 
 		let e7img = await page.$eval('#void7image', (e) => e.alt);
 		expect(e7img).equals('svg-test');

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: boldgrid, fredericktownes, maxicusc, gidomanders, bwmarkle, harryjackson1221, joemoto, vmarko, jacobd91
 Tags: seo, cache, CDN, pagespeed, caching, performance, compression, optimize, cloudflare, nginx, apache, varnish, redis, aws, amazon web services, s3, cloudfront, azure
 Requires at least: 5.3
-Tested up to: 6.1
-Stable tag: 2.3.0
+Tested up to: 6.2
+Stable tag: 2.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -284,6 +284,14 @@ It's quite difficult to recall all of the innovators that have shared their thou
 Please reach out to all of these people and support their projects if you're so inclined.
 
 == Changelog ==
+
+= 2.3.1 =
+* Fix: PHP 8 compatibility: Invalid return type if Browser Cache is disabled
+* Fix: Added AWS SNS message classes (aws/aws-php-sns-message-validator)
+* Fix: PageSpeed service: messages and escaping
+* Fix: Image Service meta query handling
+* Update: Dependency version updates
+* Update: Content-Security-Policy (CSP) and Content-Security-Policy-Report-Only (CSPRO) header field configuration
 
 = 2.3.0 =
 * Feature: PageSpeed Insights reports and performance page widget

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'W3TC', true );
-define( 'W3TC_VERSION', '2.3.0' );
+define( 'W3TC_VERSION', '2.3.1' );
 define( 'W3TC_POWERED_BY', 'W3 Total Cache' );
 define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       W3 Total Cache
  * Plugin URI:        https://www.boldgrid.com/totalcache/
  * Description:       The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
- * Version:           2.3.0
+ * Version:           2.3.1
  * Requires at least: 5.3
  * Requires PHP:      5.6
  * Author:            BoldGrid


### PR DESCRIPTION
All PHPUnit tests and Travis CI checks passed.  AWS tests passed with the exception of some Litespeed tests that we'll address later.
Perform smoke tests as usual.  Additionally, test Amazon CloudFront (or anything that loads the AWS Composer dependency) on PHP versions 5.6 through 8.1, to ensure no autoloader issues.