### PR TITLE
Update analytics

### DIFF
--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -574,7 +574,7 @@ class Extension_ImageService_Plugin_Admin {
 					),
 					'tos_choice'  => Licensing_Core::get_tos_choice(),
 					'track_usage' => $this->config->get_boolean( 'common.track_usage' ),
-					'ga_profile'  => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'UA-2264433-7' : 'UA-2264433-8',
+					'ga_profile'  => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'G-Q3CHQJWERM' : 'G-5TFS8M5TTY',
 					'settings'    => $this->config->get_array( 'imageservice' ),
 					'settingsUrl' => esc_url( Util_Ui::admin_url( 'upload.php?page=w3tc_extension_page_imageservice' ) ),
 				)

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -480,6 +480,8 @@ class Generic_Plugin_Admin {
 			);
 			?>
 			<script type="application/javascript">
+				var w3tc_ga_cid;
+
 				window.dataLayer = window.dataLayer || [];
 
 				function w3tc_ga(){dataLayer.push(arguments);}
@@ -500,6 +502,13 @@ class Generic_Plugin_Admin {
 						'w3tc_widgets': '<?php echo esc_attr( Util_Widget::list_widgets() ); ?>',
 						'page': '<?php echo esc_attr( $page ); ?>'
 					}
+				});
+
+				const cidPromise = new Promise(resolve => {
+					w3tc_ga('get', '<?php echo esc_attr( $profile ); ?>', 'client_id', resolve);
+				});
+				cidPromise.then((cid) => {
+					w3tc_ga_cid = cid;
 				});
 			</script>
 			<?php
@@ -856,11 +865,9 @@ class Generic_Plugin_Admin {
 				}
 				$line = preg_replace( '~^\s*\*\s*~', '', htmlspecialchars( $line ) );
 				echo '<li style="width: 50%; margin: 0; float: left; ' . ( 0 === $index % 2 ? 'clear: left;' : '' ) . '">' . esc_html( $line ) . '</li>';
-			} else {
-				if ( $ul ) {
-					echo '</ul><div style="clear: left;"></div>';
-					$ul = false;
-				}
+			} elseif ( $ul ) {
+				echo '</ul><div style="clear: left;"></div>';
+				$ul = false;
 			}
 		}
 

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -464,39 +464,43 @@ class Generic_Plugin_Admin {
 			}
 
 			if ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) {
-				$profile = 'UA-2264433-7';
+				$profile = 'G-Q3CHQJWERM';
 			} else {
-				$profile = 'UA-2264433-8';
+				$profile = 'G-5TFS8M5TTY';
 			}
 
 			$state = Dispatcher::config_state();
 
+			wp_enqueue_script(
+				'w3tc_ga',
+				'https://www.googletagmanager.com/gtag/js?id=' . esc_attr( $profile ),
+				array(),
+				W3TC_VERSION,
+				true
+			);
 			?>
-			<script type="text/javascript">
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,'script','https://api.w3-edge.com/v1/analytics','w3tc_ga');
+			<script type="application/javascript">
+				window.dataLayer = window.dataLayer || [];
 
-				if (window.w3tc_ga) {
-					w3tc_ga('create', '<?php echo esc_html( $profile ); ?>', 'auto');
-					w3tc_ga('set', {
-						'dimension1': 'w3-total-cache',
-						'dimension2': '<?php echo esc_html( W3TC_VERSION ); ?>',
-						'dimension3': '<?php echo esc_html( $wp_version ); ?>',
-						'dimension4': 'php<?php echo esc_html( phpversion() ); ?>',
-						'dimension5': '<?php echo esc_attr( isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '' ); ?>',
-						'dimension6': 'mysql<?php echo esc_attr( $wpdb->db_version() ); ?>',
-						'dimension7': '<?php echo esc_url( Util_Environment::home_url_host() ); ?>',
-						'dimension9': '<?php echo esc_attr( $state->get_string( 'common.install_version' ) ); ?>',
-						'dimension10': '<?php echo esc_attr( Util_Environment::w3tc_edition( $this->_config ) ); ?>',
-						'dimension11': '<?php echo esc_attr( Util_Widget::list_widgets() ); ?>',
+				function w3tc_ga(){dataLayer.push(arguments);}
 
+				w3tc_ga('js', new Date());
+
+				w3tc_ga('config', '<?php echo esc_attr( $profile ); ?>', {
+					'user_properties': {
+						'plugin': 'w3-total-cache',
+						'w3tc_version': '<?php echo esc_html( W3TC_VERSION ); ?>',
+						'wp_version': '<?php echo esc_html( $wp_version ); ?>',
+						'php_version': 'php<?php echo esc_html( phpversion() ); ?>',
+						'server_software': '<?php echo esc_attr( isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '' ); ?>',
+						'wpdb_version': 'mysql<?php echo esc_attr( $wpdb->db_version() ); ?>',
+						'home_url': '<?php echo esc_url( Util_Environment::home_url_host() ); ?>',
+						'w3tc_install_version': '<?php echo esc_attr( $state->get_string( 'common.install_version' ) ); ?>',
+						'w3tc_edition': '<?php echo esc_attr( Util_Environment::w3tc_edition( $this->_config ) ); ?>',
+						'w3tc_widgets': '<?php echo esc_attr( Util_Widget::list_widgets() ); ?>',
 						'page': '<?php echo esc_attr( $page ); ?>'
-					});
-
-					w3tc_ga('send', 'pageview');
-				}
+					}
+				});
 			</script>
 			<?php
 		}

--- a/PageSpeed_Page_View.js
+++ b/PageSpeed_Page_View.js
@@ -69,14 +69,11 @@ jQuery(document).ready(function ($) {
 	function w3tcps_breakdown_items_toggle() {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
 				'event',
+				'metric',
 				{
 					eventCategory: 'w3tc_pagespeed',
-					eventAction: 'metric',
-					eventLabel: $(this).attr('gatitle'),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: $(this).attr('gatitle')
 				}
 			);
 		}
@@ -95,14 +92,11 @@ jQuery(document).ready(function ($) {
 	function w3tcps_mobile_toggle() {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
 				'event',
+				'mobile_tab',
 				{
 					eventCategory: 'w3tc_pagespeed',
-					eventAction: 'mobile_tab',
-					eventLabel: $('#w3tcps_control_mobile').text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: $('#w3tcps_control_mobile').text()
 				}
 			);
 		}
@@ -123,14 +117,11 @@ jQuery(document).ready(function ($) {
 	function w3tcps_desktop_toggle() {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
 				'event',
+				'desktop_tab',
 				{
 					eventCategory: 'w3tc_pagespeed',
-					eventAction: 'desktop_tab',
-					eventLabel: $('#w3tcps_control_desktop').text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: $('#w3tcps_control_desktop').text()
 				}
 			);
 		}
@@ -153,14 +144,11 @@ jQuery(document).ready(function ($) {
 
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
 				'event',
+				'filter_tab',
 				{
 					eventCategory: 'w3tc_pagespeed',
-					eventAction: 'filter_tab',
-					eventLabel: $(this).text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: $(this).text()
 				}
 			);
 		}
@@ -247,14 +235,11 @@ jQuery(document).ready(function ($) {
 	$('.w3tcps_content').on('click', '.w3tcps_analyze', function () {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
 				'event',
+				're_analyze',
 				{
 					eventCategory: 'w3tc_pagespeed',
-					eventAction: 're_analyze',
-					eventLabel: $(this).closest('.page_post').find('.w3tcps_buttons').attr('page_post_url'),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: $(this).closest('.page_post').find('.w3tcps_buttons').attr('page_post_url')
 				}
 			);
 		}

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -950,7 +950,7 @@ class SetupGuide_Plugin_Admin {
 							'install_version'   => esc_attr( $state->get_string( 'common.install_version' ) ),
 							'w3tc_edition'      => esc_attr( Util_Environment::w3tc_edition( $config ) ),
 							'list_widgets'      => esc_attr( Util_Widget::list_widgets() ),
-							'ga_profile'        => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'UA-2264433-7' : 'UA-2264433-8',
+							'ga_profile'        => ( defined( 'W3TC_DEVELOPER' ) && W3TC_DEVELOPER ) ? 'G-Q3CHQJWERM' : 'G-5TFS8M5TTY',
 							'tos_choice'        => Licensing_Core::get_tos_choice(),
 							'track_usage'       => $config->get_boolean( 'common.track_usage' ),
 							'test_complete_msg' => __(

--- a/pub/js/lightbox.js
+++ b/pub/js/lightbox.js
@@ -390,9 +390,7 @@ function w3tc_lightbox_self_test(nonce) {
 function w3tc_lightbox_upgrade(nonce, data_src, renew_key) {
 	var client_id = '';
 	if (window.w3tc_ga) {
-		w3tc_ga(function(tracker) {
-			client_id = tracker.get('clientId');
-		});
+		client_id = w3tc_ga_cid;
 	}
 
   	W3tc_Lightbox.open({
@@ -417,9 +415,11 @@ function w3tc_lightbox_upgrade(nonce, data_src, renew_key) {
 		jQuery('#w3tc-purchase-link', lightbox.container).on( 'click', function() {
 			lightbox.close();
 
-			jQuery([document.documentElement, document.body]).animate({
-				scrollTop: jQuery("#licensing").offset().top
-			}, 2000);
+			if ( jQuery('#licensing').length ) {
+				jQuery([document.documentElement, document.body]).animate({
+					scrollTop: jQuery('#licensing').offset().top
+				}, 2000);
+			}
 		});
 
 		// Allow for customizations of the "upgrade" overlay specifically.

--- a/pub/js/lightbox.js
+++ b/pub/js/lightbox.js
@@ -60,16 +60,21 @@ var W3tc_Lightbox = {
 		} else if (this.options.url) {
 			this.load(this.options.url, this.options.callback);
 
-			if (typeof ga != 'undefined') {
+			if (window.w3tc_ga) {
 				var w3tc_action = this.options.url.match(/w3tc_action=([^&]+)/);
-				if (window.w3tc_ga) {
-					if (w3tc_action && w3tc_action[1])
-						w3tc_ga('send', 'pageview', 'overlays/' + w3tc_action[1]);
-					else {
-						var w3tc_action = this.options.url.match(/&(w3tc_[^&]+)&/);
-						if (w3tc_action && w3tc_action[1])
-							w3tc_ga('send', 'pageview', 'overlays/' + w3tc_action[1]);
-					}
+
+				if (! w3tc_action || ! w3tc_action[1]) {
+					w3tc_action = this.options.url.match(/&(w3tc_[^&]+)&/);
+				}
+
+				if (w3tc_action && w3tc_action[1]) {
+					w3tc_ga(
+						'event',
+						'pageview',
+						{
+							eventLabel: 'overlays/' + w3tc_action[1]
+						}
+					);
 				}
 			}
 		}

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -1346,8 +1346,14 @@ jQuery(function() {
 		}
 
 		if (window.w3tc_ga) {
-			w3tc_ga('send', 'event', 'anchor', 'click',
-				jQuery(this).data('href'));
+			w3tc_ga(
+				'event',
+				'anchor',
+				{
+					eventCategory: 'click',
+					eventLabel: jQuery(this).data('href')
+				}
+			);
 		}
 	});
 
@@ -1369,13 +1375,11 @@ jQuery(function() {
 	jQuery('#w3tc-top-nav-bar a').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_topnav_bar',
 					eventAction: 'link',
-					eventLabel: jQuery(this).text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).text()
 				}
 			);
 		}
@@ -1385,13 +1389,11 @@ jQuery(function() {
 	jQuery('#w3tc-options-menu a').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_options_menu',
 					eventAction: 'anchor',
-					eventLabel: jQuery(this).text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).text()
 				}
 			);
 		}
@@ -1401,13 +1403,11 @@ jQuery(function() {
 	jQuery('.w3tc_form_bar input').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_form_bar',
 					eventAction: 'button',
-					eventLabel: jQuery(this).text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).text()
 				}
 			);
 		}
@@ -1417,13 +1417,11 @@ jQuery(function() {
 	jQuery('#w3tc-footer a').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_footer',
 					eventAction: 'link',
-					eventLabel: jQuery(this).text(),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).text()
 				}
 			);
 		}
@@ -1433,13 +1431,11 @@ jQuery(function() {
 	jQuery('.advanced-settings a').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_general_advanced_tab',
 					eventAction: 'link',
-					eventLabel: jQuery(this).attr('gatitle'),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).attr('gatitle')
 				}
 			);
 		}
@@ -1449,43 +1445,73 @@ jQuery(function() {
 	jQuery('.extra-link a').on('click', function(e) {
 		if (window.w3tc_ga) {
 			w3tc_ga(
-				'send',
-				'event', {
+				'event',
+				{
 					eventCategory: 'w3tc_general_extra_link_tab',
 					eventAction: 'link',
-					eventLabel: jQuery(this).attr('gatitle'),
-					eventValue: 0,
-					transport: 'beacon'
+					eventLabel: jQuery(this).attr('gatitle')
 				}
 			);
 		}
 	});
 
-	// google analytics events
+	// Analytics events.
 	if (typeof w3tc_ga != 'undefined') {
 		jQuery('.w3tc_error').each(function() {
 			var id = jQuery(this).attr('id');
 			var text = jQuery(this).text();
-			if (id && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'w3tc_error', id, text);
+			if (id && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'w3tc_error',
+					{
+						eventCategory: id,
+						eventLabel: text
+					}
+				);
+			}
 		});
 		jQuery('.w3tc_note').each(function() {
 			var id = jQuery(this).attr('id');
 			var text = jQuery(this).text();
-			if (id && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'w3tc_note', id, text);
+			if (id && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'w3tc_note',
+					{
+						eventCategory: id,
+						eventLabel: text
+					}
+				);
+			}
 		});
 
 		jQuery('body').on('click', 'a', function() {
 			var url = jQuery(this).attr('href');
-			if (url && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'anchor', 'click', url, { useBeacon: true });
+			if (url && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'anchor',
+					{
+						eventCategory: 'click',
+						eventLabel: url
+					}
+				);
+			}
 		});
 
 		jQuery('body').on('click', 'input[type="button"]', function() {
 			var name = jQuery(this).attr('name');
-			if (name && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'button', 'click', name, { useBeacon: true });
+			if (name && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'button',
+					{
+						eventCategory: 'click',
+						eventLabel: name
+					}
+				);
+			}
 		});
 		jQuery('body').on('click', 'input[type="submit"]', function() {
 			var name = jQuery(this).attr('name');
@@ -1493,24 +1519,48 @@ jQuery(function() {
 			if (!id)
 				id = name;
 
-			if (name && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'button', id, name, { useBeacon: true });
+			if (name && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'button',
+					{
+						eventCategory: id,
+						eventLabel: name
+					}
+				);
+			}
 		});
 
 		jQuery('body').on('click', 'input[type="checkbox"]', function() {
 			var name = jQuery(this).attr('name');
 			var action = jQuery(this).is(':checked') ? 'check' : 'uncheck';
 
-			if (name && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'checkbox', action, name);
+			if (name && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'checkbox',
+					{
+						eventCategory: action,
+						eventLabel: name
+					}
+				);
+			}
 		});
 
 		jQuery('body').on('change', 'select', function() {
 			var name = jQuery(this).attr('name');
 			var value = jQuery(this).val();
 
-			if (name && value && window.w3tc_ga)
-				w3tc_ga('send', 'event', 'select', value, name);
+			if (name && value && window.w3tc_ga) {
+				w3tc_ga(
+					'event',
+					'select',
+					{
+						eventCategory: value,
+						eventLabel: name
+					}
+				);
+			}
 		});
 	}
 

--- a/pub/js/setup-guide.js
+++ b/pub/js/setup-guide.js
@@ -17,8 +17,14 @@ jQuery(function() {
 
 	// GA.
 	if ( w3tc_enable_ga ) {
-		w3tc_ga( 'create', W3TC_SetupGuide.ga_profile, 'auto' );
-		w3tc_ga( 'send', 'event', 'button', 'w3tc_setup_guide', 'w3tc-wizard-step-welcome' );
+		w3tc_ga(
+			'event',
+			'button',
+			{
+				eventCategory: 'w3tc_setup_guide',
+				eventLabel: 'w3tc-wizard-step-welcome'
+			}
+		);
 	}
 
 	// Handle the terms of service notice.
@@ -54,28 +60,36 @@ jQuery(function() {
 			if ( 'accept' === choice ) {
 				W3TC_SetupGuide.tos_choice = choice;
 
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-					(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-					m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-					})(window,document,'script','https://api.w3-edge.com/v1/analytics','w3tc_ga');
+				var gaScript = document.createElement( 'script' );
+				gaScript.type = 'text/javascript';
+				gaScript.setAttribute( 'async', 'true' );
+				gaScript.setAttribute( 'src', 'https://www.googletagmanager.com/gtag/js?id=' + W3TC_SetupGuide.ga_profile );
+				document.documentElement.firstChild.appendChild( gaScript );
+
+				window.dataLayer = window.dataLayer || [];
+
+				const w3tc_ga = function() { dataLayer.push( arguments ); }
 
 				if (window.w3tc_ga) {
-					w3tc_ga( 'create', W3TC_SetupGuide.ga_profile, 'auto' );
-					w3tc_ga( 'set', {
-						'dimension1': 'w3-total-cache',
-						'dimension2': W3TC_SetupGuide.w3tc_version,
-						'dimension3': W3TC_SetupGuide.wp_version,
-						'dimension4': W3TC_SetupGuide.php_version,
-						'dimension5': W3TC_SetupGuide.server_software,
-						'dimension6': W3TC_SetupGuide.db_version,
-						'dimension7': W3TC_SetupGuide.home_url_host,
-						'dimension9': W3TC_SetupGuide.install_version,
-						'dimension10': W3TC_SetupGuide.w3tc_edition,
-						'dimension11': W3TC_SetupGuide.list_widgets,
-						'page': W3TC_SetupGuide.page
-					});
+					w3tc_enable_ga = true;
 
-					w3tc_ga( 'send', 'pageview' );
+					w3tc_ga( 'js', new Date() );
+
+					w3tc_ga( 'config', W3TC_SetupGuide.ga_profile, {
+						'user_properties': {
+							'plugin': 'w3-total-cache',
+							'w3tc_version': W3TC_SetupGuide.w3tc_version,
+							'wp_version': W3TC_SetupGuide.wp_version,
+							'php_version': W3TC_SetupGuide.php_version,
+							'server_software': W3TC_SetupGuide.server_software,
+							'wpdb_version': W3TC_SetupGuide.db_version,
+							'home_url': W3TC_SetupGuide.home_url_host,
+							'w3tc_install_version': W3TC_SetupGuide.install_version,
+							'w3tc_edition': W3TC_SetupGuide.w3tc_edition,
+							'w3tc_widgets': W3TC_SetupGuide.list_widgets,
+							'page': W3TC_SetupGuide.page
+						}
+					});
 				}
 			}
 		});
@@ -449,7 +463,14 @@ function w3tc_wizard_actions( $slide ) {
 
 	// GA.
 	if ( w3tc_enable_ga ) {
-		w3tc_ga( 'send', 'event', 'button', 'w3tc_setup_guide', slideId );
+		w3tc_ga(
+			'event',
+			'button',
+			{
+				eventCategory: 'w3tc_setup_guide',
+				eventLabel: slideId
+			}
+		);
 	}
 
 	switch ( slideId ) {

--- a/pub/js/wizard.js
+++ b/pub/js/wizard.js
@@ -52,7 +52,14 @@
 
 		// GA.
 		if ( window.w3tc_ga ) {
-			w3tc_ga( 'send', 'event', 'button', page, 'skip' );
+			w3tc_ga(
+				'event',
+				'button',
+				{
+					eventCategory: page,
+					eventLabel: 'skip'
+				}
+			);
 		}
 
 		jQuery.ajax({


### PR DESCRIPTION
Test with `define( 'W3TC_DEVELOPER', true );` added to `wp-config.php`.  You can also use the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) for Chrome to see the commands sent in the web console.

Remove the WP Option "w3tc_state" and set the config setting "common.track_usage" to `false` in "wp-content/w3tc-config/master.php".  Also, remove any license key.

Test the Setup Guide wizard, settings pages, and PageSpeed.  Review all of the analytics sent to ensure it aligns with the data sent previously wit the old code.
