### PR TITLE
Fixed flush admin notice when flushing all via admin bar

### DIFF
--- a/Generic_AdminActions_Flush.php
+++ b/Generic_AdminActions_Flush.php
@@ -17,6 +17,12 @@ class Generic_AdminActions_Flush {
 	 */
 	function w3tc_flush_all() {
 		w3tc_flush_all( array( 'ui_action' => 'flush_button' ) );
+
+		$state_note = Dispatcher::config_state_note();
+		$state_note->set( 'common.show_note.flush_statics_needed', false );
+		$state_note->set( 'common.show_note.flush_posts_needed', false );
+		$state_note->set( 'common.show_note.plugins_updated', false );
+
 		$this->_redirect_after_flush( 'flush_all' );
 	}
 


### PR DESCRIPTION
Before this fix, clicking the "Purge All Caches" in the top admin bar did not clear the admin notice indicating that a flush was needed after changes were saved but no flush done. This PR should fix that 