### PR TITLE
Fixed issue with auto-apply failing after puchase of license

### DIFF
--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -48,7 +48,7 @@ class Generic_AdminActions_Default {
 	 *
 	 * @return void
 	 */
-	function w3tc_default_save_licence_key() {
+	function w3tc_default_save_license_key() {
 		$license = Util_Request::get_string( 'license_key' );
 		try {
 			$old_config = new Config();

--- a/pub/js/lightbox.js
+++ b/pub/js/lightbox.js
@@ -481,7 +481,7 @@ function w3tc_lightbox_save_license_key(license_key, nonce, callback) {
   var params = {
 	w3tc_default_save_license_key: 1,
 	license_key: license_key,
-	_wpnonce: ('array' == jQuery.type(nonce)) ? nonce[0] : nonce
+	_wpnonce: ('array' === jQuery.type(nonce)) ? nonce[0] : nonce
   };
 
   jQuery.post('admin.php?page=w3tc_dashboard', params, function(data) {

--- a/pub/js/lightbox.js
+++ b/pub/js/lightbox.js
@@ -444,7 +444,7 @@ function w3tc_lightbox_buy_plugin(nonce, data_src, renew_key, client_id) {
 				var data = event.data.split(' ');
 				if (data[0] === 'license') {
 					// legacy purchase
-					w3tc_lightbox_save_licence_key(function() {
+					w3tc_lightbox_save_license_key(function() {
 						lightbox.close();
 					});
 				} else if (data[0] === 'v2_license') {
@@ -457,7 +457,7 @@ function w3tc_lightbox_buy_plugin(nonce, data_src, renew_key, client_id) {
 						window.location = window.location + '&refresh';
 					}
 
-					w3tc_lightbox_save_licence_key(data[1], nonce, function() {
+					w3tc_lightbox_save_license_key(data[1], nonce, function() {
 						jQuery('#buy_frame').attr('src', data[3]);
 					});
 				}
@@ -476,12 +476,12 @@ function w3tc_lightbox_buy_plugin(nonce, data_src, renew_key, client_id) {
 	});
 }
 
-function w3tc_lightbox_save_licence_key(license_key, nonce, callback) {
+function w3tc_lightbox_save_license_key(license_key, nonce, callback) {
   jQuery('#plugin_license_key').val(license_key);
   var params = {
-	w3tc_default_save_licence_key: 1,
+	w3tc_default_save_license_key: 1,
 	license_key: license_key,
-	_wpnonce: nonce
+	_wpnonce: ('array' == jQuery.type(nonce)) ? nonce[0] : nonce
   };
 
   jQuery.post('admin.php?page=w3tc_dashboard', params, function(data) {


### PR DESCRIPTION
The issue was due to the nonce value being of type array which caused the "save license" AJAX request to fail the nonce verification with a 403. This PR adds a check to ensure the nonce is a string before the AJAX request is made