### PR TITLE
Set permissions on created cache files to value of FS_CHMOD_FILE

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -60,6 +60,12 @@ class Cache_File_Generic extends Cache_File {
 		@fputs( $fp, $var['content'] );
 		@fclose( $fp );
 
+		$chmod = 0644;
+		if ( defined( 'FS_CHMOD_FILE' ) )
+			$chmod = FS_CHMOD_FILE;
+
+		@chmod( $tmppath, $chmod );
+
 		if ( $this->_locking )
 			@flock( $fp, LOCK_UN );
 
@@ -135,8 +141,14 @@ class Cache_File_Generic extends Cache_File {
 			}
 
 			if ( !empty($rules) ) {
-				@file_put_contents( dirname( $path ) .
-					DIRECTORY_SEPARATOR . '.htaccess', $rules );
+				$htaccess_path = dirname( $path ) . DIRECTORY_SEPARATOR . '.htaccess';
+				@file_put_contents( $htaccess_path, $rules );
+
+				$chmod = 0644;
+				if ( defined( 'FS_CHMOD_FILE' ) )
+					$chmod = FS_CHMOD_FILE;
+
+				@chmod( $htaccess_path, $chmod );
 			}
 		}
 

--- a/Util_Rule.php
+++ b/Util_Rule.php
@@ -359,6 +359,12 @@ class Util_Rule {
 					return;
 				}
 			}
+
+			$chmod = 0644;
+			if ( defined( 'FS_CHMOD_FILE' ) )
+				$chmod = FS_CHMOD_FILE;
+
+			@chmod( $path, $chmod );
 		}
 
 		Util_Rule::after_rules_modified();

--- a/Util_WpFile.php
+++ b/Util_WpFile.php
@@ -62,8 +62,14 @@ class Util_WpFile {
 	 * @return void
 	 */
 	static public function write_to_file( $filename, $content ) {
-		if ( @file_put_contents( $filename, $content ) )
+		$chmod = 0644;
+		if ( defined( 'FS_CHMOD_FILE' ) )
+			$chmod = FS_CHMOD_FILE;
+
+		if ( @file_put_contents( $filename, $content ) ) {
+			@chmod( $filename, $chmod );
 			return;
+		}
 
 		try {
 			self::request_filesystem_credentials();
@@ -73,7 +79,7 @@ class Util_WpFile {
 		}
 
 		global $wp_filesystem;
-		if ( !$wp_filesystem->put_contents( $filename, $content ) ) {
+		if ( !$wp_filesystem->put_contents( $filename, $content, $chmod ) ) {
 			throw new Util_WpFile_FilesystemWriteException(
 				'FTP credentials don\'t allow to write to file <strong>' .
 				$filename . '</strong>', self::get_filesystem_credentials_form(),


### PR DESCRIPTION
This was already been done in other parts of the codebase e.g. https://github.com/BoldGrid/w3-total-cache/blob/3a094493064ea60d727b3389dee813639860ef49/Util_File.php#L398-L401

So I have taken the same code and applied it in other places files are created.

This is needed for example so a web server user and CLI user in the same group both have permission to clear cache files when `FS_CHMOD_FILE` is set to `0664`.