### PR TITLE
fix for nginx header|permissions fields being a string instead of array

### DIFF
--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -344,11 +344,13 @@ class BrowserCache_Environment_Nginx {
 				}
 
 				if ( ! empty( $feature_v ) ) {
-					$rules .= '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
+				    $feature_v_rules = 'add_header Feature-Policy "' . implode( ',', $feature_v ) . "\";";
+					$rules[] = $feature_v_rules;
 				}
 
 				if ( ! empty( $permission_v ) ) {
-					$rules .= '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
+				    $permission_v_rules = 'add_header Permissions-Policy "' . implode( ',', $permission_v ) . "\";";
+					$rules[] = $permission_v_rules;
 				}
 			}
 		}


### PR DESCRIPTION
In the Browser Cache settings for Nginx for the Header/Permission Policies, any input in any field (none, src, etc.) will cause a critical error on the site when you save. It appears this happens because the $rules variable gets converted from an Array to a String. To fix this issue, I created a variable to house the concatenated string with the correct nginx "add_header Feature-Policy" and "add_header Permission-Policy" string prepend. Then pushed into the $rules array. This sets the nginx.conf correctly and allows the nginx server to pass testing / restart.