### PR TITLE
PageSpeed Google Analytics event label update

### DIFF
--- a/PageSpeed_Page_View.js
+++ b/PageSpeed_Page_View.js
@@ -74,7 +74,7 @@ jQuery(document).ready(function ($) {
 				{
 					eventCategory: 'w3tc_pagespeed',
 					eventAction: 'metric',
-					eventLabel: $(this).text(),
+					eventLabel: $(this).attr('gatitle'),
 					eventValue: 0,
 					transport: 'beacon'
 				}

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -88,11 +88,11 @@ class Util_PageSpeed {
 		$bar = '';
 
 		if ( $metric['score'] >= 90 ) {
-			$bar = '<div style="flex-grow: ' . $metric['score'] . '"><span class="w3tcps_range w3tcps_pass">' . $metric['displayValue'] . '</span></div>';
+			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ) . '"><span class="w3tcps_range w3tcps_pass">' . esc_html( $metric['displayValue'] ) . '</span></div>';
 		} elseif ( $metric['score'] >= 50 && $metric['score'] < 90 ) {
-			$bar = '<div style="flex-grow: ' . $metric['score'] . '"><span class="w3tcps_range w3tcps_average">' . $metric['displayValue'] . '</span></div>';
+			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ). '"><span class="w3tcps_range w3tcps_average">' . esc_html( $metric['displayValue'] ) . '</span></div>';
 		} elseif ( $metric['score'] < 50 ) {
-			$bar = '<div style="flex-grow: ' . $metric['score'] . '"><span class="w3tcps_range w3tcps_fail">' . $metric['displayValue'] . '<span></div>';
+			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ) . '"><span class="w3tcps_range w3tcps_fail">' . esc_html( $metric['displayValue'] ) . '<span></div>';
 		}
 
 		echo wp_kses(
@@ -267,7 +267,7 @@ class Util_PageSpeed {
 				}
 			}
 
-			$opportunity['description'] = preg_replace( '/(.*)(\[Learn more\])\((.*?)\)(.*)/i', '$1<a href="$3">$2</a>$4', $opportunity['description'] );
+			$opportunity['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/i', '$1<a href="$3">$2</a>$4', esc_html( $opportunity['description'] ) );
 
 			$headers = '';
 			$items   = '';
@@ -297,83 +297,83 @@ class Util_PageSpeed {
 				}
 				if ( isset( $item['totalBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total Bytes', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['totalBytes'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['totalBytes'] ) . '</td>';
 				}
 				if ( isset( $item['wastedBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Bytes', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['wastedBytes'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['wastedBytes'] ) . '</td>';
 				}
 				if ( isset( $item['wastedPercent'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Percentage', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( $item['wastedPercent'], 2 ) . '%</td>';
+					$items   .= '<td>' . round( esc_html( $item['wastedPercent'] ), 2 ) . '%</td>';
 				}
 				if ( isset( $item['wastedMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( $item['wastedMs'], 2 ) . '</td>';
+					$items   .= '<td>' . round( esc_html( $item['wastedMs'] ), 2 ) . '</td>';
 				}
 				if ( isset( $item['label'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Type', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['label'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['label'] ) . '</td>';
 				}
 				if ( isset( $item['groupLabel'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Group', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['groupLabel'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['groupLabel'] ) . '</td>';
 				}
 				if ( isset( $item['requestCount'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Requests', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['requestCount'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['requestCount'] ) . '</td>';
 				}
 				if ( isset( $item['transferSize'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Transfer Size', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['transferSize'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['transferSize'] ) . '</td>';
 				}
 				if ( isset( $item['startTime'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Start Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['startTime'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['startTime'] ) . '</td>';
 				}
 				if ( isset( $item['duration'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Duration', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['duration'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['duration'] ) . '</td>';
 				}
 				if ( isset( $item['scriptParseCompile'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Parse/Compile Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['scriptParseCompile'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['scriptParseCompile'] ) . '</td>';
 				}
 				if ( isset( $item['scripting'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Execution Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['scripting'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['scripting'] ) . '</td>';
 				}
 				if ( isset( $item['total'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['total'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['total'] ) . '</td>';
 				}
 				if ( isset( $item['cacheLifetimeMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Cache Lifetime Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['cacheLifetimeMs'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['cacheLifetimeMs'] ) . '</td>';
 				}
 				if ( isset( $item['cacheHitProbability'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Cache Hit Probability', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['cacheHitProbability'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['cacheHitProbability'] ) . '</td>';
 				}
 				if ( isset( $item['value'] ) && isset( $item['statistic'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Statistic', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['statistic'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['statistic'] ) . '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					if ( isset( $item['node'] ) ) {
 						$items .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-						$items .= '<p>' . $item['node']['selector'] . '</p>';
+						$items .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
 					}
 					$items .= '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Value', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['value'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['value'] ) . '</td>';
 				} elseif ( isset( $item['node'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					$items   .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-					$items   .= '<p>' . $item['node']['selector'] . '</p>';
+					$items   .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
 					$items   .= '</td>';
 				}
 				$items .= '</tr>';
@@ -383,8 +383,8 @@ class Util_PageSpeed {
 
 			if ( $opportunity['score'] >= 90 ) {
 				$passed_audits .= '
-					<div class="audits w3tcps_passed_audit' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $opportunity['title'] . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+					<div class="audits w3tcps_passed_audit' . esc_attr( $audit_classes ) . ' ' . esc_attr( $notice ) . '">
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . esc_attr( $grade ) . '" gatitle="' . esc_attr( $opportunity['title'] ) . '">' . esc_html( $opportunity['title'] ) . ( isset( $opportunity['displayValue'] ) ? ' - ' . esc_html( $opportunity['displayValue'] ) : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_pass_audit_items">
 							<p class="w3tcps_item_desciption">' . $opportunity['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -407,8 +407,8 @@ class Util_PageSpeed {
 					</div>';
 			} else {
 				$opportunities .= '
-					<div class="audits w3tcps_opportunities' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $opportunity['title'] . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+					<div class="audits w3tcps_opportunities' . esc_attr( $audit_classes ) . ' ' . esc_attr( $notice ) . '">
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . esc_attr( $grade ) . '" gatitle="' . esc_attr( $opportunity['title'] ) . '">' . esc_html( $opportunity['title'] ) . ( isset( $opportunity['displayValue'] ) ? ' - ' . esc_html( $opportunity['displayValue'] ) : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_opportunity_items">
 							<p class="w3tcps_item_desciption">' . $opportunity['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -451,7 +451,7 @@ class Util_PageSpeed {
 				$audit_classes .= ' ' . $type;
 			}
 
-			$diagnostic['description'] = preg_replace( '/(.*)(\[Learn more\])\((.*?)\)(.*)/i', '$1<a href="$3">$2</a>$4', $diagnostic['description'] );
+			$diagnostic['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/i', '$1<a href="$3">$2</a>$4', esc_html( $diagnostic['description'] ) );
 
 			$headers = '';
 			$items   = '';
@@ -480,83 +480,83 @@ class Util_PageSpeed {
 				}
 				if ( isset( $item['totalBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total Bytes', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['totalBytes'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['totalBytes'] ) . '</td>';
 				}
 				if ( isset( $item['wastedBytes'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Bytes', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['wastedBytes'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['wastedBytes'] ) . '</td>';
 				}
 				if ( isset( $item['wastedPercent'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Percentage', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( $item['wastedPercent'], 2 ) . '%</td>';
+					$items   .= '<td>' . round( esc_html( $item['wastedPercent'] ), 2 ) . '%</td>';
 				}
 				if ( isset( $item['wastedMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( $item['wastedMs'], 2 ) . '</td>';
+					$items   .= '<td>' . round( esc_html( $item['wastedMs'] ), 2 ) . '</td>';
 				}
 				if ( isset( $item['label'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Type', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['label'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['label'] ) . '</td>';
 				}
 				if ( isset( $item['groupLabel'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Group', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['groupLabel'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['groupLabel'] ) . '</td>';
 				}
 				if ( isset( $item['requestCount'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Requests', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['requestCount'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['requestCount'] ) . '</td>';
 				}
 				if ( isset( $item['transferSize'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Transfer Size', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['transferSize'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['transferSize'] ) . '</td>';
 				}
 				if ( isset( $item['startTime'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Start Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['startTime'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['startTime'] ) . '</td>';
 				}
 				if ( isset( $item['duration'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Duration', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['duration'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['duration'] ) . '</td>';
 				}
 				if ( isset( $item['scriptParseCompile'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Parse/Compile Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['scriptParseCompile'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['scriptParseCompile'] ) . '</td>';
 				}
 				if ( isset( $item['scripting'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Execution Time', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['scripting'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['scripting'] ) . '</td>';
 				}
 				if ( isset( $item['total'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Total', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['total'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['total'] ) . '</td>';
 				}
 				if ( isset( $item['cacheLifetimeMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Cache Lifetime Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['cacheLifetimeMs'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['cacheLifetimeMs'] ) . '</td>';
 				}
 				if ( isset( $item['cacheHitProbability'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Cache Hit Probability', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . ( $item['cacheHitProbability'] * 100 ) . '%</td>';
+					$items   .= '<td>' . ( esc_html( $item['cacheHitProbability'] ) * 100 ) . '%</td>';
 				}
 				if ( isset( $item['value'] ) && isset( $item['statistic'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Statistic', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['statistic'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['statistic'] ) . '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					if ( isset( $item['node'] ) ) {
 						$items .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-						$items .= '<p>' . $item['node']['selector'] . '</p>';
+						$items .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
 					}
 					$items .= '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Value', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . $item['value'] . '</td>';
+					$items   .= '<td>' . esc_html( $item['value'] ) . '</td>';
 				} elseif ( isset( $item['node'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					$items   .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-					$items   .= '<p>' . $item['node']['selector'] . '</p>';
+					$items   .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
 					$items   .= '</td>';
 				}
 				$items .= '</tr>';
@@ -566,8 +566,8 @@ class Util_PageSpeed {
 
 			if ( $diagnostic['score'] >= 90 ) {
 				$passed_audits .= '
-					<div class="audits w3tcps_passed_audit' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $diagnostic['title'] . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+					<div class="audits w3tcps_passed_audit' . esc_attr( $audit_classes ) . ' ' . esc_attr( $notice ) . '">
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . esc_attr( $grade ) . '" gatitle="' . esc_attr( $diagnostic['title'] ) . '">' . esc_html( $diagnostic['title'] ) . ( isset( $diagnostic['displayValue'] ) ? ' - ' . esc_html( $diagnostic['displayValue'] ) : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_pass_audit_items">
 							<p class="w3tcps_item_desciption">' . $diagnostic['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -590,8 +590,8 @@ class Util_PageSpeed {
 					</div>';
 			} else {
 				$diagnostics .= '
-					<div class="audits w3tcps_diagnostics' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $diagnostic['title'] . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+					<div class="audits w3tcps_diagnostics' . esc_attr( $audit_classes ) . ' ' . esc_attr( $notice ) . '">
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . esc_attr( $grade ) . '" gatitle="' . esc_attr( $diagnostic['title'] ) . '">' . esc_html( $diagnostic['title'] ) . ( isset( $diagnostic['displayValue'] ) ? ' - ' . esc_html( $diagnostic['displayValue'] ) : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_diagnostic_items">
 							<p class="w3tcps_item_desciption">' . $diagnostic['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -384,7 +384,7 @@ class Util_PageSpeed {
 			if ( $opportunity['score'] >= 90 ) {
 				$passed_audits .= '
 					<div class="audits w3tcps_passed_audit' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $opportunity['title'] . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_pass_audit_items">
 							<p class="w3tcps_item_desciption">' . $opportunity['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -408,7 +408,7 @@ class Util_PageSpeed {
 			} else {
 				$opportunities .= '
 					<div class="audits w3tcps_opportunities' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $opportunity['title'] . '">' . $opportunity['title'] . ( isset( $opportunity['displayValue'] ) ? ' - ' . $opportunity['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_opportunity_items">
 							<p class="w3tcps_item_desciption">' . $opportunity['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -567,7 +567,7 @@ class Util_PageSpeed {
 			if ( $diagnostic['score'] >= 90 ) {
 				$passed_audits .= '
 					<div class="audits w3tcps_passed_audit' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $diagnostic['title'] . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_pass_audit_items">
 							<p class="w3tcps_item_desciption">' . $diagnostic['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -591,7 +591,7 @@ class Util_PageSpeed {
 			} else {
 				$diagnostics .= '
 					<div class="audits w3tcps_diagnostics' . $audit_classes . ' ' . $notice . '">
-						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
+						<span class="w3tcps_breakdown_items_toggle w3tcps_range ' . $grade . '" gatitle="' . $diagnostic['title'] . '">' . $diagnostic['title'] . ( isset( $diagnostic['displayValue'] ) ? ' - ' . $diagnostic['displayValue'] : '' ) . '<span class="dashicons dashicons-arrow-down-alt2"></span></span>
 						<div class="w3tcps_breakdown_items w3tcps_diagnostic_items">
 							<p class="w3tcps_item_desciption">' . $diagnostic['description'] . '</p>
 							<div class="w3tcps_breakdown_items_container">
@@ -663,6 +663,7 @@ class Util_PageSpeed {
 				'id'      => array(),
 				'class'   => array(),
 				'title'   => array(),
+				'gatitle' => array(),
 				'copyurl' => array(),
 			),
 			'p'     => array(

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -90,7 +90,7 @@ class Util_PageSpeed {
 		if ( $metric['score'] >= 90 ) {
 			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ) . '"><span class="w3tcps_range w3tcps_pass">' . esc_html( $metric['displayValue'] ) . '</span></div>';
 		} elseif ( $metric['score'] >= 50 && $metric['score'] < 90 ) {
-			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ). '"><span class="w3tcps_range w3tcps_average">' . esc_html( $metric['displayValue'] ) . '</span></div>';
+			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ) . '"><span class="w3tcps_range w3tcps_average">' . esc_html( $metric['displayValue'] ) . '</span></div>';
 		} elseif ( $metric['score'] < 50 ) {
 			$bar = '<div style="flex-grow: ' . esc_attr( $metric['score'] ) . '"><span class="w3tcps_range w3tcps_fail">' . esc_html( $metric['displayValue'] ) . '<span></div>';
 		}
@@ -267,7 +267,7 @@ class Util_PageSpeed {
 				}
 			}
 
-			$opportunity['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/i', '$1<a href="$3">$2</a>$4', esc_html( $opportunity['description'] ) );
+			$opportunity['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/', '$1<a href="$3">$2</a>$4', esc_html( $opportunity['description'] ) );
 
 			$headers = '';
 			$items   = '';
@@ -305,11 +305,11 @@ class Util_PageSpeed {
 				}
 				if ( isset( $item['wastedPercent'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Percentage', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( esc_html( $item['wastedPercent'] ), 2 ) . '%</td>';
+					$items   .= '<td>' . round( $item['wastedPercent'], 2 ) . '%</td>';
 				}
 				if ( isset( $item['wastedMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( esc_html( $item['wastedMs'] ), 2 ) . '</td>';
+					$items   .= '<td>' . round( $item['wastedMs'], 2 ) . '</td>';
 				}
 				if ( isset( $item['label'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Type', 'w3-total-cache' ) . '</th>';
@@ -451,7 +451,7 @@ class Util_PageSpeed {
 				$audit_classes .= ' ' . $type;
 			}
 
-			$diagnostic['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/i', '$1<a href="$3">$2</a>$4', esc_html( $diagnostic['description'] ) );
+			$diagnostic['description'] = preg_replace( '/(.*?)(\[.*?\])\((.*?)\)(.*?[,.?!]*)/', '$1<a href="$3">$2</a>$4', esc_html( $diagnostic['description'] ) );
 
 			$headers = '';
 			$items   = '';
@@ -488,11 +488,11 @@ class Util_PageSpeed {
 				}
 				if ( isset( $item['wastedPercent'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Percentage', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( esc_html( $item['wastedPercent'] ), 2 ) . '%</td>';
+					$items   .= '<td>' . round( $item['wastedPercent'], 2 ) . '%</td>';
 				}
 				if ( isset( $item['wastedMs'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Wasted Miliseconds', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . round( esc_html( $item['wastedMs'] ), 2 ) . '</td>';
+					$items   .= '<td>' . round( $item['wastedMs'], 2 ) . '</td>';
 				}
 				if ( isset( $item['label'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Type', 'w3-total-cache' ) . '</th>';


### PR DESCRIPTION
Previously the GA tracking on metric toggles used the display text as the event label which for some metrics would contain displayValues that would result in variance. Subsequently the GA would show separate tracking for each variance rather than the intended general metric 

With this PR the event label should be generic for each metric