### PR TITLE
Fix Memcached test using SASL auth

### DIFF
--- a/DbCache_Plugin_Admin.php
+++ b/DbCache_Plugin_Admin.php
@@ -52,8 +52,11 @@ class DbCache_Plugin_Admin {
 
 		if ( $c->get_string( 'dbcache.engine' ) == 'memcached' ) {
 			$memcached_servers = $c->get_array( 'dbcache.memcached.servers' );
+			$memcached_binary_protocol = $c->get_boolean( 'dbcache.memcached.binary_protocol' );
+			$memcached_username = $c->get_string( 'dbcache.memcached.username' );
+			$memcached_password = $c->get_string( 'dbcache.memcached.password' );
 
-			if ( !Util_Installed::is_memcache_available( $memcached_servers ) ) {
+			if ( !Util_Installed::is_memcache_available( $memcached_servers, $memcached_binary_protocol, $memcached_username, $memcached_password ) ) {
 				if ( !isset( $errors['memcache_not_responding.details'] ) )
 					$errors['memcache_not_responding.details'] = array();
 

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -27,9 +27,12 @@ class Generic_AdminActions_Test {
 	 * @return void
 	 */
 	function w3tc_test_memcached() {
-		$servers = Util_Request::get_array( 'servers' );
+		$servers 		 = Util_Request::get_array( 'servers' );
+		$binary_protocol = Util_Request::get_boolean( 'binary_protocol', true );
+		$username        = Util_Request::get_string( 'username', '' );
+		$password        = Util_Request::get_string( 'password', '' );
 
-		$this->respond_test_result( $this->is_memcache_available( $servers ) );
+		$this->respond_test_result( $this->is_memcache_available( $servers, $binary_protocol, $username, $password ) );
 	}
 
 	/**
@@ -166,14 +169,17 @@ class Generic_AdminActions_Test {
 	 * @param array   $servers
 	 * @return boolean
 	 */
-	private function is_memcache_available( $servers ) {
+	private function is_memcache_available( $servers, $binary_protocol, $username, $password ) {
 		if ( count( $servers ) <= 0 )
 			return false;
 
 		foreach ( $servers as $server ) {
 			@$memcached = Cache::instance( 'memcached', array(
 					'servers' => $server,
-					'persistent' => false
+					'persistent' => false,
+					'binary_protocol' => $binary_protocol,
+					'username' => $username,
+					'password' => $password
 				) );
 			if ( is_null( $memcached ) )
 				return false;

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -36,7 +36,7 @@ class Generic_AdminActions_Test {
 	}
 
 	/**
-	 * Test memcached.
+	 * Test redis
 	 */
 	public function w3tc_test_redis() {
 		$servers                 = Util_Request::get_array( 'servers' );

--- a/Minify_Plugin_Admin.php
+++ b/Minify_Plugin_Admin.php
@@ -136,8 +136,11 @@ class Minify_Plugin_Admin {
 
 		if ( $c->get_string( 'minify.engine' ) == 'memcached' ) {
 			$memcached_servers = $c->get_array( 'minify.memcached.servers' );
+			$memcached_binary_protocol = $c->get_boolean( 'minify.memcached.binary_protocol' );
+			$memcached_username = $c->get_string( 'minify.memcached.username' );
+			$memcached_password = $c->get_string( 'minify.memcached.password' );
 
-			if ( !Util_Installed::is_memcache_available( $memcached_servers ) ) {
+			if ( !Util_Installed::is_memcache_available( $memcached_servers, $memcached_binary_protocol, $memcached_username, $memcached_password ) ) {
 				if ( !isset( $errors['memcache_not_responding.details'] ) )
 					$errors['memcache_not_responding.details'] = array();
 

--- a/ObjectCache_Plugin_Admin.php
+++ b/ObjectCache_Plugin_Admin.php
@@ -23,8 +23,14 @@ class ObjectCache_Plugin_Admin {
 		if ( $c->get_string( 'objectcache.engine' ) == 'memcached' ) {
 			$memcached_servers = $c->get_array(
 				'objectcache.memcached.servers' );
+			$memcached_binary_protocol = $c->get_boolean(
+				'objectcache.memcached.binary_protocol' );
+			$memcached_username = $c->get_string(
+				'objectcache.memcached.username' );
+			$memcached_password = $c->get_string(
+				'objectcache.memcached.password' );
 
-			if ( !Util_Installed::is_memcache_available( $memcached_servers ) ) {
+			if ( !Util_Installed::is_memcache_available( $memcached_servers, $memcached_binary_protocol, $memcached_username, $memcached_password ) ) {
 				if ( !isset( $errors['memcache_not_responding.details'] ) )
 					$errors['memcache_not_responding.details'] = array();
 

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -281,8 +281,11 @@ class PgCache_Plugin_Admin {
 
 		if ( $c->get_string( 'pgcache.engine' ) == 'memcached' ) {
 			$memcached_servers = $c->get_array( 'pgcache.memcached.servers' );
+			$memcached_binary_protocol = $c->get_boolean( 'pgcache.memcached.binary_protocol' );
+			$memcached_username = $c->get_string( 'pgcache.memcached.username' );
+			$memcached_password = $c->get_string( 'pgcache.memcached.password' );
 
-			if ( !Util_Installed::is_memcache_available( $memcached_servers ) ) {
+			if ( !Util_Installed::is_memcache_available( $memcached_servers, $memcached_binary_protocol, $memcached_username, $memcached_password ) ) {
 				if ( !isset( $errors['memcache_not_responding.details'] ) )
 					$errors['memcache_not_responding.details'] = array();
 

--- a/Util_Installed.php
+++ b/Util_Installed.php
@@ -123,9 +123,12 @@ class Util_Installed {
 	 * Check if memcache is available
 	 *
 	 * @param array   $servers
+	 * @param boolean $binary_protocol
+	 * @param string  $username
+	 * @param string  $password
 	 * @return boolean
 	 */
-	static public function is_memcache_available( $servers ) {
+	static public function is_memcache_available( $servers, $binary_protocol, $username, $password ) {
 		static $results = array();
 
 		$key = md5( implode( '', $servers ) );
@@ -133,7 +136,10 @@ class Util_Installed {
 		if ( !isset( $results[$key] ) ) {
 			$memcached = Cache::instance( 'memcached', array(
 					'servers' => $servers,
-					'persistent' => false
+					'persistent' => false,
+					'binary_protocol' => $binary_protocol,
+					'username' => $username,
+					'password' => $password
 				) );
 			if ( is_null( $memcached ) )
 				return false;

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -993,6 +993,9 @@ jQuery(function() {
 		jQuery.post('admin.php?page=w3tc_dashboard', {
 			w3tc_test_memcached: 1,
 			servers: jQuery('#memcached_servers').val(),
+			binary_protocol: jQuery('[id$=__memcached__binary_protocol]').is(':checked'),
+			username: jQuery('#memcached_username').val(),
+			password: jQuery('#memcached_password').val(),
 			_wpnonce: jQuery(this).metadata().nonce
 		}, function(data) {
 			status.addClass(data.result ? 'w3tc-success' : 'w3tc-error');


### PR DESCRIPTION
Fixes #448.

When testing a Memcached cache, in addition to passing the configured servers, also pass binary protocol, username and password. This allows the test to be run correctly when SASL authentication is used (when a username and password are supplied). The binary protocol option is also passed as SASL auth with Memcached requires the binary protocol to be used.