### PR TITLE
Defer Scripts Fix

### DIFF
--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -235,13 +235,25 @@ class FeatureShowcase_Plugin_Admin {
 		}
 
 		return array(
+			'defer-scripts'       => array(
+				'title'      => esc_html__( 'Defer JavaScript', 'w3-total-cache' ),
+				'icon'       => 'dashicons-media-code',
+				'text'       => esc_html__( "Defer the loading of specified JavaScript sources on your pages separate from Minify.", 'w3-total-cache' ),
+				'button'     => '<button class="button" onclick="window.location=\'' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '\'">' .
+					__( 'Settings', 'w3-total-cache' ) . '</button>',
+				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/defer-scripts-tool/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=defer-scripts-tool' ) .
+					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
+				'is_premium' => true,
+				'is_new'     => true,
+			),
 			'pagespeed'           => array(
 				'title'      => esc_html__( 'Google Page Speed', 'w3-total-cache' ),
 				'icon'       => 'dashicons-analytics',
 				'text'       => esc_html__( "Adds the ability to analyze the website's homepage and provide a detailed breakdown of performance metrics including potential issues and proposed solutions.", 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-				esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_pagespeed' ) ) . '\'">' .
-				__( 'Launch', 'w3-total-cache' ) . '</button>',
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_pagespeed' ) ) . '\'">' .
+					__( 'Launch', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/google-pagespeed-tool/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pagespeed-tool' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
 				'is_premium' => false,

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -92,7 +92,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 				'Defer the loading of specified JavaScript sources on your pages.',
 				'w3-total-cache'
 			) . (
-				Util_Environment::is_w3tc_pro( $config ) && $config->is_extension_active_frontend( 'user-experience-defer-scripts' )
+				Util_Environment::is_w3tc_pro( $config ) && $config->is_extension_active( 'user-experience-defer-scripts' )
 				? wp_kses(
 					sprintf(
 						// translators: 1 opening HTML a tag to W3TC User Experience page, 2 closing HTML a tag.

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -92,7 +92,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 				'Defer the loading of specified JavaScript sources on your pages.',
 				'w3-total-cache'
 			) . (
-				Util_Environment::is_w3tc_pro( $config )
+				Util_Environment::is_w3tc_pro( $config ) && $config->is_extension_active_frontend( 'user-experience-defer-scripts' )
 				? wp_kses(
 					sprintf(
 						// translators: 1 opening HTML a tag to W3TC User Experience page, 2 closing HTML a tag.


### PR DESCRIPTION
This PR fixes a display issue for the General Settings block for defer scripts where a link was shown for the settings that doesn't exist if the feature isn't enabled.

This also adds the missing feature showcase block (documentation link pending)