### PR TITLE
Fix Bunny CDN library upload

### DIFF
--- a/CdnEngine_Mirror_BunnyCdn.php
+++ b/CdnEngine_Mirror_BunnyCdn.php
@@ -9,13 +9,13 @@
 namespace W3TC;
 
 /**
- * Class: CdnEngine_Mirror_BunnyCDN
+ * Class: CdnEngine_Mirror_BunnyCdn
  *
  * @since X.X.X
  *
  * @extends CdnEngine_Mirror
  */
-class CdnEngine_Mirror_BunnyCDN extends CdnEngine_Mirror {
+class CdnEngine_Mirror_BunnyCdn extends CdnEngine_Mirror {
 	/**
 	 * Constructor.
 	 *
@@ -60,8 +60,14 @@ class CdnEngine_Mirror_BunnyCDN extends CdnEngine_Mirror {
 			return false;
 		}
 
+		if ( empty( $this->_config['cdn_hostname'] ) ) {
+			$results = $this->_get_results( $files, W3TC_CDN_RESULT_HALT, \__( 'Missing CDN hostname.', 'w3-total-cache' ) );
+
+			return false;
+		}
+
 		$url_prefixes = $this->url_prefixes();
-		$api          = new Cdn_BunnyCDN_Api( $this->_config );
+		$api          = new Cdn_BunnyCdn_Api( $this->_config );
 		$results      = array();
 
 		try {

--- a/Cdn_BunnyCdn_Api.php
+++ b/Cdn_BunnyCdn_Api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File: Cdn_BunnyCDN_Api.php
+ * File: Cdn_BunnyCdn_Api.php
  *
  * @since   X.X.X
  * @package W3TC

--- a/Cdn_BunnyCdn_Popup.php
+++ b/Cdn_BunnyCdn_Popup.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File: Cdn_BunnyCDN_Popup.php
+ * File: Cdn_BunnyCdn_Popup.php
  *
  * @since   X.X.X
  * @package W3TC


### PR DESCRIPTION
To test, enable Bunny CDN for static assets.  You do not have to authorize the CDN to replicate the issue.  Before the update, try to upload something to the WordPress Media Library with Bunny CDN enabled.  An error message will be raised.  After applying the fix, the error will not be raised and the file will be uploaded without issue.
