### PR TITLE
Defer Scripts Config Save Fix

### DIFF
--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -698,6 +698,10 @@ class Generic_AdminActions_Default {
 
 			if ( isset( $descriptor['type'] ) ) {
 				if ( 'array' === $descriptor['type'] ) {
+					if ( is_array( $request_value ) ) {
+						// This is needed for radio inputs.
+						$request_value = implode( "\n", $request_value );
+					}
 					$request_value = Util_Environment::textarea_to_array( $request_value );
 				} elseif ( 'boolean' === $descriptor['type'] ) {
 					$request_value = ( '1' === $request_value );


### PR DESCRIPTION
This restores a check that was removed in the defer-scripts branch that was apparently needed for radio inputs. Without this, any settings page save that contained a radio input would fatal error