### PR TITLE
Fix php 8.2 deprecation

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -104,15 +104,28 @@ class PgCache_ContentGrabber {
 	private $output_size = 0;
 
 	/**
-	 *
-	 *
 	 * @var bool If cached page should be displayed after init
 	 */
 	var $_late_init = false;
 
+	/**
+	 * @var bool late caching
+	 */
+	var $_late_caching = false;
+
 	var $_cached_data = null;
 
 	var $_old_exists = false;
+
+	/**
+	 * @var bool Nginx memcached flag
+	 */
+	var $_nginx_memcached = false;
+
+	/**
+	 * @var string
+	 */
+	var $_page_group;
 
 	/**
 	 * PHP5 Constructor


### PR DESCRIPTION
Fix php 8.2 creation of dynamic properties.
Please check the variable type for `$_page_group` as it was a string in my case, but it could be more vast.