### PR TITLE
:bug: Fix memcache check

### DIFF
--- a/Util_Installed.php
+++ b/Util_Installed.php
@@ -148,7 +148,7 @@ class Util_Installed {
 			$test_value = array( 'content' => $test_string );
 			$memcached->set( $test_string, $test_value, 60 );
 			$test_value = $memcached->get( $test_string );
-			$results[$key] = ( $test_value['content'] == $test_string );
+			$results[$key] = ( is_array($test_value) && array_key_exists('content', $results) && $test_value['content'] == $test_string );
 		}
 
 		return $results[$key];

--- a/Util_Installed.php
+++ b/Util_Installed.php
@@ -134,23 +134,30 @@ class Util_Installed {
 		$key = md5( implode( '', $servers ) );
 
 		if ( !isset( $results[$key] ) ) {
-			$memcached = Cache::instance( 'memcached', array(
-					'servers' => $servers,
-					'persistent' => false,
+			$memcached = Cache::instance(
+				'memcached',
+				array(
+					'servers'         => $servers,
+					'persistent'      => false,
 					'binary_protocol' => $binary_protocol,
-					'username' => $username,
-					'password' => $password
-				) );
-			if ( is_null( $memcached ) )
+					'username'        => $username,
+					'password'        => $password
+				)
+			);
+			
+			if ( is_null( $memcached ) ) {
 				return false;
+			}
 
 			$test_string = sprintf( 'test_' . md5( time() ) );
-			$test_value = array( 'content' => $test_string );
+			$test_value  = array( 'content' => $test_string );
+
 			$memcached->set( $test_string, $test_value, 60 );
-			$test_value = $memcached->get( $test_string );
-			$results[$key] = ( is_array($test_value) && array_key_exists('content', $results) && $test_value['content'] == $test_string );
+
+			$test_value      = $memcached->get( $test_string );
+			$results[ $key ] = ( is_array( $test_value ) && array_key_exists( 'content', $results ) && $test_value['content'] === $test_string );
 		}
 
-		return $results[$key];
+		return $results[ $key ];
 	}
 }


### PR DESCRIPTION
After upgrading my website from PHP 7.4 to PHP 8.2, memcache was not available anymore. But W3 Total Cache was configured to use memcache. 

This error happened : 
![image](https://github.com/BoldGrid/w3-total-cache/assets/13284087/66eb654d-291b-43ec-b8a7-90351d68aae6)

To fix this issue, I add two more checks to `$test_value['content']` 