### PR TITLE
Fix AWS for release 2.4.0

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -270,7 +270,13 @@ class Cache_File_Generic extends Cache_File {
 			}
 		}
 
-		@touch( $old_entry_path, 1479904835 );
+		/**
+		 * Disabling this as we don't want to immediately hard-expire _old cache files as there is a
+		 * 30 second window where they are still served via get_with_old calls. During AWS testing on
+		 * WP 5.9/6.3 this was resulting in the _old file immediately being removed during the clean
+		 * operation, resulting in failed automated tests
+		 */
+		//@touch( $old_entry_path, 1479904835 );
 		return true;
 	}
 

--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -274,9 +274,9 @@ class Cache_File_Generic extends Cache_File {
 		 * Disabling this as we don't want to immediately hard-expire _old cache files as there is a
 		 * 30 second window where they are still served via get_with_old calls. During AWS testing on
 		 * WP 5.9/6.3 this was resulting in the _old file immediately being removed during the clean
-		 * operation, resulting in failed automated tests
+		 * operation, resulting in failed automated tests (8/1/2023)
 		 */
-		//@touch( $old_entry_path, 1479904835 );
+		// @touch( $old_entry_path, 1479904835 );
 		return true;
 	}
 

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -2636,6 +2636,12 @@ $keys = array(
 		'type' => 'boolean',
 		'default' => true,
 	),
+	'fragmentcache' => array(
+		'type'    => 'array',
+		'default' => array(
+			'engine' => 'file',
+		),
+	),
 
 	// extensions keys:
 	//

--- a/Extension_FragmentCache_Plugin_Admin.php
+++ b/Extension_FragmentCache_Plugin_Admin.php
@@ -34,8 +34,7 @@ class Extension_FragmentCache_Plugin_Admin {
 			'version' => '1.0',
 			'enabled' => empty( $requirements ),
 			'requirements' => implode( ', ', $requirements ),
-			'active_frontend_own_control' => true,
-			'path' => 'w3-total-cache/Extension_FragmentCache_Plugin.php'
+			'path' => 'w3-total-cache/Extension_FragmentCache_Plugin.php',
 		);
 
 		return $extensions;
@@ -140,14 +139,7 @@ class Extension_FragmentCache_Plugin_Admin {
 
 
 	public function w3tc_config_save( $config ) {
-		// frontend activity
-		$engine = $config->get_string( array( 'fragmentcache', 'engine' ) );
-
-		$is_frontend_active = ( !empty( $engine ) &&
-			Util_Environment::is_w3tc_pro( $config ) );
-
-		$config->set_extension_active_frontend( 'fragmentcache',
-			$is_frontend_active );
+		$config->set_extension_active_frontend( 'fragmentcache', Util_Environment::is_w3tc_pro( $config ) );
 	}
 
 

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -336,7 +336,7 @@ class Util_Ui {
 
 		?>
 		<div class="btn-group w3tc-button-flush-dropdown">
-			<input type="submit" class="btn btn-light btn-sm" name="w3tc_flush_all" value="<?php esc_html_e( 'Empty All Caches', 'w3-total-cache' ); ?>"/>
+			<input id="flush_all" type="submit" class="btn btn-light btn-sm" name="w3tc_flush_all" value="<?php esc_html_e( 'Empty All Caches', 'w3-total-cache' ); ?>"/>
 			<button type="button" class="btn btn-light btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 				<span class="sr-only">Toggle Dropdown</span>
 			</button>

--- a/inc/options/common/top_nav_bar.php
+++ b/inc/options/common/top_nav_bar.php
@@ -90,7 +90,7 @@ $menu_array = array(
 		array(
 			'url'   => '#',
 			'text'  => __( 'Compatibility Test', 'w3-total-cache' ),
-			'class' => 'button-self-test',
+			'class' => 'compatiblity-test button-self-test',
 		),
 		array(
 			'url'      => 'https://api.w3-edge.com/v1/redirects/faq',

--- a/qa/env/100-generate-envs
+++ b/qa/env/100-generate-envs
@@ -179,14 +179,20 @@ def generate_box_descriptors(image_name)
 		#		'litespeed'
 		#	]
 		#},
-		'wp61' => {
-			'WP_VERSION' => '6.1',
+		#'wp61' => {
+		#	'WP_VERSION' => '6.1',
+		#	'_except_name_contains' => [
+		#		'litespeed'
+		#	]
+		#},
+		'wp62' => {
+			'WP_VERSION' => '6.2',
 			'_except_name_contains' => [
 				'litespeed'
 			]
 		},
-		'wp62' => {
-			'WP_VERSION' => '6.2',
+		'wp63' => {
+			'WP_VERSION' => '6.3-RC3',
 			'_except_name_contains' => [
 				'litespeed'
 			]

--- a/qa/env/scripts/init-image/150-mocha.sh
+++ b/qa/env/scripts/init-image/150-mocha.sh
@@ -17,5 +17,5 @@ case "${W3D_OS}" in
 esac
 
 
-npm i puppeteer@1.11.0 -g --unsafe-perm
+npm i puppeteer@2.1.1 -g --unsafe-perm
 npm i -g mocha@5.2.0 chai@4.2.0 mocha-logger@1.0.6

--- a/qa/tests/generic/compatibility-check.js
+++ b/qa/tests/generic/compatibility-check.js
@@ -37,7 +37,7 @@ describe('', function() {
 
 		await adminPage.goto(env.networkAdminUrl + 'admin.php?page=w3tc_dashboard');
 		
-		let compatibilityCheck = 'input[value="compatibility check"]';
+		let compatibilityCheck = '#w3tc-top-nav-info-menu a.compatiblity-test';
 		await adminPage.evaluate((compatibilityCheck) => document.querySelector(compatibilityCheck).click(), compatibilityCheck);
 
 		await adminPage.waitFor(() => {


### PR DESCRIPTION
This PR addresses several issues experienced under testing of WP 6.3 as well as a few other tests

Of note

- Puppeteer from version 1.11.0 to 2.1.1
- Page Cache disk enhanced no longer hard-expires old cache files when renamed during flush. This was causing the garbage collection under certain environments to immediately remove the old file which broke the temporary serve functionally while waiting for the new cache file
- Updated Fragment cache default settings to be inactive and simplified the activated toggle on save logic
- Various test adjustments to account for changed HTML markup IDs/classes