### PR TITLE
Fixing visual bug related to missing space

### DIFF
--- a/inc/options/cdn/azure.php
+++ b/inc/options/cdn/azure.php
@@ -97,7 +97,7 @@ if ( ! defined( 'W3TC' ) ) {
 			sprintf(
 				// translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
 				__(
-					'or %1$sCNAME%2$s:',
+					' or %1$sCNAME%2$s:',
 					'w3-total-cache'
 				),
 				'<acronym title="' . __( 'Canonical Name', 'w3-total-cache' ) . '">',


### PR DESCRIPTION
There is a missing space between the configured FQDN and the word or.

Please have a look at the attached screen shoot
![image](https://github.com/BoldGrid/w3-total-cache/assets/6505576/c0d8498e-1c6f-41b5-9f8b-0f73ee35ff3c)
