### PR TITLE
Fix GA switch for development

### DIFF
--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -572,7 +572,7 @@ class Extension_ImageService_Plugin_Admin {
 					),
 					'tos_choice'  => Licensing_Core::get_tos_choice(),
 					'track_usage' => $this->config->get_boolean( 'common.track_usage' ),
-					'ga_profile'  => ( defined( 'W3TC_DEBUG' ) && W3TC_DEBUG ) ? 'UA-2264433-7' : 'UA-2264433-8',
+					'ga_profile'  => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'UA-2264433-7' : 'UA-2264433-8',
 					'settings'    => $this->config->get_array( 'imageservice' ),
 					'settingsUrl' => esc_url( Util_Ui::admin_url( 'upload.php?page=w3tc_extension_page_imageservice' ) ),
 				)

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -435,7 +435,7 @@ class Generic_Plugin_Admin {
 				$page = 'extensions/' . Util_Request::get_string( 'extension' );
 			}
 
-			if ( defined( 'W3TC_DEBUG' ) && W3TC_DEBUG ) {
+			if ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) {
 				$profile = 'UA-2264433-7';
 			} else {
 				$profile = 'UA-2264433-8';

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -889,7 +889,7 @@ class SetupGuide_Plugin_Admin {
 							'install_version'   => esc_attr( $state->get_string( 'common.install_version' ) ),
 							'w3tc_edition'      => esc_attr( Util_Environment::w3tc_edition( $config ) ),
 							'list_widgets'      => esc_attr( Util_Widget::list_widgets() ),
-							'ga_profile'        => ( defined( 'W3TC_DEBUG' ) && W3TC_DEBUG ) ? 'UA-2264433-7' : 'UA-2264433-8',
+							'ga_profile'        => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'UA-2264433-7' : 'UA-2264433-8',
 							'tos_choice'        => Licensing_Core::get_tos_choice(),
 							'track_usage'       => $config->get_boolean( 'common.track_usage' ),
 							'test_complete_msg' => __(

--- a/qa/env/scripts/init-box/800-w3tc.sh
+++ b/qa/env/scripts/init-box/800-w3tc.sh
@@ -5,6 +5,7 @@ echo "alias w3test=\"/share/scripts/w3test \"" >> /root/.bash_aliases
 # ask w3tc to use debug GA profile
 cd $W3D_WP_PATH
 sed -i '2idefine( \"W3TC_DEBUG\", true );' wp-config.php
+sed -i '2idefine( \"W3TC_DEVELOPER\", true );' wp-config.php
 
 # backup before w3tc
 /share/scripts/w3tc-umount.sh


### PR DESCRIPTION
This is to avoid the W3TC_DEBUG constant from switching Google Analytics to the development property.  I added a new constant check for "W3TC_DEVELOPER", which will only change the GA property ID to development.