### PR TITLE
Fixed PHP8+ warning for image service extension.

### DIFF
--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1443,7 +1443,7 @@ class Util_Ui {
 	}
 
 	/**
-	 * Returns option name accepted by W3TC as http paramter * from it's id (full name from config file)
+	 * Returns option name accepted by W3TC as http paramter from its id (full name from config file).
 	 *
 	 * @param mixed $id ID key string/array.
 	 *

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1443,10 +1443,15 @@ class Util_Ui {
 	}
 
 	/**
-	 * Returns option name accepted by W3TC as http paramter
-	 * from it's id (full name from config file)
+	 * Returns option name accepted by W3TC as http paramter * from it's id (full name from config file)
+	 *
+	 * @param mixed $id ID key string/array.
+	 *
+	 * @return string
 	 */
 	public static function config_key_to_http_name( $id ) {
+		$id = isset( $id ) ? $id : '';
+
 		if ( is_array( $id ) ) {
 			$id = $id[0] . '___' . $id[1];
 		}


### PR DESCRIPTION
Warning thrown by null key value passed to Util_Ui::config_item call

https://github.com/BoldGrid/w3-total-cache/blob/366ec47fcc7691614b9a14583fb47528b045ceb1/Extension_ImageService_Page_View.php#L110C1-L132C3