### PR TITLE
Fix Nginx rules and php 8.2 deprecated error

### DIFF
--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -344,11 +344,11 @@ class BrowserCache_Environment_Nginx {
 				}
 
 				if ( ! empty( $feature_v ) ) {
-					$rules .= '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
+					$rules[] = '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
 				}
 
 				if ( ! empty( $permission_v ) ) {
-					$rules .= '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
+					$rules[] = '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
 				}
 			}
 		}

--- a/Mobile_Base.php
+++ b/Mobile_Base.php
@@ -10,7 +10,7 @@ abstract class Mobile_Base {
 	private $_groups = array();
 	private $_compare_key = '';
 	private $_config_key = '';
-	private $_cacheclass = '';
+	private $_cachecase = '';
 
 	/**
 	 * PHP5-style constructor


### PR DESCRIPTION
Fixed https://github.com/BoldGrid/w3-total-cache/blob/2.4.1/BrowserCache_Environment_Nginx.php#L346-L352 where lines should be added into the rules array and not concatenating a string.

Fixed incorrect class property name at https://github.com/BoldGrid/w3-total-cache/blob/2.4.1/Mobile_Base.php#L13 to what is used at https://github.com/BoldGrid/w3-total-cache/blob/2.4.1/Mobile_Base.php#L23