### PR TITLE
Fix fatal error in edge case.  Fixes #759

### DIFF
--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -132,17 +132,19 @@ class Minify_Cache_File {
 	 *
 	 * @param string $id cache id (e.g. a filename)
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public function fetch($id)
 	{
 		$path = $this->_path . '/' . $id;
 
 		$data = @file_get_contents($path . '_meta');
-		if ($data) {
+		if ( ! empty( $data ) ) {
 			$data = @unserialize($data);
 			if (!is_array($data))
 				$data = array();
+		} else {
+			$data = array();
 		}
 
 		if (is_readable($path)) {


### PR DESCRIPTION
This is a simple fix for an edge case where a cache meta file may not be present, the cache file is present, and file locking is disabled.  I don't know the best way to test it.  Marko and I couldn't replicate it but asked the reporter to test it.