### PR TITLE
Update GPS recommedations to reference new Defer Scripts feature

### DIFF
--- a/PageSpeed_Instructions.php
+++ b/PageSpeed_Instructions.php
@@ -34,14 +34,25 @@ class PageSpeed_Instructions {
 						'<p>' . wp_kses(
 							sprintf(
 								// translators: 1 W3TC plugin name, 2 HTML a tag to W3TC minify JS admin page
-								// translators: 3 HTML a tag to W3TC minify CSS admin page.
+								// translators: 3 HTML a tag to W3TC general settings user experience section
+								// translators: 4 HTML a tag to W3TC user expereince advanced settings page
+								// translators: 5 HTML a tag to W3TC minify CSS admin page, 6 HTML line break tag.
 								esc_html__(
-									'%1$s can eliminate render blocking resources. Once Minified, you can defer JS in the %2$s. Render blocking CSS can be eliminated in %3$s using the "Eliminate Render blocking CSS by moving it to HTTP body" (PRO FEATURE).',
+									'%1$s can eliminate render blocking resources.%6$sOnce Minified, you can defer JS in the
+										%2$s.%6$sThe Defer Scripts (PRO FEATURE) can also be used with or without minify to defer
+										the loading of JS files containing the "src" attribute. Scripts matched using this
+										feature will be excluded from the minify process. To enable this feature navigate
+										to %3$s and check the "Defer JavaScript" checkbox. Once enabled the settings can be found
+										at %4$s.%6$sRender blocking CSS can be eliminated in %5$s using the "Eliminate Render
+										blocking CSS by moving it to HTTP body" (PRO FEATURE).',
 									'w3-total-cache'
 								),
 								'W3 Total Cache',
 								'<a target="_blank" href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_minify#js' ) ) . '" alt="' . esc_attr__( 'Minify JS', 'w3-total-cache' ) . '">' . esc_html__( 'Performance &raquo; Minify &raquo; JS', 'w3-total-cache' ) . '</a> ',
-								'<a target="_blank" href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '" alt="' . esc_attr__( 'Minify CSS', 'w3-total-cache' ) . '">' . esc_html__( 'Performance &raquo; Minify &raquo; CSS', 'w3-total-cache' ) . '</a>'
+								'<a target="_blank" href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '" alt="' . esc_attr__( 'Defer Scripts', 'w3-total-cache' ) . '">' . esc_html__( 'Performance &raquo; General Settings &raquo; User Experience', 'w3-total-cache' ) . '</a>',
+								'<a target="_blank" href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#application' ) ) . '" alt="' . esc_attr__( 'Defer Scripts Settings', 'w3-total-cache' ) . '">' . esc_html__( 'Performance &raquo; User Experience', 'w3-total-cache' ) . '</a>',
+								'<a target="_blank" href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '" alt="' . esc_attr__( 'Minify CSS', 'w3-total-cache' ) . '">' . esc_html__( 'Performance &raquo; Minify &raquo; CSS', 'w3-total-cache' ) . '</a>',
+								'<br/><br/>'
 							),
 							$allowed_tags
 						) . '</p>',

--- a/Util_PageSpeed.php
+++ b/Util_PageSpeed.php
@@ -362,19 +362,46 @@ class Util_PageSpeed {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					if ( isset( $item['node'] ) ) {
-						$items .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-						$items .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
+						$items .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' )  . '</b>' . esc_html( $item['node']['snippet'] ) . '</p>';
+						$items .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' )  . '</b>' . esc_html( $item['node']['selector'] ) . '</p>';
 					}
 					$items .= '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Value', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . esc_html( $item['value'] ) . '</td>';
+					$items   .= is_array( $item['value'] ) ? '<td>' . esc_html( $item['value']['value'] ) . '</td>' : '<td>' . esc_html( $item['value'] ) . '</td>';
 				} elseif ( isset( $item['node'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
-					$items   .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-					$items   .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
+					$items   .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' ) . '</b>' . esc_html( $item['node']['snippet'] ) . '</p>';
+					$items   .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' ) . '</b>' . esc_html( $item['node']['selector'] ) . '</p>';
 					$items   .= '</td>';
+				}
+				if ( isset( $item['headings'] ) && isset( $item['items'] ) ) {
+					$items   .= '<td><table class="w3tcps_breakdown_subitems_table"><tr class="w3tcps_passed_audit_subitem_header">';
+					foreach ( $item['headings'] as $heading ) {
+						$items .= '<th>' . esc_html( $heading['label'], 'w3-total-cache' ) . '</th>';
+					}
+					$items  .= '</tr>';
+					foreach ( $item['items'] as $sub_item ) {
+						$items .= '<tr class="w3tcps_passed_audit_subitem">';
+						if ( isset( $sub_item['node'] ) ) {
+							$items   .= '<td>';
+							$items   .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' ) . '</b>' . esc_html( $sub_item['node']['snippet'] ) . '</p>';
+							$items   .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' ) . '</b>' . esc_html( $sub_item['node']['selector'] ) . '</p>';
+							$items   .= '</td>';
+						}
+						if ( isset( $sub_item['phase'] ) && isset( $sub_item['timing'] ) && isset( $sub_item['percent'] ) ) {
+							$items   .= '<td>' . esc_html( $sub_item['phase'] ) . '</td>';
+							$items   .= '<td>' . esc_html( $sub_item['percent'] ) . '</td>';
+							$items   .= '<td>' . esc_html( $sub_item['timing'] ) . ' ms</td>';
+						}
+						$items .= '</tr>';
+					}
+					$items  .= '</table></td>';
+				}
+				if ( isset( $item['responseTime'] ) ) {
+					$headers .= '<th>' . esc_html__( 'Response Time', 'w3-total-cache' ) . '</th>';
+					$items   .= '<td>' . esc_html( $item['responseTime'] ) . '</td>';
 				}
 				$items .= '</tr>';
 			}
@@ -545,19 +572,46 @@ class Util_PageSpeed {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
 					if ( isset( $item['node'] ) ) {
-						$items .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-						$items .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
+						$items .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' ) . '</b>' . esc_html( $item['node']['snippet'] ) . '</p>';
+						$items .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' ) . '</b>' .esc_html( $item['node']['selector'] ) . '</p>';
 					}
 					$items .= '</td>';
 
 					$headers .= '<th>' . esc_html__( 'Value', 'w3-total-cache' ) . '</th>';
-					$items   .= '<td>' . esc_html( $item['value'] ) . '</td>';
+					$items   .= is_array( $item['value'] ) ? '<td>' . esc_html( $item['value']['value'] ) . '</td>' : '<td>' . esc_html( $item['value'] ) . '</td>';
 				} elseif ( isset( $item['node'] ) ) {
 					$headers .= '<th>' . esc_html__( 'Element', 'w3-total-cache' ) . '</th>';
 					$items   .= '<td>';
-					$items   .= '<p>' . esc_html( $item['node']['snippet'] ) . '</p>';
-					$items   .= '<p>' . esc_html( $item['node']['selector'] ) . '</p>';
+					$items   .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' ) . '</b>' . esc_html( $item['node']['snippet'] ) . '</p>';
+					$items   .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' ) . '</b>' . esc_html( $item['node']['selector'] ) . '</p>';
 					$items   .= '</td>';
+				}
+				if ( isset( $item['headings'] ) && isset( $item['items'] ) ) {
+					$items   .= '<td><table class="w3tcps_breakdown_subitems_table"><tr class="w3tcps_passed_audit_subitem_header">';
+					foreach ( $item['headings'] as $heading ) {
+						$items .= '<th>' . esc_html( $heading['label'], 'w3-total-cache' ) . '</th>';
+					}
+					$items  .= '</tr>';
+					foreach ( $item['items'] as $sub_item ) {
+						$items .= '<tr class="w3tcps_passed_audit_subitem">';
+						if ( isset( $sub_item['node'] ) ) {
+							$items   .= '<td>';
+							$items   .= '<p><b>' . __( 'Snippet : ', 'w3-total-cache' ) . '</b>' . esc_html( $sub_item['node']['snippet'] ) . '</p>';
+							$items   .= '<p><b>' . __( 'Selector : ', 'w3-total-cache' ) . '</b>' . esc_html( $sub_item['node']['selector'] ) . '</p>';
+							$items   .= '</td>';
+						}
+						if ( isset( $sub_item['phase'] ) && isset( $sub_item['timing'] ) && isset( $sub_item['percent'] ) ) {
+							$items   .= '<td>' . esc_html( $sub_item['phase'] ) . '</td>';
+							$items   .= '<td>' . esc_html( $sub_item['percent'] ) . '</td>';
+							$items   .= '<td>' . esc_html( $sub_item['timing'] ) . ' ms</td>';
+						}
+						$items .= '</tr>';
+					}
+					$items  .= '</table></td>';
+				}
+				if ( isset( $item['responseTime'] ) ) {
+					$headers .= '<th>' . esc_html__( 'Response Time', 'w3-total-cache' ) . '</th>';
+					$items   .= '<td>' . esc_html( $item['responseTime'] ) . '</td>';
 				}
 				$items .= '</tr>';
 			}


### PR DESCRIPTION
This PR updated the GPS recommendations for the "render blocking elements" metric to include the new Defer Scripts feature. To view it simply authorize and use the GPS feature, and look under the "render blocking elements" metric block

This PR also fixes a PHP warning issue when rendering the GPS results. The issue was that an array was being passed to an esc_html call instead of the intended string value. I also fixed the "Largest Contentful Paint element" metric so it will now show results instead of a blank section. Lastly I updated a few metrics so that snippets and selectors would be prefixed with a label for better clarification