### PR TITLE
Fixed cache.php instance warning for FC if no engine has been selected

### DIFF
--- a/Extension_FragmentCache_Plugin.php
+++ b/Extension_FragmentCache_Plugin.php
@@ -22,8 +22,9 @@ class Extension_FragmentCache_Plugin {
 
 		$config = Dispatcher::config();
 		// remainder only when extension is frontend-active
-		if ( !$config->is_extension_active_frontend( 'fragmentcache' ) )
+		if ( ! $config->is_extension_active_frontend( 'fragmentcache' ) || empty( $this->_config->get_string( array( 'fragmentcache', 'engine' ) ) ) ) {
 			return;
+		}
 
 		add_action( 'init', array( $this, 'on_init' ), 9999999 );
 


### PR DESCRIPTION
If pro and FC activated but no engine selected under the settings block on the General Settings page, the cache.php instance method would process the FC as enabled but no engine value would exist, resulting in it defaulting to Cache_Base and throwing a warning

This PR adds to the is_extension_active_frontend check for FC to check if an engine has been selected. If none is, then FC will not process