### PR TITLE
Reverted purchase/renew links back to popup modals with iframe cart

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -2600,9 +2600,7 @@ $keys = array(
 
 	'extensions.active' => array(
 		'type' => 'array',
-		'default' => array(
-			'fragmentcache' => 'w3-total-cache/Extension_FragmentCache_Plugin.php',
-		),
+		'default' => array(),
 	),
 	'extensions.active_frontend' => array(
 		'type' => 'array',

--- a/Extension_FragmentCache_Plugin_Admin.php
+++ b/Extension_FragmentCache_Plugin_Admin.php
@@ -97,13 +97,15 @@ class Extension_FragmentCache_Plugin_Admin {
 
 
 	public function w3tc_admin_menu( $menu ) {
-		$menu['w3tc_fragmentcache'] = array(
-			'page_title' => __( 'Fragment Cache', 'w3-total-cache' ),
-			'menu_text' => '<span class="w3tc_menu_item_pro">' .
-			__( 'Fragment Cache', 'w3-total-cache' ) . '</span>',
-			'visible_always' => false,
-			'order' => 1100
-		);
+		if ( $this->_config->is_extension_active_frontend( 'fragmentcache' ) && Util_Environment::is_w3tc_pro( $this->_config ) ) {
+			$menu['w3tc_fragmentcache'] = array(
+				'page_title' => __( 'Fragment Cache', 'w3-total-cache' ),
+				'menu_text' => '<span class="w3tc_menu_item_pro">' .
+				__( 'Fragment Cache', 'w3-total-cache' ) . '</span>',
+				'visible_always' => false,
+				'order' => 1100
+			);
+		}
 
 		return $menu;
 	}

--- a/Extension_FragmentCache_Plugin_Admin.php
+++ b/Extension_FragmentCache_Plugin_Admin.php
@@ -13,6 +13,10 @@ class Extension_FragmentCache_Plugin_Admin {
 	static public function w3tc_extensions( $extensions, $config ) {
 		$requirements = array();
 
+		if ( ! Util_Environment::is_w3tc_pro( $config ) ) {
+			$requirements[] = __( 'Valid W3 Total Cache Pro license', 'w3-total-cache' );
+		}
+
 		$extensions['fragmentcache'] = array (
 			'name' => 'Fragment Cache',
 			'author' => 'W3 EDGE',
@@ -86,9 +90,11 @@ class Extension_FragmentCache_Plugin_Admin {
 
 	public function w3tc_extension_plugin_links( $links ) {
 		$links = array();
-		$links[] = '<a class="edit" href="' .
-			esc_attr( Util_Ui::admin_url( 'admin.php?page=w3tc_fragmentcache' ) ) .
-			'">'. __( 'Settings' ).'</a>';
+
+		if ( $this->_config->is_extension_active_frontend( 'fragmentcache' ) && Util_Environment::is_w3tc_pro( $this->_config ) ) {
+			$links[] = '<a class="edit" href="' . esc_attr( Util_Ui::admin_url( 'admin.php?page=w3tc_fragmentcache' ) ) . '">'
+				. __( 'Settings', 'w3-total-cache' ) . '</a>';
+		}
 
 		return $links;
 	}
@@ -99,11 +105,10 @@ class Extension_FragmentCache_Plugin_Admin {
 	public function w3tc_admin_menu( $menu ) {
 		if ( $this->_config->is_extension_active_frontend( 'fragmentcache' ) && Util_Environment::is_w3tc_pro( $this->_config ) ) {
 			$menu['w3tc_fragmentcache'] = array(
-				'page_title' => __( 'Fragment Cache', 'w3-total-cache' ),
-				'menu_text' => '<span class="w3tc_menu_item_pro">' .
-				__( 'Fragment Cache', 'w3-total-cache' ) . '</span>',
+				'page_title'     => __( 'Fragment Cache', 'w3-total-cache' ),
+				'menu_text'      => '<span class="w3tc_menu_item_pro">' . __( 'Fragment Cache', 'w3-total-cache' ) . '</span>',
 				'visible_always' => false,
-				'order' => 1100
+				'order'          => 1100,
 			);
 		}
 
@@ -115,11 +120,10 @@ class Extension_FragmentCache_Plugin_Admin {
 	public function w3tc_admin_bar_menu( $menu_items ) {
 		if ( $this->_config->is_extension_active_frontend( 'fragmentcache' ) && Util_Environment::is_w3tc_pro( $this->_config ) ) {
 			$menu_items['20510.fragmentcache'] = array(
-				'id' => 'w3tc_flush_fragmentcache',
+				'id'     => 'w3tc_flush_fragmentcache',
 				'parent' => 'w3tc_flush',
-				'title' => __( 'Fragment Cache', 'w3-total-cache' ),
-				'href' => wp_nonce_url( admin_url(
-						'admin.php?page=w3tc_dashboard&amp;w3tc_flush_fragmentcache' ), 'w3tc' )
+				'title'  => __( 'Fragment Cache', 'w3-total-cache' ),
+				'href'   => wp_nonce_url( admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_fragmentcache' ), 'w3tc' )
 			);
 		}
 

--- a/Extension_ImageService_Api.php
+++ b/Extension_ImageService_Api.php
@@ -203,7 +203,7 @@ class Extension_ImageService_Api {
 						sprintf(
 							// translators: 1: Hourly request limit, 2: HTML anchor open tag, 3: HTML anchor close tag.
 							esc_html__( ' or %1$supgrade to Pro%2$s for higher limits', 'w3-total-cache' ),
-							'<a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">',
+							'<a href="#" class="button-buy-plugin" data-src="imageservice_api_limit">',
 							'</a>'
 						)
 				);
@@ -213,7 +213,7 @@ class Extension_ImageService_Api {
 					// translators: 1: Monthly request limit, 2: HTML anchor open tag, 3: HTML anchor close tag.
 					esc_html__( 'You reached your monthly limit of %1$d; try again later or %2$supgrade to Pro%3$s for unlimited.', 'w3-total-cache' ),
 					esc_attr( $response_body['limit_monthly'] ),
-					'<a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">',
+					'<a href="#" class="button-buy-plugin" data-src="imageservice_api_limit">',
 					'</a>'
 				);
 				set_transient( 'w3tc_imageservice_limited', $result, DAY_IN_SECONDS );

--- a/Extension_Wpml_Plugin_Admin.php
+++ b/Extension_Wpml_Plugin_Admin.php
@@ -111,7 +111,7 @@ class Extension_Wpml_Plugin_Admin {
 
 		$config = Dispatcher::config();
 		if ( !Util_Environment::is_w3tc_pro( $config ) )
-			$activate_text = 'Available after <a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">' . esc_html__( 'upgrade', 'w3-total-cache' ) . '</a>. ';
+		$activate_text = 'Available after <a href="#" class="button-buy-plugin" data-src="wpml_requirements3">upgrade</a>. ';
 		else {
 			$activate_text = sprintf( '<a class="button" href="%s">Click here</a> to try it. ',
 				Util_Ui::url( array( 'w3tc_extensions_activate' => $extension_id ) ) );

--- a/FeatureShowcase_Plugin_Admin_View.php
+++ b/FeatureShowcase_Plugin_Admin_View.php
@@ -77,7 +77,11 @@ foreach ( $cards as $feature_id => $card ) {
 				<div class="w3tc-card-button">
 					<?php
 					if ( $is_premium && ! $is_pro ) {
-						echo '<button class="button w3tc-gopro-button button-buy-plugin" data-src="feature_showcase">Unlock Feature</button>';
+						?>
+						<button class="button w3tc-gopro-button button-buy-plugin" data-src="feature_showcase">
+							<?php esc_html_e( 'Unlock Feature', 'w3-total-cache' ); ?>
+						</button>
+						<?php
 					} elseif ( ! empty( $card['button'] ) ) {
 						echo $card['button'];
 					}

--- a/FeatureShowcase_Plugin_Admin_View.php
+++ b/FeatureShowcase_Plugin_Admin_View.php
@@ -75,18 +75,13 @@ foreach ( $cards as $feature_id => $card ) {
 			<div class="w3tc-card-body"><p><?php echo $card['text']; ?></p></div>
 			<div class="w3tc-card-footer">
 				<div class="w3tc-card-button">
-	<?php
-
-	if ( $is_premium && ! $is_pro ) {
-		?>
-					<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Unlock Feature', 'w3-total-cache' ); ?></a>
-			
-		<?php
-	} elseif ( ! empty( $card['button'] ) ) {
-		echo $card['button'];
-	}
-
-	?>
+					<?php
+					if ( $is_premium && ! $is_pro ) {
+						echo '<button class="button w3tc-gopro-button button-buy-plugin" data-src="feature_showcase">Unlock Feature</button>';
+					} elseif ( ! empty( $card['button'] ) ) {
+						echo $card['button'];
+					}
+					?>
 				</div><div class="w3tc-card-links"><?php echo $card['link']; ?></div>
 			</div>
 		</div>

--- a/Generic_WidgetCommunity_View.php
+++ b/Generic_WidgetCommunity_View.php
@@ -35,5 +35,6 @@ if ( !defined( 'W3TC' ) )
 </p>
 
 <p>
-	<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Learn more about Pro!', 'w3-total-cache' ); ?></a>
+	<input type="button" class="button-primary button-buy-plugin" data-src="community_widget"
+		value="<?php esc_attr_e( 'Learn more about Pro', 'w3-total-cache' ); ?>" />
 </p>

--- a/Licensing_Plugin_Admin.php
+++ b/Licensing_Plugin_Admin.php
@@ -21,6 +21,8 @@ class Licensing_Plugin_Admin {
 		add_action( 'wp_ajax_w3tc_verify_plugin_license_key', array( $this, 'action_verify_plugin_license_key' ) );
 		add_action( 'w3tc_config_ui_save-w3tc_general', array( $this, 'possible_state_change' ), 2, 10 );
 
+		add_action( 'w3tc_message_action_licensing_upgrade', array( $this, 'w3tc_message_action_licensing_upgrade' ) );
+
 		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );
 	}
 
@@ -45,9 +47,9 @@ class Licensing_Plugin_Admin {
 						),
 					)
 				),
-				'href'   => esc_url( 'https://www.boldgrid.com/w3-total-cache/' ),
-				'meta'   => array(
-					'target' => '_blank',
+				'href'   => wp_nonce_url(
+					network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_message_action=licensing_upgrade' ),
+					'w3tc'
 				),
 			);
 		}
@@ -57,10 +59,7 @@ class Licensing_Plugin_Admin {
 				'id'     => 'w3tc_debug_overlay_upgrade',
 				'parent' => 'w3tc_debug_overlays',
 				'title'  => esc_html__( 'Upgrade', 'w3-total-cache' ),
-				'href'   => esc_url( 'https://www.boldgrid.com/w3-total-cache/' ),
-				'meta'   => array(
-					'target' => '_blank',
-				),
+				'href'   => wp_nonce_url( network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_message_action=licensing_upgrade' ), 'w3tc' ),
 			);
 		}
 
@@ -164,21 +163,25 @@ class Licensing_Plugin_Admin {
 		if ( defined( 'W3TC_PRO' ) ) {
 		} elseif ( 'no_key' === $status ) {
 		} elseif ( $this->_status_is( $status, 'inactive.expired' ) ) {
-			$ga_client_id = preg_replace( '/^.+\.(.+?\..+?)$/', '$1', $_COOKIE['_ga'] );
-			$message      = wp_kses(
+			$message = wp_kses(
 				sprintf(
 					// translators: 1 HTML input button for renewing license.
 					__(
 						'It looks like your W3 Total Cache Pro license has expired. %1$s to continue using the Pro features',
 						'w3-total-cache'
 					),
-					'<a class="button" href="' . esc_url( \W3TC\Licensing_Core::purchase_url( 'licensing_expired', $this->get_license_key(), $ga_client_id) ) . '" target="_blank">' . esc_html__( 'Renew Now', 'w3-total-cache' ) . '</a>'
+					'<input type="button" class="button button-buy-plugin" data-nonce="' .
+						wp_create_nonce( 'w3tc' ) . '" data-renew-key="' . esc_attr( $this->get_license_key() ) .
+						'" data-src="licensing_expired" value="' . __( 'Renew Now', 'w3-total-cache' ) . '" />'
 				),
 				array(
-					'a' => array(
-						'class'  => array(),
-						'href'   => array(),
-						'target' => array(),
+					'input' => array(
+						'type'           => array(),
+						'class'          => array(),
+						'data-nonce'     => array(),
+						'data-renew-key' => array(),
+						'data-src'       => array(),
+						'value'          => array(),
 					),
 				)
 			);

--- a/Licensing_Plugin_Admin.php
+++ b/Licensing_Plugin_Admin.php
@@ -47,10 +47,7 @@ class Licensing_Plugin_Admin {
 						),
 					)
 				),
-				'href'   => wp_nonce_url(
-					network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_message_action=licensing_upgrade' ),
-					'w3tc'
-				),
+				'href'   => wp_nonce_url( network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_message_action=licensing_upgrade' ), 'w3tc' ),
 			);
 		}
 

--- a/UsageStatistics_Page_View_Free.php
+++ b/UsageStatistics_Page_View_Free.php
@@ -12,7 +12,9 @@ require W3TC_INC_DIR . '/options/common/header.php';
 
 	<div class="ustats_ad">
 		<?php require __DIR__ . '/UsageStatistics_Page_View_Ad.php'; ?>
-		<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Upgrade', 'w3-total-cache' ); ?></a>	
+		<input type="button" class="button-primary button-buy-plugin"
+			data-src="page_stats_bottom"
+			value="<?php esc_attr_e( 'upgrade', 'w3-total-cache' ); ?>" />
 	</div>
 
 	<?php Util_Ui::postbox_footer(); ?>

--- a/UsageStatistics_Widget_View_Disabled.php
+++ b/UsageStatistics_Widget_View_Disabled.php
@@ -29,7 +29,8 @@ if ( ! defined( 'W3TC' ) ) {
 </style>
 <p class="w3tcuw_inactive">
 	<?php if ( ! Util_Environment::is_w3tc_pro( Dispatcher::config() ) ) : ?>
-		<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Upgrade to Pro', 'w3-total-cache' ); ?></a>
+		<input type="button" class="button-primary button-buy-plugin {nonce: '<?php echo esc_attr( wp_create_nonce( 'w3tc' ) ); ?>'}"
+			data-src="usagestatistics_widget" value="<?php esc_html_e( 'Upgrade to Pro', 'w3-total-cache' ); ?>" />
 	<?php else : ?>
 		<a href="admin.php?page=w3tc_general#stats" class="button-primary">Enable</a>
 	<?php endif ?>

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1298,7 +1298,9 @@ class Util_Ui {
 		?>
 			</div>
 			<div class="w3tc-gopro-action">
-				<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Learn more about Pro!', 'w3-total-cache' ); ?></a>
+				<button class="button w3tc-gopro-button button-buy-plugin" data-src="<?php echo esc_attr( $button_data_src ); ?>">
+					Learn more about Pro
+				</button>
 			</div>
 		</div>
 		<?php
@@ -1323,7 +1325,9 @@ class Util_Ui {
 		?>
 			</p>
 			<div style="text-align: right">
-				<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Unlock Feature', 'w3-total-cache' ); ?></a>
+				<button class="button w3tc-gopro-button button-buy-plugin" data-src="<?php echo esc_attr( $button_data_src ); ?>">
+					Unlock Feature
+				</button>
 			</div>
 		</div>
 		<?php

--- a/inc/options/common/footer.php
+++ b/inc/options/common/footer.php
@@ -87,7 +87,8 @@ do_action( 'w3tc-dashboard-footer' );
 			</div>
 			<?php
 			if ( ! Util_Environment::is_w3tc_pro( $config ) ) {
-				echo '<a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">' . esc_html__( 'Learn more about Pro!', 'w3-total-cache' ) . '</a>';
+				echo '<input type="button" class="button button-buy-plugin {nonce: \'' . esc_attr( wp_create_nonce( 'w3tc' ) ) . '\'}"
+					data-src="footer" value="' . esc_html__( 'Learn more about Pro!', 'w3-total-cache' ) . '" />';
 			}
 			?>
 		</div>

--- a/inc/options/common/top_nav_bar.php
+++ b/inc/options/common/top_nav_bar.php
@@ -203,7 +203,8 @@ do_action( 'w3tc_dashboard_top_nav_bar' );
 			</a>
 			<?php
 			if ( ! Util_Environment::is_w3tc_pro( $config ) ) {
-				echo '<a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">' . esc_html__( 'Upgrade', 'w3-total-cache' ) . '</a>';
+				echo '<input type="button" class="button-primary button-buy-plugin {nonce: \'' . esc_attr( wp_create_nonce( 'w3tc' ) ) . '\'}"
+					data-src="top_nav_bar" value="' . esc_html__( 'Upgrade', 'w3-total-cache' ) . '" />';
 			}
 			?>
 		</div>

--- a/inc/options/edd/buy.php
+++ b/inc/options/edd/buy.php
@@ -21,13 +21,14 @@ if ( ! defined( 'W3TC' ) ) {
 				'Unlock more speed, %1$s now!',
 				'w3-total-cache'
 			),
-			'<a class="button w3tc-gopro-button" href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">' . esc_html__( 'Upgrade', 'w3-total-cache' ) . '</a>'
+			'<input type="button" class="button-primary button-buy-plugin" data-src="' . esc_attr( 'page_' . $page ) . '" value="' . esc_attr( __( 'upgrade', 'w3-total-cache' ) ) . '" />'
 		),
 		array(
-			'a' => array(
-				'class'  => array(),
-				'href'   => array(),
-				'target' => array(),
+			'input' => array(
+				'type'     => array(),
+				'class'    => array(),
+				'data-src' => array(),
+				'value'    => array(),
 			),
 		)
 	);

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -705,7 +705,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 											'Please enter the license key provided after %1$s.',
 											'w3-total-cache'
 										),
-										'<a href="' . esc_url( 'https://www.boldgrid.com/w3-total-cache/' ) . '" target="_blank">' . esc_html__( 'upgrading', 'w3-total-cache' ) . '</a>'
+										'<a class="button-buy-plugin" data-src="generic_license" href="#">' . esc_html__( 'upgrading', 'w3-total-cache' ) . '</a>'
 									),
 									array(
 										'a' => array(

--- a/inc/options/parts/dashboard_banner.php
+++ b/inc/options/parts/dashboard_banner.php
@@ -53,7 +53,8 @@ if ( ! defined( 'W3TC' ) ) {
 				?>
 			</p>
 			<p>
-				<a class="button w3tc-gopro-button" href="<?php echo esc_url( 'https://www.boldgrid.com/w3-total-cache/' ); ?>" target="_blank"><?php esc_html_e( 'Learn more about Pro!', 'w3-total-cache' ); ?></a>
+				<input type="button" class="button w3tc-gopro-button button-buy-plugin"	data-src="dashboard_banner"
+					value="<?php esc_attr_e( 'Learn more about Pro', 'w3-total-cache' ); ?>" />
 			</p>
 		</div>
 	</div>

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -1093,6 +1093,7 @@ td .w3tc-control-after span {
 	margin-left: 4px;
 }
 
+#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links input.button-buy-plugin,
 #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links a.w3tc-gopro-button {
 	border-color: darkgreen;
 	box-shadow: 0 1px 0 darkgreen;
@@ -1101,6 +1102,8 @@ td .w3tc-control-after span {
 	box-shadow: unset;
 }
 
+#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links input.button-buy-plugin:hover,
+#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links input.button-buy-plugin:focus,
 #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links a.w3tc-gopro-button:hover,
 #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links a.w3tc-gopro-button:focus {
 	border-color: green;
@@ -1156,12 +1159,17 @@ td .w3tc-control-after span {
 	text-decoration: none;
 	margin-right: 5px;
 }
-
+#w3tc-footer .button-buy-plugin,
 #w3tc-footer .w3tc-gopro-button {
 	margin-top: 10px;
 	white-space: normal;
 	float: left;
 	clear: both;
+	border-color: darkgreen;
+	box-shadow: 0 1px 0 darkgreen;
+	background: green;
+	color: #fff;
+	box-shadow: unset;
 }
 
 #w3tc-footer .w3tc-footer-column-1 {


### PR DESCRIPTION
This PR reverts all changes made to the purchase/renew buttons to restore the popup modals and iframe embeds of the cart. This allows for users to stay on-site and to automatically apply licenses on purchase