### PR TITLE
Allow Bunny CDN custom hostname changes

### DIFF
--- a/Cdn_BunnyCdn_Page_View.js
+++ b/Cdn_BunnyCdn_Page_View.js
@@ -80,14 +80,21 @@ jQuery(function($) {
 		.on('change', '#w3tc-origin-url', function() {
 			var $this = $(this);
 
-			$this.val($.trim($this.val().replace(/[^a-z0-9\.:\/-]/g, '')));
+			$this.val($.trim($this.val().toLowerCase().replace(/[^a-z0-9\.:\/-]/g, '')));
 		})
 
 		// Sanitize the pull zone name input value.
 		.on('change', '#w3tc-pull-zone-name', function() {
 			var $this = $(this);
 
-			$this.val($.trim($this.val().replace(/[^a-z0-9-]/g, '')));
+			$this.val($.trim($this.val().toLowerCase().replace(/[^a-z0-9-]/g, '')));
+		})
+
+		// Sanitize the CDN hostname input value.
+		.on('change', '#w3tc_bunnycdn_hostname', function() {
+			var $this = $(this);
+
+			$this.val($.trim($this.val().toLowerCase().replace(/(^https?:|:.+$|[^a-z0-9\.-])/g, '')));
 		})
 
 		// Configure pull zone.

--- a/Cdn_BunnyCdn_Page_View.php
+++ b/Cdn_BunnyCdn_Page_View.php
@@ -102,14 +102,15 @@ $is_unavailable  = ! empty( $account_api_key ) && $config->get_string( 'cdnfsd.b
 			</label>
 		</th>
 		<td class="w3tc_config_value_text">
-			<?php echo esc_html( $config->get_string( 'cdn.bunnycdn.cdn_hostname' ) ); ?>
+		<input id="w3tc_bunnycdn_hostname" type="text" name="cdn__bunnycdn__cdn_hostname"
+			value="<?php echo esc_html( $config->get_string( 'cdn.bunnycdn.cdn_hostname' ) ); ?>" size="100" />
 			<p class="description">
 				<?php
 				echo wp_kses(
 					sprintf(
 						// translators: 1: Opening HTML acronym tag, 2: Closing HTML acronym tag.
 						esc_html__(
-							'The %1$sCDN%2$s hostname is used in media links on pages.',
+							'The %1$sCDN%2$s hostname is used in media links on pages.  For example: example.b-cdn.net',
 							'w3-total-cache'
 						),
 						'<acronym title="' . esc_attr__( 'Content Delivery Network', 'w3-total-cache' ) . '">',


### PR DESCRIPTION
Adds the ability to change the Bunny CDN custom hostname used when rewriting asset URLs on pages.  It does not change anything at Bunny.Net.
See https://github.com/BoldGrid/w3-total-cache/issues/768
Fixes #768
