### PR TITLE
Fixed delete_blog hook deprecation in WP 5.1.0

### DIFF
--- a/DbCache_Plugin.php
+++ b/DbCache_Plugin.php
@@ -60,7 +60,8 @@ class DbCache_Plugin {
 		add_action( 'edit_user_profile_update', array( $this, 'on_change' ), 0 );
 
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array( $this, 'on_change' ), 0 );
+			add_action( 'wp_uninitialize_site', array( $this, 'on_change' ), 0 );
+			add_action( 'wp_update_site', array( $this, 'on_change' ), 0 );
 		}
 
 		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -75,7 +75,8 @@ class ObjectCache_Plugin {
 		add_filter( 'w3tc_usage_statistics_sources', array( $this, 'w3tc_usage_statistics_sources' ) );
 
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array( $this, 'on_change' ), 0 );
+			add_action( 'wp_uninitialize_site', array( $this, 'on_change' ), 0 );
+			add_action( 'wp_update_site', array( $this, 'on_change' ), 0 );
 			add_action( 'switch_blog', array( $this, 'switch_blog' ), 0, 2 );
 		}
 	}

--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -49,7 +49,8 @@ class Util_AttachToActions {
 
 		// multisite.
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array( $o, 'on_change' ), 0 );
+			add_action( 'wp_uninitialize_site', array( $o, 'on_change' ), 0 );
+			add_action( 'wp_update_site', array( $o, 'on_change' ), 0 );
 		}
 	}
 


### PR DESCRIPTION
WP deprecated the delete_blog hook in WP 5.1.0
Swapped for wp_uninitialize_site and wp_update_site which fire on site deletion and modification respectively.