### PR TITLE
Fix Cache Groups JS

### DIFF
--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -7,62 +7,123 @@
  */
 
 jQuery(function() {
+	jQuery(document).on( 'submit', '#cachegroups_form', function() {
+		var error = [];
 
-	// User agent groups.
+		var mobile_groups = jQuery('#mobile_groups li');
+    	mobile_groups.each(function(index, mobile_group) {
+    	    var $mobile_group = jQuery(mobile_group);
 
-	jQuery('#mobile_form').on( 'submit', function() {
-		var error = false;
+    	    if ($mobile_group.find('.mobile_group_enabled:checked').length) {
+    	        var name = $mobile_group.find('.mobile_group').text();
+    	        var theme = $mobile_group.find('select').val();
+    	        var redirect = $mobile_group.find('input[type=text]').val();
+    	        var agents = jQuery.trim($mobile_group.find('textarea').val()).split('\n');
 
-		jQuery('#mobile_groups li').each(function() {
-			if (jQuery(this).find(':checked').length) {
-				var group = jQuery(this).find('.mobile_group').text();
-				var theme = jQuery(this).find(':selected').val();
-				var redirect = jQuery(this).find('input[type=text]').val();
-				var agents = jQuery.trim(jQuery(this).find('textarea').val()).split("\n");
+    	        mobile_groups.not($mobile_group).each(function(index, compare_mobile_group) {
+    	            var $compare_mobile_group = jQuery(compare_mobile_group);
 
-				jQuery('#mobile_groups li').each(function() {
-					if (jQuery(this).find(':checked').length) {
-						var compare_group = jQuery(this).find('.mobile_group').text();
-						if (compare_group != group) {
-							var compare_theme = jQuery(this).find(':selected').val();
-							var compare_redirect = jQuery(this).find('input[type=text]').val();
-							var compare_agents = jQuery.trim(jQuery(this).find('textarea').val()).split("\n");
+    	            if ($compare_mobile_group.find('.mobile_group_enabled:checked').length) {
+    	                var compare_name = $compare_mobile_group.find('.mobile_group').text();
+    	                var compare_theme = $compare_mobile_group.find('select').val();
+    	                var compare_redirect = $compare_mobile_group.find('input[type=text]').val();
+    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val()).split('\n');
 
-							if (compare_redirect == '' && redirect == '' && compare_theme != '' && compare_theme == theme) {
-								alert('Duplicate theme "' + compare_theme + '" found in the group "' + group + '".');
-								error = true;
-								return false;
-							}
+    	                var groups = sort_array([name, compare_name]);
 
-							if (compare_redirect != '' && compare_redirect == redirect) {
-								alert('Duplicate redirect "' + compare_redirect + '" found in the group "' + group + '".');
-								error = true;
-								return false;
-							}
+    	                if (compare_redirect === '' && redirect === '' && compare_theme !== '' && compare_theme === theme) {
+    	                    error.push('Duplicate theme "' + compare_theme + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                }
 
-							jQuery.each(compare_agents, function(index, value) {
-								if (jQuery.inArray(value, agents) != -1) {
-									alert('Duplicate stem "' + value + '" found in the group "' + compare_group + '".');
-									error = true;
-									return false;
-								}
-							});
-						}
-					}
-				});
+    	                if (compare_redirect !== '' && compare_redirect === redirect) {
+    	                    error.push('Duplicate redirect "' + compare_redirect + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                }
 
-				if (error) {
-					return false;
-				}
-			}
-		});
+    	                jQuery.each(compare_agents, function(index, value) {
+    	                    if (jQuery.inArray(value, agents) !== -1) {
+    	                        error.push('Duplicate stem "' + value + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                    }
+    	                });
+    	            }
+    	        });
+    	    }
+    	});
 
-		if (error) {
+		var referrer_groups = jQuery('#referrer_groups li');
+    	referrer_groups.each(function(index, referrer_group) {
+    	    var $referrer_group = jQuery(referrer_group);
+
+    	    if ($referrer_group.find('.referrer_group_enabled:checked').length) {
+    	        var name = $referrer_group.find('.referrer_group').text();
+    	        var theme = $referrer_group.find('select').val();
+    	        var redirect = $referrer_group.find('input[type=text]').val();
+    	        var agents = jQuery.trim($referrer_group.find('textarea').val()).split('\n');
+
+    	        referrer_groups.not($referrer_group).each(function(index, compare_referrer_group) {
+    	            var $compare_referrer_group = jQuery(compare_referrer_group);
+
+    	            if ($compare_referrer_group.find('.referrer_group_enabled:checked').length) {
+    	                var compare_name = $compare_referrer_group.find('.referrer_group').text();
+    	                var compare_theme = $compare_referrer_group.find('select').val();
+    	                var compare_redirect = $compare_referrer_group.find('input[type=text]').val();
+    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val()).split('\n');
+
+    	                var groups = sort_array([name, compare_name]);
+
+    	                if (compare_redirect === '' && redirect === '' && compare_theme !== '' && compare_theme === theme) {
+    	                    error.push('Duplicate theme "' + compare_theme + '" found in the referrer groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                }
+
+    	                if (compare_redirect !== '' && compare_redirect === redirect) {
+    	                    error.push('Duplicate redirect "' + compare_redirect + '" found in the referrer groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                }
+
+    	                jQuery.each(compare_agents, function(index, value) {
+    	                    if (jQuery.inArray(value, agents) !== -1) {
+    	                        error.push('Duplicate stem "' + value + '" found in the referrer groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                    }
+    	                });
+    	            }
+    	        });
+    	    }
+    	});
+
+		var cookiegroups = jQuery('#cookiegroups li');
+    	cookiegroups.each(function(index, cookiegroup) {
+    	    var $cookiegroup = jQuery(cookiegroup);
+
+    	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
+    	        var name = $cookiegroup.find('.cookiegroup').text();
+    	        var agents = jQuery.trim($cookiegroup.find('textarea').val()).split('\n');
+
+    	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
+    	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
+
+    	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
+    	                var compare_name = $compare_cookiegroup.find('.cookiegroup').text();
+    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val()).split('\n');
+
+    	                var groups = sort_array([name, compare_name]);
+
+    	                jQuery.each(compare_agents, function(index, value) {
+    	                    if (jQuery.inArray(value, agents) !== -1) {
+    	                        error.push('Duplicate stem "' + value + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                    }
+    	                });
+    	            }
+    	        });
+    	    }
+    	});
+
+		if (error.length !== 0) {
+			alert(unique_array(error).join('\n'));
 			return false;
 		}
+		
+		return true;
 	});
 
-	jQuery('#mobile_add').on( 'click', function() {
+	jQuery(document).on( 'click', '#mobile_add', function() {
 		var group = prompt('Enter group name (only "0-9", "a-z", "_" symbols are allowed).');
 
 		if (group !== null) {
@@ -83,7 +144,46 @@ jQuery(function() {
 				});
 
 				if (!exists) {
-					var li = jQuery('<li id="mobile_group_' + group + '"><table class="form-table"><tr><th>Group name:</th><td><span class="mobile_group_number">' + (jQuery('#mobile_groups li').length + 1) + '.</span> <span class="mobile_group">' + group + '</span> <input type="button" class="button mobile_delete" value="Delete group" /></td></tr><tr><th><label for="mobile_groups_' + group + '_enabled">Enabled:</label></th><td><input type="hidden" name="mobile_groups[' + group + '][enabled]" value="0" /><input id="mobile_groups_' + group + '_enabled" type="checkbox" name="mobile_groups[' + group + '][enabled]" value="1" checked="checked" /></td></tr><tr><th><label for="mobile_groups_' + group + '_theme">Theme:</label></th><td><select id="mobile_groups_' + group + '_theme" name="mobile_groups[' + group + '][theme]"><option value="">-- Pass-through --</option></select><p class="description">Assign this group of user agents to a specific them. Leaving this option "Active Theme" allows any plugins you have (e.g. mobile plugins) to properly handle requests for these user agents. If the "redirect users to" field is not empty, this setting is ignored.</p></td></tr><tr><th><label for="mobile_groups_' + group + '_redirect">Redirect users to:</label></th><td><input id="mobile_groups_' + group + '_redirect" type="text" name="mobile_groups[' + group + '][redirect]" value="" size="60" /><p class="description">A 302 redirect is used to send this group of users to another hostname (domain); recommended if a 3rd party service provides a mobile version of your site.</p></td></tr><tr><th><label for="mobile_groups_' + group + '_agents">User agents:</label></th><td><textarea id="mobile_groups_' + group + '_agents" name="mobile_groups[' + group + '][agents]" rows="10" cols="50"></textarea><p class="description">Specify the user agents for this group.</p></td></tr></table></li>');
+					var li = jQuery('<li id="mobile_group_' + group + '">' +
+						'<table class="form-table">' +
+						'<tr>' +
+						'<th>Group name:</th>' +
+						'<td>' +
+						'<span class="mobile_group_number">' + (jQuery('#mobile_groups li').length + 1) + '.</span> ' +
+						'<span class="mobile_group">' + group + '</span> ' +
+						'<input type="button" class="button mobile_delete" value="Delete group" />' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="mobile_groups_' + group + '_enabled">Enabled:</label></th>' +
+						'<td>' +
+						'<input type="hidden" name="mobile_groups[' + group + '][enabled]" value="0" />' +
+						'<input id="mobile_groups_' + group + '_enabled" class="mobile_group_enabled" type="checkbox" name="mobile_groups[' + group + '][enabled]" value="1" checked="checked" />' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="mobile_groups_' + group + '_theme">Theme:</label></th>' +
+						'<td>' +
+						'<select id="mobile_groups_' + group + '_theme" name="mobile_groups[' + group + '][theme]"><option value="">-- Pass-through --</option></select>' +
+						'<p class="description">Assign this group of user agents to a specific them. Leaving this option "Active Theme" allows any plugins you have (e.g. mobile plugins) to properly handle requests for these user agents. If the "redirect users to" field is not empty, this setting is ignored.</p>' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="mobile_groups_' + group + '_redirect">Redirect users to:</label></th>' +
+						'<td>' +
+						'<input id="mobile_groups_' + group + '_redirect" type="text" name="mobile_groups[' + group + '][redirect]" value="" size="60" />' +
+						'<p class="description">A 302 redirect is used to send this group of users to another hostname (domain); recommended if a 3rd party service provides a mobile version of your site.</p>' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="mobile_groups_' + group + '_agents">User agents:</label></th>' +
+						'<td>' +
+						'<textarea id="mobile_groups_' + group + '_agents" name="mobile_groups[' + group + '][agents]" rows="10" cols="50"></textarea>' +
+						'<p class="description">Specify the user agents for this group.</p>' +
+						'</td>' +
+						'</tr>' +
+						'</table>' +
+						'</li>');
 					var select = li.find('select');
 
 					jQuery.each(mobile_themes, function(index, value) {
@@ -101,7 +201,7 @@ jQuery(function() {
 		}
 	});
 
-	jQuery('.mobile_delete').on('click', function () {
+	jQuery(document).on('click', '.mobile_delete', function () {
 		if (confirm('Are you sure want to delete this group?')) {
 			jQuery(this).parents('#mobile_groups li').remove();
 			w3tc_mobile_groups_clear();
@@ -113,59 +213,7 @@ jQuery(function() {
 
 	// Referrer groups.
 
-	jQuery('#referrer_form').on( 'submit', function() {
-		var error = false;
-
-		jQuery('#referrer_groups li').each(function() {
-			if (jQuery(this).find(':checked').length) {
-				var group = jQuery(this).find('.referrer_group').text();
-				var theme = jQuery(this).find(':selected').val();
-				var redirect = jQuery(this).find('input[type=text]').val();
-				var agents = jQuery.trim(jQuery(this).find('textarea').val()).split("\n");
-
-				jQuery('#referrer_groups li').each(function() {
-					if (jQuery(this).find(':checked').length) {
-						var compare_group = jQuery(this).find('.referrer_group').text();
-						if (compare_group != group) {
-							var compare_theme = jQuery(this).find(':selected').val();
-							var compare_redirect = jQuery(this).find('input[type=text]').val();
-							var compare_agents = jQuery.trim(jQuery(this).find('textarea').val()).split("\n");
-
-							if (compare_redirect == '' && redirect == '' && compare_theme != '' && compare_theme == theme) {
-								alert('Duplicate theme "' + compare_theme + '" found in the group "' + group + '".');
-								error = true;
-								return false;
-							}
-
-							if (compare_redirect != '' && compare_redirect == redirect) {
-								alert('Duplicate redirect "' + compare_redirect + '" found in the group "' + group + '".');
-								error = true;
-								return false;
-							}
-
-							jQuery.each(compare_agents, function(index, value) {
-								if (jQuery.inArray(value, agents) != -1) {
-									alert('Duplicate stem "' + value + '" found in the group "' + compare_group + '".');
-									error = true;
-									return false;
-								}
-							});
-						}
-					}
-				});
-
-				if (error) {
-					return false;
-				}
-			}
-		});
-
-		if (error) {
-			return false;
-		}
-	});
-
-	jQuery('#referrer_add').on( 'click', function() {
+	jQuery(document).on( 'click', '#referrer_add', function() {
 		var group = prompt('Enter group name (only "0-9", "a-z", "_" symbols are allowed).');
 
 		if (group !== null) {
@@ -186,7 +234,48 @@ jQuery(function() {
 				});
 
 				if (!exists) {
-					var li = jQuery('<li id="referrer_group_' + group + '"><table class="form-table"><tr><th>Group name:</th><td><span class="referrer_group_number">' + (jQuery('#referrer_groups li').length + 1) + '.</span> <span class="referrer_group">' + group + '</span> <input type="button" class="button referrer_delete" value="Delete group" /></td></tr><tr><th><label for="referrer_groups_' + group + '_enabled">Enabled:</label></th><td><input type="hidden" name="referrer_groups[' + group + '][enabled]" value="0" /><input id="referrer_groups_' + group + '_enabled" type="checkbox" name="referrer_groups[' + group + '][enabled]" value="1" checked="checked" /></td></tr><tr><th><label for="referrer_groups_' + group + '_theme">Theme:</label></th><td><select id="referrer_groups_' + group + '_theme" name="referrer_groups[' + group + '][theme]"><option value="">-- Pass-through --</option></select><p class="description">Assign this group of referrers to a specific them. Leaving this option "Active Theme" allows any plugins you have (e.g. referrer plugins) to properly handle requests for these referrers. If the "redirect users to" field is not empty, this setting is ignored.</p></td></tr><tr><th><label for="referrer_groups_' + group + '_redirect">Redirect users to:</label></th><td><input id="referrer_groups_' + group + '_redirect" type="text" name="referrer_groups[' + group + '][redirect]" value="" size="60" /><p class="description">A 302 redirect is used to send this group of users to another hostname (domain); recommended if a 3rd party service provides a referrer version of your site.</p></td></tr><tr><th><label for="referrer_groups_' + group + '_referrers">Referrers:</label></th><td><textarea id="referrer_groups_' + group + '_referrers" name="referrer_groups[' + group + '][referrers]" rows="10" cols="50"></textarea><p class="description">Specify the referrers for this group.</p></td></tr></table></li>');
+					var li = jQuery('<li id="referrer_group_' + group + '">' +
+						'<table class="form-table">' +
+						'<tr>' +
+						'<th>Group name:</th>' +
+						'<td>' +
+						'<span class="referrer_group_number">' + (jQuery('#referrer_groups li').length + 1) + '.</span> ' +
+						'<span class="referrer_group">' + group + '</span> ' +
+						'<input type="button" class="button referrer_delete" value="Delete group" />' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th>' +
+						'<label for="referrer_groups_' + group + '_enabled">Enabled:</label>' +
+						'</th>' +
+						'<td>' +
+						'<input type="hidden" name="referrer_groups[' + group + '][enabled]" value="0" />' +
+						'<input id="referrer_groups_' + group + '_enabled" class="referrer_group_enabled" type="checkbox" name="referrer_groups[' + group + '][enabled]" value="1" checked="checked" />' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="referrer_groups_' + group + '_theme">Theme:</label></th>' +
+						'<td>' +
+						'<select id="referrer_groups_' + group + '_theme" name="referrer_groups[' + group + '][theme]"><option value="">-- Pass-through --</option></select>' +
+						'<p class="description">Assign this group of referrers to a specific them. Leaving this option "Active Theme" allows any plugins you have (e.g. referrer plugins) to properly handle requests for these referrers. If the "redirect users to" field is not empty, this setting is ignored.</p>' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="referrer_groups_' + group + '_redirect">Redirect users to:</label></th>' +
+						'<td>' +
+						'<input id="referrer_groups_' + group + '_redirect" type="text" name="referrer_groups[' + group + '][redirect]" value="" size="60" />' +
+						'<p class="description">A 302 redirect is used to send this group of users to another hostname (domain); recommended if a 3rd party service provides a referrer version of your site.</p>' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="referrer_groups_' + group + '_referrers">Referrers:</label></th>' +
+						'<td>' +
+						'<textarea id="referrer_groups_' + group + '_referrers" name="referrer_groups[' + group + '][referrers]" rows="10" cols="50"></textarea>' +
+						'<p class="description">Specify the referrers for this group.</p>' +
+						'</td>' +
+						'</tr>' +
+						'</table>' +
+						'</li>');
 					var select = li.find('select');
 
 					jQuery.each(referrer_themes, function(index, value) {
@@ -204,7 +293,7 @@ jQuery(function() {
 		}
 	});
 
-	jQuery('.referrer_delete').on('click', function () {
+	jQuery(document).on('click', '.referrer_delete', function () {
 		if (confirm('Are you sure want to delete this group?')) {
 			jQuery(this).parents('#referrer_groups li').remove();
 			w3tc_referrer_groups_clear();
@@ -216,7 +305,7 @@ jQuery(function() {
 
 	// Cookie groups.
 
-	jQuery( '#w3tc_cookiegroup_add' ).on( 'click', function() {
+	jQuery(document).on( 'click', '#w3tc_cookiegroup_add', function() {
 		var group = prompt('Enter group name (only "0-9", "a-z", "_" symbols are allowed).');
 
 		if (group !== null) {
@@ -241,27 +330,32 @@ jQuery(function() {
 						'<table class="form-table">' +
 						'<tr>' +
 						'<th>Group name:</th>' +
-						'<td><span class="cookiegroup_number">' + (jQuery('#cookiegroups li').length + 1) + '.</span> ' +
+						'<td>' +
+						'<span class="cookiegroup_number">' + (jQuery('#cookiegroups li').length + 1) + '.</span> ' +
 						'<span class="cookiegroup_name">' + group + '</span> ' +
-						'<input type="button" class="button cookiegroup_delete" value="Delete group" /></td>' +
+						'<input type="button" class="button w3tc_cookiegroup_delete" value="Delete group" />' +
+						'</td>' +
 						'</tr>' +
 						'<tr>' +
 						'<th><label for="cookiegroup_' + group + '_enabled">Enabled:</label></th>' +
 						'<td>' +
-						'<input id="cookiegroup_' + group + '_enabled" type="checkbox" name="cookiegroups[' +
-						group + '][enabled]" value="1" checked="checked" /></td>' +
+						'<input id="cookiegroup_' + group + '_enabled" class="cookiegroup_enabled" type="checkbox" name="cookiegroups[' + group + '][enabled]" value="1" checked="checked" />' +
+						'</td>' +
 						'</tr>' +
 						'<tr>' +
 						'<th><label for="cookiegroup_' + group + '_cache">Cache:</label></th>' +
 						'<td>' +
-						'<input id="cookiegroup_' + group + '_cache" type="checkbox" name="cookiegroups[' +
-						group + '][cache]" value="1" checked="checked" /></td></tr>' +
+						'<input id="cookiegroup_' + group + '_cache" type="checkbox" name="cookiegroups[' + group + '][cache]" value="1" checked="checked" /></td>' +
+						'</tr>' +
 						'<tr>' +
 						'<th><label for="cookiegroups_' + group + '_cookies">Cookies:</label></th>' +
-						'<td><textarea id="cookiegroups_' + group + '_cookies" name="cookiegroups[' +
-						group + '][cookies]" rows="10" cols="50"></textarea>' +
-						'<p class="description">Specify the cookies for this group. Values like \'cookie\', \'cookie=value\', and cookie[a-z]+=value[a-z]+are supported. Remember to escape special characters like spaces, dots or dashes with a backslash. Regular expressions are also supported.</p></td></tr>' +
-						'</table></li>');
+						'<td>' +
+						'<textarea id="cookiegroups_' + group + '_cookies" name="cookiegroups[' + group + '][cookies]" rows="10" cols="50"></textarea>' +
+						'<p class="description">Specify the cookies for this group. Values like \'cookie\', \'cookie=value\', and cookie[a-z]+=value[a-z]+are supported. Remember to escape special characters like spaces, dots or dashes with a backslash. Regular expressions are also supported.</p>' +
+						'</td>' +
+						'</tr>' +
+						'</table>' +
+						'</li>');
 					var select = li.find('select');
 
 					jQuery('#cookiegroups').append(li);
@@ -275,7 +369,7 @@ jQuery(function() {
 		}
 	});
 
-	jQuery('.w3tc_cookiegroup_delete').on( 'click', function () {
+	jQuery(document).on( 'click', '.w3tc_cookiegroup_delete', function () {
 		if (confirm('Are you sure want to delete this group?')) {
 			jQuery(this).parents('#cookiegroups li').remove();
 			w3tc_cookiegroups_clear();
@@ -321,4 +415,11 @@ function w3tc_cookiegroups_clear() {
 	} else {
 		jQuery('#cookiegroups_empty').hide();
 	}
+}
+function unique_array(array) {
+	return jQuery.grep(array,function(el,i){return i === jQuery.inArray(el,array)});
+}
+
+function sort_array(array) {
+	return array.sort();
 }

--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -9,6 +9,7 @@
 jQuery(function() {
 	jQuery(document).on( 'submit', '#cachegroups_form', function() {
 		var error = [];
+		var textarea_filter = /^(\s)*|(\s)*$|(\r\n|\n|\r)/gm;
 
 		var mobile_groups = jQuery('#mobile_groups li');
     	mobile_groups.each(function(index, mobile_group) {
@@ -18,7 +19,7 @@ jQuery(function() {
     	        var name = $mobile_group.find('.mobile_group').text();
     	        var theme = $mobile_group.find('select').val();
     	        var redirect = $mobile_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	        mobile_groups.not($mobile_group).each(function(index, compare_mobile_group) {
     	            var $compare_mobile_group = jQuery(compare_mobile_group);
@@ -27,7 +28,7 @@ jQuery(function() {
     	                var compare_name = $compare_mobile_group.find('.mobile_group').text();
     	                var compare_theme = $compare_mobile_group.find('select').val();
     	                var compare_redirect = $compare_mobile_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -57,7 +58,7 @@ jQuery(function() {
     	        var name = $referrer_group.find('.referrer_group').text();
     	        var theme = $referrer_group.find('select').val();
     	        var redirect = $referrer_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	        referrer_groups.not($referrer_group).each(function(index, compare_referrer_group) {
     	            var $compare_referrer_group = jQuery(compare_referrer_group);
@@ -66,7 +67,7 @@ jQuery(function() {
     	                var compare_name = $compare_referrer_group.find('.referrer_group').text();
     	                var compare_theme = $compare_referrer_group.find('select').val();
     	                var compare_redirect = $compare_referrer_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -94,14 +95,14 @@ jQuery(function() {
 
     	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	        var name = $cookiegroup.find('.cookiegroup_name').text();
-    	        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
     	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
 
     	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	                var compare_name = $compare_cookiegroup.find('.cookiegroup_name').text();
-    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
+		                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(textarea_filter, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 

--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -93,21 +93,21 @@ jQuery(function() {
     	    var $cookiegroup = jQuery(cookiegroup);
 
     	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
-    	        var name = $cookiegroup.find('.cookiegroup').text();
+    	        var name = $cookiegroup.find('.cookiegroup_name').text();
     	        var agents = jQuery.trim($cookiegroup.find('textarea').val()).split('\n');
 
     	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
     	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
 
     	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
-    	                var compare_name = $compare_cookiegroup.find('.cookiegroup').text();
+    	                var compare_name = $compare_cookiegroup.find('.cookiegroup_name').text();
     	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val()).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
     	                jQuery.each(compare_agents, function(index, value) {
     	                    if (jQuery.inArray(value, agents) !== -1) {
-    	                        error.push('Duplicate stem "' + value + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                        error.push('Duplicate stem "' + value + '" found in the cookie groups "' + groups[0] + '" and "' + groups[1] + '"');
     	                    }
     	                });
     	            }

--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -18,7 +18,7 @@ jQuery(function() {
     	        var name = $mobile_group.find('.mobile_group').text();
     	        var theme = $mobile_group.find('select').val();
     	        var redirect = $mobile_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	        mobile_groups.not($mobile_group).each(function(index, compare_mobile_group) {
     	            var $compare_mobile_group = jQuery(compare_mobile_group);
@@ -27,7 +27,7 @@ jQuery(function() {
     	                var compare_name = $compare_mobile_group.find('.mobile_group').text();
     	                var compare_theme = $compare_mobile_group.find('select').val();
     	                var compare_redirect = $compare_mobile_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -57,7 +57,7 @@ jQuery(function() {
     	        var name = $referrer_group.find('.referrer_group').text();
     	        var theme = $referrer_group.find('select').val();
     	        var redirect = $referrer_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	        referrer_groups.not($referrer_group).each(function(index, compare_referrer_group) {
     	            var $compare_referrer_group = jQuery(compare_referrer_group);
@@ -66,7 +66,7 @@ jQuery(function() {
     	                var compare_name = $compare_referrer_group.find('.referrer_group').text();
     	                var compare_theme = $compare_referrer_group.find('select').val();
     	                var compare_redirect = $compare_referrer_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -94,14 +94,14 @@ jQuery(function() {
 
     	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	        var name = $cookiegroup.find('.cookiegroup_name').text();
-    	        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
     	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
 
     	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	                var compare_name = $compare_cookiegroup.find('.cookiegroup_name').text();
-    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
+    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(/^(\s)*(\r\n|\n|\r)/gm, '')).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -119,7 +119,7 @@ jQuery(function() {
 			alert(unique_array(error).join('\n'));
 			return false;
 		}
-		
+
 		return true;
 	});
 

--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -9,7 +9,6 @@
 jQuery(function() {
 	jQuery(document).on( 'submit', '#cachegroups_form', function() {
 		var error = [];
-		var textarea_filter = /^(\s)*|(\s)*$|(\r\n|\n|\r)/gm;
 
 		var mobile_groups = jQuery('#mobile_groups li');
     	mobile_groups.each(function(index, mobile_group) {
@@ -19,7 +18,7 @@ jQuery(function() {
     	        var name = $mobile_group.find('.mobile_group').text();
     	        var theme = $mobile_group.find('select').val();
     	        var redirect = $mobile_group.find('input[type=text]').val();
-		        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
+		        var agents = $mobile_group.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
 
     	        mobile_groups.not($mobile_group).each(function(index, compare_mobile_group) {
     	            var $compare_mobile_group = jQuery(compare_mobile_group);
@@ -28,7 +27,7 @@ jQuery(function() {
     	                var compare_name = $compare_mobile_group.find('.mobile_group').text();
     	                var compare_theme = $compare_mobile_group.find('select').val();
     	                var compare_redirect = $compare_mobile_group.find('input[type=text]').val();
-		                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
+		                var compare_agents = $compare_mobile_group.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -58,7 +57,7 @@ jQuery(function() {
     	        var name = $referrer_group.find('.referrer_group').text();
     	        var theme = $referrer_group.find('select').val();
     	        var redirect = $referrer_group.find('input[type=text]').val();
-		        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
+		        var agents = $referrer_group.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
 
     	        referrer_groups.not($referrer_group).each(function(index, compare_referrer_group) {
     	            var $compare_referrer_group = jQuery(compare_referrer_group);
@@ -67,7 +66,7 @@ jQuery(function() {
     	                var compare_name = $compare_referrer_group.find('.referrer_group').text();
     	                var compare_theme = $compare_referrer_group.find('select').val();
     	                var compare_redirect = $compare_referrer_group.find('input[type=text]').val();
-		                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(textarea_filter, '')).split('\n');
+		                var compare_agents = $compare_referrer_group.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -95,15 +94,15 @@ jQuery(function() {
 
     	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	        var name = $cookiegroup.find('.cookiegroup_name').text();
-		        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(textarea_filter, '')).split('\n');
-
+		        var agents = $cookiegroup.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
+				console.log(agents);
     	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
     	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
 
     	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	                var compare_name = $compare_cookiegroup.find('.cookiegroup_name').text();
-		                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(textarea_filter, '')).split('\n');
-
+		                var compare_agents = $compare_cookiegroup.find('textarea').val().split("\n").filter(function(line){return line.trim()!==''}).map(function(line){return line.trim();});
+						console.log(compare_agents);
     	                var groups = sort_array([name, compare_name]);
 
     	                jQuery.each(compare_agents, function(index, value) {

--- a/CacheGroups_Plugin_Admin_View.js
+++ b/CacheGroups_Plugin_Admin_View.js
@@ -18,7 +18,7 @@ jQuery(function() {
     	        var name = $mobile_group.find('.mobile_group').text();
     	        var theme = $mobile_group.find('select').val();
     	        var redirect = $mobile_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($mobile_group.find('textarea').val()).split('\n');
+    	        var agents = jQuery.trim($mobile_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	        mobile_groups.not($mobile_group).each(function(index, compare_mobile_group) {
     	            var $compare_mobile_group = jQuery(compare_mobile_group);
@@ -27,21 +27,21 @@ jQuery(function() {
     	                var compare_name = $compare_mobile_group.find('.mobile_group').text();
     	                var compare_theme = $compare_mobile_group.find('select').val();
     	                var compare_redirect = $compare_mobile_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val()).split('\n');
+    	                var compare_agents = jQuery.trim($compare_mobile_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
     	                if (compare_redirect === '' && redirect === '' && compare_theme !== '' && compare_theme === theme) {
-    	                    error.push('Duplicate theme "' + compare_theme + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                    error.push('Duplicate theme "' + compare_theme + '" found in the user agent groups "' + groups[0] + '" and "' + groups[1] + '"');
     	                }
 
     	                if (compare_redirect !== '' && compare_redirect === redirect) {
-    	                    error.push('Duplicate redirect "' + compare_redirect + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                    error.push('Duplicate redirect "' + compare_redirect + '" found in the user agent groups "' + groups[0] + '" and "' + groups[1] + '"');
     	                }
 
     	                jQuery.each(compare_agents, function(index, value) {
     	                    if (jQuery.inArray(value, agents) !== -1) {
-    	                        error.push('Duplicate stem "' + value + '" found in the mobile groups "' + groups[0] + '" and "' + groups[1] + '"');
+    	                        error.push('Duplicate stem "' + value + '" found in the user agent groups "' + groups[0] + '" and "' + groups[1] + '"');
     	                    }
     	                });
     	            }
@@ -57,7 +57,7 @@ jQuery(function() {
     	        var name = $referrer_group.find('.referrer_group').text();
     	        var theme = $referrer_group.find('select').val();
     	        var redirect = $referrer_group.find('input[type=text]').val();
-    	        var agents = jQuery.trim($referrer_group.find('textarea').val()).split('\n');
+    	        var agents = jQuery.trim($referrer_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	        referrer_groups.not($referrer_group).each(function(index, compare_referrer_group) {
     	            var $compare_referrer_group = jQuery(compare_referrer_group);
@@ -66,7 +66,7 @@ jQuery(function() {
     	                var compare_name = $compare_referrer_group.find('.referrer_group').text();
     	                var compare_theme = $compare_referrer_group.find('select').val();
     	                var compare_redirect = $compare_referrer_group.find('input[type=text]').val();
-    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val()).split('\n');
+    	                var compare_agents = jQuery.trim($compare_referrer_group.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 
@@ -94,14 +94,14 @@ jQuery(function() {
 
     	    if ($cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	        var name = $cookiegroup.find('.cookiegroup_name').text();
-    	        var agents = jQuery.trim($cookiegroup.find('textarea').val()).split('\n');
+    	        var agents = jQuery.trim($cookiegroup.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	        cookiegroups.not($cookiegroup).each(function(index, compare_cookiegroup) {
     	            var $compare_cookiegroup = jQuery(compare_cookiegroup);
 
     	            if ($compare_cookiegroup.find('.cookiegroup_enabled:checked').length) {
     	                var compare_name = $compare_cookiegroup.find('.cookiegroup_name').text();
-    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val()).split('\n');
+    	                var compare_agents = jQuery.trim($compare_cookiegroup.find('textarea').val().replace(/(?:(?:\r\n|\r|\n)\s*){2}/gm, "")).split('\n');
 
     	                var groups = sort_array([name, compare_name]);
 

--- a/CacheGroups_Plugin_Admin_View.php
+++ b/CacheGroups_Plugin_Admin_View.php
@@ -68,7 +68,7 @@ if ( ! defined( 'W3TC' ) ) {
 						<td>
 							<input type="hidden" name="mobile_groups[<?php echo esc_attr( $group ); ?>][enabled]" value="0" />
 							<input id="mobile_groups_<?php echo esc_attr( $group ); ?>_enabled"
-								type="checkbox"
+								class="mobile_group_enabled" type="checkbox"
 								name="mobile_groups[<?php echo esc_attr( $group ); ?>][enabled]"
 								<?php disabled( $useragent_groups['disabled'] ); ?> value="1"
 								<?php checked( $group_config['enabled'], true ); ?> />
@@ -184,7 +184,10 @@ if ( ! defined( 'W3TC' ) ) {
 						</th>
 						<td>
 							<input type="hidden" name="referrer_groups[<?php echo esc_attr( $group ); ?>][enabled]" value="0" />
-							<input id="referrer_groups_<?php echo esc_attr( $group ); ?>_enabled" type="checkbox" name="referrer_groups[<?php echo esc_attr( $group ); ?>][enabled]" value="1"<?php checked( $group_config['enabled'], true ); ?> />
+							<input id="referrer_groups_<?php echo esc_attr( $group ); ?>_enabled"
+								class="referrer_group_enabled" type="checkbox"
+								name="referrer_groups[<?php echo esc_attr( $group ); ?>][enabled]"
+								value="1"<?php checked( $group_config['enabled'], true ); ?> />
 						</td>
 					</tr>
 					<tr>
@@ -267,7 +270,7 @@ if ( ! defined( 'W3TC' ) ) {
 						</th>
 						<td>
 							<input id="cookiegroup_<?php echo esc_attr( $group ); ?>_enabled"
-								type="checkbox"
+								class="cookiegroup_enabled" type="checkbox"
 								name="cookiegroups[<?php echo esc_attr( $group ); ?>][enabled]"
 								<?php disabled( $cookie_groups['disabled'] ); ?> value="1"
 								<?php checked( $group_config['enabled'], true ); ?> />
@@ -284,7 +287,8 @@ if ( ! defined( 'W3TC' ) ) {
 								type="checkbox"
 								name="cookiegroups[<?php echo esc_attr( $group ); ?>][cache]"
 								<?php disabled( $cookie_groups['disabled'] ); ?> value="1"
-								<?php checked( $group_config['cache'], true ); ?> />
+								<?php checked( $group_config['cache'], true ); ?> /> <?php esc_html_e( 'Enable', 'w3-total-cache' ); ?>
+							<p class="description"><?php esc_html_e( 'Controls whether web pages can be cached or not when cookies from this group are detected.', 'w3-total-cache' ); ?></p>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
This PR fixes several issues with the cache groups feature JavaScript as well as a few additional small tweaks
1. Added groups will now have dom events properly apply to them
2. The submit validation JS will now properly audit submissions to prevent duplicate values between group blocks
3. The cookie groups "cache" field now has a label to identify it's purpose