### PR TITLE
Expired license renewal admin notice Modal fix

### DIFF
--- a/Licensing_Plugin_Admin.php
+++ b/Licensing_Plugin_Admin.php
@@ -171,7 +171,7 @@ class Licensing_Plugin_Admin {
 						'w3-total-cache'
 					),
 					'<input type="button" class="button-primary button-buy-plugin" data-nonce="' .
-						esc_url( wp_create_nonce( 'w3tc' ) ) . '" data-renew-key="' . esc_attr( $this->get_license_key() ) .
+						wp_create_nonce( 'w3tc' ) . '" data-renew-key="' . esc_attr( $this->get_license_key() ) .
 						'" data-src="licensing_expired" value="' . __( 'Renew Now', 'w3-total-cache' ) . '" />'
 				),
 				array(


### PR DESCRIPTION
Fixed nonce issue with the Renew Now button in the licensing expired admin notice that resulted in a 403 in the modal popup.

Without this fix, if a W3TC license expired an admin notice would be displayed at the top containing a "Renew Now" button. This button would trigger a modal containing the upgrade.php light-box template with a button linking to the checkout cart that additionally passed the relevant information to renew a license. This modal would throw a 403 due to a bad nonce in the original button and would fail to load, showing an infinite loading spinner

With this fix, the modal should now load and properly allow for a renewal to proceed