### PR TITLE
Add Remove CSS/JS feature

### DIFF
--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -240,6 +240,21 @@ class FeatureShowcase_Plugin_Admin {
 
 		return array(
 			'new' => array(
+				'remove-cssjs' => array(
+					'title'      => esc_html__( 'Remove Unused CSS/JS', 'w3-total-cache' ),
+					'icon'       => 'dashicons-editor-strikethrough',
+					'text'       => esc_html__( 'Removes specfied CSS/JS tags from all pages or on a per page basis. Can be used to eliminate unused CSS/JS on pages that do not require them.', 'w3-total-cache' ),
+					'button'     => '<button class="button" onclick="window.location=\'' . (
+						UserExperience_Remove_CssJs_Extension::is_enabled() ?
+							esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#remove-cssjs' ) ) :
+							esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) )
+						) . '\'">' .
+						__( 'Settings', 'w3-total-cache' ) . '</button>',
+					'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/remove-cssjs/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=remove-cssjs' ) .
+						'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
+					'is_premium' => true,
+					'is_new'     => true,
+				),
 				'preload-requests' => array(
 					'title'      => esc_html__( 'Preload Requests', 'w3-total-cache' ),
 					'icon'       => 'dashicons-controls-repeat',

--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -243,7 +243,7 @@ class FeatureShowcase_Plugin_Admin {
 				'remove-cssjs' => array(
 					'title'      => esc_html__( 'Remove Unused CSS/JS', 'w3-total-cache' ),
 					'icon'       => 'dashicons-editor-strikethrough',
-					'text'       => esc_html__( 'Removes specfied CSS/JS tags from all pages or on a per page basis. Can be used to eliminate unused CSS/JS on pages that do not require them.', 'w3-total-cache' ),
+					'text'       => esc_html__( 'Removes specfied CSS/JS tags from the homepage or on a per page basis. Can be used to eliminate unused CSS/JS on pages that do not require them.', 'w3-total-cache' ),
 					'button'     => '<button class="button" onclick="window.location=\'' . (
 						UserExperience_Remove_CssJs_Extension::is_enabled() ?
 							esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#remove-cssjs' ) ) :

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -545,6 +545,7 @@ class Generic_Plugin {
 				array(
 					'swarmify',
 					'lazyload',
+					'removecssjs',
 					'minify',
 					'newrelic',
 					'cdn',

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -632,6 +632,19 @@ class Generic_Plugin_Admin {
 					true
 				);
 				// No break.
+			case 'w3tc_userexperience':
+				if ( UserExperience_Remove_CssJs_Extension::is_enabled() ) {
+					wp_enqueue_script(
+						'w3tc_remove_cssjs',
+						plugins_url( 'UserExperience_Remove_CssJs_Page_View.js', W3TC_FILE ),
+						array(
+							'jquery',
+						),
+						W3TC_VERSION,
+						true
+					);
+				}
+				// No break.
 			case 'w3tc_cdn':
 				wp_enqueue_script( 'jquery-ui-sortable' );
 				break;

--- a/UserExperience_DeferScripts_Page_View.php
+++ b/UserExperience_DeferScripts_Page_View.php
@@ -22,7 +22,7 @@ if ( is_null( $c->get( array( 'user-experience-defer-scripts', 'timeout' ) ) ) )
 }
 
 ?>
-<?php Util_Ui::postbox_header( esc_html__( 'Delay Scripts', 'w3-total-cache' ), '', 'application' ); ?>
+<?php Util_Ui::postbox_header( esc_html__( 'Delay Scripts', 'w3-total-cache' ), '', 'defer-scripts' ); ?>
 <p><?php esc_html_e( 'For best results it is recommended to enable the Minify feature to optimize internal sources and to then use this feature to handle external sources and/or any internal sources excluded from Minify.', 'w3-total-cache' ); ?></p>
 <p>
 	<?php

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -123,7 +123,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 			'extension_id'   => 'user-experience-remove-cssjs',
 			'checkbox_label' => esc_html__( 'Remove Unwanted/Unused CSS/JS', 'w3-total-cache' ),
 			'description'    => __(
-				'Removes specfied CSS/JS tags from all pages or on a per page basis.',
+				'Removes specfied CSS/JS tags from the homepage or on a per page basis.',
 				'w3-total-cache'
 			) . (
 				UserExperience_Remove_CssJs_Extension::is_enabled()

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -101,7 +101,40 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 							' Settings can be found on the %1$sUser Experience page%2$s.',
 							'w3-total-cache'
 						),
-						'<a href="' . Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#application' ) . '">',
+						'<a href="' . Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#defer-scripts' ) . '">',
+						'</a>'
+					),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				)
+				: ''
+			),
+			'label_class'    => 'w3tc_single_column',
+			'pro'            => true,
+			'disabled'       => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+		)
+	);
+
+	Util_Ui::config_item_extension_enabled(
+		array(
+			'extension_id'   => 'user-experience-remove-cssjs',
+			'checkbox_label' => esc_html__( 'Remove Unwanted/Unused CSS/JS', 'w3-total-cache' ),
+			'description'    => __(
+				'Removes specfied CSS/JS tags from all pages or on a per page basis.',
+				'w3-total-cache'
+			) . (
+				UserExperience_Remove_CssJs_Extension::is_enabled()
+				? wp_kses(
+					sprintf(
+						// translators: 1 opening HTML a tag to W3TC User Experience page, 2 closing HTML a tag.
+						__(
+							' Settings can be found on the %1$sUser Experience page%2$s.',
+							'w3-total-cache'
+						),
+						'<a href="' . Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience#remove-cssjs' ) . '">',
 						'</a>'
 					),
 					array(

--- a/UserExperience_Plugin_Admin.php
+++ b/UserExperience_Plugin_Admin.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * File: UserExperience_Plugin_Admin.php
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
+/**
+ * UserExperience Plugin Admin.
+ */
 class UserExperience_Plugin_Admin {
 	/**
 	 * Runs the user experience feature.
@@ -17,7 +26,7 @@ class UserExperience_Plugin_Admin {
 	/**
 	 * Set user experience admin menu item.
 	 *
-	 * @param array $menu
+	 * @param array $menu Menu array.
 	 *
 	 * @return array
 	 */
@@ -35,13 +44,13 @@ class UserExperience_Plugin_Admin {
 	/**
 	 * Configures extensions for user experience.
 	 *
-	 * @param array $extensions
-	 * @param object $config
+	 * @param array  $extensions Extensions array.
+	 * @param object $config     Config object.
 	 *
 	 * @return array
 	 */
 	public static function w3tc_extensions( $extensions, $config ) {
-		$extensions['user-experience-defer-scripts'] = array(
+		$extensions['user-experience-defer-scripts']    = array(
 			'public'       => false,
 			'extension_id' => 'user-experience-defer-scripts',
 			'path'         => 'w3-total-cache/UserExperience_DeferScripts_Extension.php',
@@ -51,12 +60,17 @@ class UserExperience_Plugin_Admin {
 			'extension_id' => 'user-experience-preload-requests',
 			'path'         => 'w3-total-cache/UserExperience_Preload_Requests_Extension.php',
 		);
-		$extensions['user-experience-emoji'] = array(
+		$extensions['user-experience-remove-cssjs']     = array(
+			'public'       => false,
+			'extension_id' => 'user-experience-remove-cssjs',
+			'path'         => 'w3-total-cache/UserExperience_Remove_CssJs_Extension.php',
+		);
+		$extensions['user-experience-emoji']            = array(
 			'public'       => false,
 			'extension_id' => 'user-experience-emoji',
 			'path'         => 'w3-total-cache/UserExperience_Emoji_Extension.php',
 		);
-		$extensions['user-experience-oembed'] = array(
+		$extensions['user-experience-oembed']           = array(
 			'public'       => false,
 			'extension_id' => 'user-experience-oembed',
 			'path'         => 'w3-total-cache/UserExperience_OEmbed_Extension.php',

--- a/UserExperience_Preload_Requests_Extension.php
+++ b/UserExperience_Preload_Requests_Extension.php
@@ -50,7 +50,7 @@ class UserExperience_Preload_Requests_Extension {
 		add_filter( 'w3tc_save_options', array( $this, 'w3tc_save_options' ) );
 
 		// Renders the Preload Reqeusts settings metabox on the User Expereince advanced setting page.
-		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ) );
+		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 20 );
 
 		// This filter is documented in Generic_AdminActions_Default.php under the read_request method.
 		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
@@ -68,7 +68,9 @@ class UserExperience_Preload_Requests_Extension {
 	 * @return void
 	 */
 	public function w3tc_userexperience_page() {
-		include __DIR__ . '/UserExperience_Preload_Requests_Page_View.php';
+		if ( self::is_enabled() ) {
+			include __DIR__ . '/UserExperience_Preload_Requests_Page_View.php';
+		}
 	}
 
 	/**
@@ -143,7 +145,7 @@ class UserExperience_Preload_Requests_Extension {
 		foreach ( $preconnect as $url ) {
 			echo '<link rel="preconnect" href="' . esc_url( $url ) . '" crossorigin>';
 		}
-		
+
 		$dns_prefetch = $this->config->get_array( array( 'user-experience-preload-requests', 'dns-prefetch' ) );
 		foreach ( $dns_prefetch as $url ) {
 			echo '<link rel="dns-prefetch" href="' . esc_url( $url ) . '">';

--- a/UserExperience_Remove_CssJs_Extension.php
+++ b/UserExperience_Remove_CssJs_Extension.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * File: UserExperience_DeferScripts_Extension.php
+ * File: UserExperience_Remove_CssJs_Extension.php
  *
- * Controls the defer JS feature.
+ * Controls the Remove CSS/JS feature.
  *
- * @since 2.4.2
+ * @since 2.7.0
  *
  * @package W3TC
  */
@@ -12,11 +12,11 @@
 namespace W3TC;
 
 /**
- * UserExperience DeferScripts Extension.
+ * UserExperience Remove Css/Js Extension.
  *
- * @since 2.4.2
+ * @since 2.7.0
  */
-class UserExperience_DeferScripts_Extension {
+class UserExperience_Remove_CssJs_Extension {
 	/**
 	 * Config.
 	 *
@@ -32,33 +32,32 @@ class UserExperience_DeferScripts_Extension {
 	private $mutator;
 
 	/**
-	 * User Experience DeferScripts constructor.
+	 * User Experience Remove Css/Js constructor.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 */
 	public function __construct() {
 		$this->config = Dispatcher::config();
 	}
 
 	/**
-	 * Runs User Experience DeferScripts feature.
+	 * Runs User Experience Remove Css/Js feature.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @return void
 	 */
 	public function run() {
 		if ( ! Util_Environment::is_w3tc_pro( $this->config ) ) {
-			$this->config->set_extension_active_frontend( 'user-experience-defer-scripts', false );
+			$this->config->set_extension_active_frontend( 'user-experience-remove-cssjs', false );
 			return;
 		}
 
-		Util_Bus::add_ob_callback( 'lazyload', array( $this, 'ob_callback' ) );
+		Util_Bus::add_ob_callback( 'removecssjs', array( $this, 'ob_callback' ) );
 
-		add_filter( 'w3tc_minify_js_script_tags', array( $this, 'w3tc_minify_js_script_tags' ) );
 		add_filter( 'w3tc_save_options', array( $this, 'w3tc_save_options' ) );
 
-		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 11 );
+		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 12 );
 
 		/**
 		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
@@ -67,9 +66,9 @@ class UserExperience_DeferScripts_Extension {
 	}
 
 	/**
-	 * Processes the page content buffer to defer JS.
+	 * Processes the page content buffer to remove target CSS/JS.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @param string $buffer page content buffer.
 	 *
@@ -87,7 +86,7 @@ class UserExperience_DeferScripts_Extension {
 		);
 
 		$can_process = $this->can_process( $can_process );
-		$can_process = apply_filters( 'w3tc_deferscripts_can_process', $can_process );
+		$can_process = apply_filters( 'w3tc_remove_cssjs_can_process', $can_process );
 
 		// set reject reason in comment.
 		if ( $can_process['enabled'] ) {
@@ -97,7 +96,7 @@ class UserExperience_DeferScripts_Extension {
 		}
 
 		$buffer = str_replace(
-			'{w3tc_deferscripts_reject_reason}',
+			'{w3tc_remove_cssjs_reject_reason}',
 			$reject_reason,
 			$buffer
 		);
@@ -107,29 +106,19 @@ class UserExperience_DeferScripts_Extension {
 			return $buffer;
 		}
 
-		$this->mutator = new UserExperience_DeferScripts_Mutator( $this->config );
+		$this->mutator = new UserExperience_Remove_CssJs_Mutator( $this->config );
 
 		$buffer = $this->mutator->run( $buffer );
-
-		// embed lazyload script.
-		if ( $this->mutator->content_modified() ) {
-			$buffer = apply_filters( 'w3tc_deferscripts_embed_script', $buffer );
-
-			$is_embed_script = apply_filters( 'w3tc_deferscripts_is_embed_script', true );
-			if ( $is_embed_script ) {
-				$buffer = $this->embed_script( $buffer );
-			}
-		}
 
 		return $buffer;
 	}
 
 	/**
-	 * Checks if the request can be processed for defer JS.
+	 * Checks if the request can be processed for remove CSS/JS.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
-	 * @param boolean $can_process flag representing if defer JS can be executed.
+	 * @param boolean $can_process flag representing if remove CSS/JS can be executed.
 	 *
 	 * @return boolean
 	 */
@@ -159,89 +148,36 @@ class UserExperience_DeferScripts_Extension {
 	}
 
 	/**
-	 * Adds defer JS message to W3TC footer comment.
+	 * Adds remove CSS/JS message to W3TC footer comment.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @param array $strings array of W3TC footer comments.
 	 *
 	 * @return array
 	 */
 	public function w3tc_footer_comment( $strings ) {
-		$strings[] = __( 'Defer Scripts', 'w3-total-cache' ) . '{w3tc_deferscripts_reject_reason}';
+		$strings[] = __( 'Remove CSS/JS', 'w3-total-cache' ) . '{w3tc_remove_cssjs_reject_reason}';
 		return $strings;
 	}
 
 	/**
-	 * Embeds the defer JS script in buffer.
+	 * Renders the user experience remove CSS/JS settings page.
 	 *
-	 * @since 2.4.2
-	 *
-	 * @param string $buffer page content buffer.
-	 *
-	 * @return string
-	 */
-	private function embed_script( $buffer ) {
-		$config_timeout = $this->config->get_integer(
-			array(
-				'user-experience-defer-scripts',
-				'timeout',
-			)
-		);
-
-		$content = file_get_contents( W3TC_DIR . '/UserExperience_DeferScripts_Script.js' );
-		$content = str_replace(
-			'{config_timeout}',
-			$config_timeout,
-			$content
-		);
-
-		$footer_script = '<script>' . $content . '</script>';
-
-		$buffer = preg_replace(
-			'~</body(\s+[^>]*)*>~Ui',
-			$footer_script . '\\0',
-			$buffer,
-			1
-		);
-
-		return $buffer;
-	}
-
-	/**
-	 * Filters script tags that are flaged as deferred. This is used to prevent Minify from touching scripts deferred by this feature.
-	 *
-	 * @since 2.4.2
-	 *
-	 * @param array $script_tags array of script tags.
-	 *
-	 * @return array
-	 */
-	public function w3tc_minify_js_script_tags( $script_tags ) {
-		if ( ! is_null( $this->mutator ) ) {
-			$script_tags = $this->mutator->w3tc_minify_js_script_tags( $script_tags );
-		}
-
-		return $script_tags;
-	}
-
-	/**
-	 * Renders the user experience defer JS settings page.
-	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @return void
 	 */
 	public function w3tc_userexperience_page() {
 		if ( self::is_enabled() ) {
-			include __DIR__ . '/UserExperience_DeferScripts_Page_View.php';
+			include __DIR__ . '/UserExperience_Remove_CssJs_Page_View.php';
 		}
 	}
 
 	/**
 	 * Specify config key typing for fields that need it.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @param mixed $descriptor Descriptor.
 	 * @param mixed $key Compound key array.
@@ -249,7 +185,7 @@ class UserExperience_DeferScripts_Extension {
 	 * @return array
 	 */
 	public function w3tc_config_key_descriptor( $descriptor, $key ) {
-		if ( is_array( $key ) && 'user-experience-defer-scripts.includes' === implode( '.', $key ) ) {
+		if ( is_array( $key ) && 'user-experience-remove-cssjs.includes' === implode( '.', $key ) ) {
 			$descriptor = array( 'type' => 'array' );
 		}
 
@@ -259,7 +195,7 @@ class UserExperience_DeferScripts_Extension {
 	/**
 	 * Performs actions on save.
 	 *
-	 * @since 2.4.2
+	 * @since 2.7.0
 	 *
 	 * @param array $data Array of save data.
 	 *
@@ -270,8 +206,8 @@ class UserExperience_DeferScripts_Extension {
 		$old_config = $data['old_config'];
 
 		if (
-			$new_config->get_array( array( 'user-experience-defer-scripts', 'timeout' ) ) !== $old_config->get_array( array( 'user-experience-defer-scripts', 'timeout' ) )
-			|| $new_config->get_array( array( 'user-experience-defer-scripts', 'includes' ) ) !== $old_config->get_array( array( 'user-experience-defer-scripts', 'includes' ) )
+			$new_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) ) !== $old_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) )
+			|| $new_config->get_array( 'user-experience-remove-cssjs-singles' ) !== $old_config->get_array( 'user-experience-remove-cssjs-singles' )
 		) {
 			$minify_enabled  = $this->config->get_boolean( 'minify.enabled' );
 			$pgcache_enabled = $this->config->get_boolean( 'pgcache.enabled' );
@@ -300,9 +236,9 @@ class UserExperience_DeferScripts_Extension {
 	public static function is_enabled() {
 		$config            = Dispatcher::config();
 		$extensions_active = $config->get_array( 'extensions.active' );
-		return Util_Environment::is_w3tc_pro( $config ) && array_key_exists( 'user-experience-defer-scripts', $extensions_active );
+		return Util_Environment::is_w3tc_pro( $config ) && array_key_exists( 'user-experience-remove-cssjs', $extensions_active );
 	}
 }
 
-$o = new UserExperience_DeferScripts_Extension();
+$o = new UserExperience_Remove_CssJs_Extension();
 $o->run();

--- a/UserExperience_Remove_CssJs_Extension.php
+++ b/UserExperience_Remove_CssJs_Extension.php
@@ -205,10 +205,20 @@ class UserExperience_Remove_CssJs_Extension {
 		$new_config = $data['new_config'];
 		$old_config = $data['old_config'];
 
-		if (
-			$new_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) ) !== $old_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) )
-			|| $new_config->get_array( 'user-experience-remove-cssjs-singles' ) !== $old_config->get_array( 'user-experience-remove-cssjs-singles' )
-		) {
+		$old_cssjs_includes = $old_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) );
+		$old_cssjs_singles  = $old_config->get_array( 'user-experience-remove-cssjs-singles' );
+		$new_cssjs_includes = $new_config->get_array( array( 'user-experience-remove-cssjs', 'includes' ) );
+		$new_cssjs_singles  = $new_config->get_array( 'user-experience-remove-cssjs-singles' );
+
+		foreach ( $new_cssjs_singles as $url => $pages ) {
+			if ( is_string( $pages['includes'] ) ) {
+				$new_cssjs_singles[ $url ]['includes'] = Util_Environment::textarea_to_array( $pages['includes'] );
+			}
+		}
+
+		$new_config->set( 'user-experience-remove-cssjs-singles', $new_cssjs_singles );
+
+		if ( $new_cssjs_includes !== $old_cssjs_includes || $new_cssjs_singles !== $old_cssjs_singles ) {
 			$minify_enabled  = $this->config->get_boolean( 'minify.enabled' );
 			$pgcache_enabled = $this->config->get_boolean( 'pgcache.enabled' );
 			if ( $minify_enabled || $pgcache_enabled ) {

--- a/UserExperience_Remove_CssJs_Mutator.php
+++ b/UserExperience_Remove_CssJs_Mutator.php
@@ -121,11 +121,13 @@ class UserExperience_Remove_CssJs_Mutator {
 	private function is_content_included( $content ) {
 		global $wp;
 
-		// Always removes matched CSS/JS for all pages.
-		foreach ( $this->includes as $include ) {
-			if ( ! empty( $include ) ) {
-				if ( strpos( $content, $include ) !== false ) {
-					return true;
+		// Always removes matched CSS/JS for home page.
+		if ( is_front_page() ) {
+			foreach ( $this->includes as $include ) {
+				if ( ! empty( $include ) ) {
+					if ( strpos( $content, $include ) !== false ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/UserExperience_Remove_CssJs_Mutator.php
+++ b/UserExperience_Remove_CssJs_Mutator.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * File: UserExperience_Remove_CssJs_Mutator.php
+ *
+ * CSS/JS feature mutator for buffer processing.
+ *
+ * @since 2.7.0
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+/**
+ * UserExperience Remove CSS/JS Mutator.
+ *
+ * @since 2.7.0
+ */
+class UserExperience_Remove_CssJs_Mutator {
+	/**
+	 * Config.
+	 *
+	 * @var object
+	 */
+	private $config;
+
+	/**
+	 * Array of includes.
+	 *
+	 * @var array
+	 */
+	private $includes = array();
+
+	/**
+	 * Array of singles includes.
+	 *
+	 * @var array
+	 */
+	private $singles_includes = array();
+
+	/**
+	 * User Experience Remove CSS/JS Mutator constructor.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param object $config Config object.
+	 *
+	 * @return void
+	 */
+	public function __construct( $config ) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Runs User Experience Remove CSS/JS Mutator.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param string $buffer Buffer string containing browser output.
+	 *
+	 * @return string
+	 */
+	public function run( $buffer ) {
+		$r = apply_filters(
+			'w3tc_remove_cssjs_mutator_before',
+			array(
+				'buffer' => $buffer,
+			)
+		);
+
+		$buffer = $r['buffer'];
+
+		// Sets includes whose matches will be stripped site-wide.
+		$this->includes = $this->config->get_array(
+			array(
+				'user-experience-remove-cssjs',
+				'includes',
+			)
+		);
+
+		// Sets singles includes data whose matches will be removed on mated pages.
+		$this->singles_includes = $this->config->get_array( 'user-experience-remove-cssjs-singles' );
+
+		$buffer = preg_replace_callback(
+			'~<link.*?href.*?/>~is',
+			array(
+				$this,
+				'remove_styles',
+			),
+			$buffer
+		);
+
+		$buffer = preg_replace_callback(
+			'~<script.*?src.*?<\/script>~is',
+			array(
+				$this,
+				'remove_scripts',
+			),
+			$buffer
+		);
+
+		return $buffer;
+	}
+
+	/**
+	 * Removes style tag for style matched to be removed.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param array $matches array of matched CSS entries.
+	 *
+	 * @return string
+	 */
+	public function remove_styles( $matches ) {
+		$content = $matches[0];
+
+		if ( is_main_query() && $this->is_content_included( $content ) ) {
+			$count   = 0;
+			$content = preg_replace(
+				'~<link.*?href.*?/>~is',
+				'',
+				$content,
+				-1,
+				$count
+			);
+
+			if ( $count > 0 ) {
+				$this->modified = true;
+			}
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Removes script tag for script matched to be removed.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param array $matches array of matched JS entries.
+	 *
+	 * @return string
+	 */
+	public function remove_scripts( $matches ) {
+		$content = $matches[0];
+
+		if ( is_main_query() && $this->is_content_included( $content ) ) {
+			$count   = 0;
+			$content = preg_replace(
+				'~<script.*?src.*?<\/script>~is',
+				'',
+				$content,
+				-1,
+				$count
+			);
+
+			if ( $count > 0 ) {
+				$this->modified = true;
+			}
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Checks if content has already been removed.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param string $content script tag string.
+	 *
+	 * @return boolean
+	 */
+	private function is_content_included( $content ) {
+		global $wp;
+
+		// Always removes matched CSS/JS for all pages.
+		foreach ( $this->includes as $include ) {
+			if ( ! empty( $include ) ) {
+				if ( strpos( $content, $include ) !== false ) {
+					return true;
+				}
+			}
+		}
+
+		// Only removes matched CSS/JS on matching pages.
+		foreach ( $this->singles_includes as $include => $pages ) {
+			if ( ! empty( $pages ) && in_array( ) ) {
+				foreach ( $pages as $page ) {
+					if ( home_url( $wp->request ) === $page && strpos( $content, $include ) !== false ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/UserExperience_Remove_CssJs_Page_View.js
+++ b/UserExperience_Remove_CssJs_Page_View.js
@@ -31,17 +31,17 @@ jQuery(function() {
 						'<li id="remove_cssjs_singles_' + single + '">' +
 						'<table class="form-table">' +
 						'<tr>' +
-						'<th>CSS/JS Path:</th>' +
+						'<th>CSS/JS path to remove:</th>' +
 						'<td>' +
 						'<span class="remove_cssjs_singles_path">' + single + '</span> ' +
 						'<input type="button" class="button w3tc_remove_cssjs_singles_delete" value="Delete" />' +
 						'</td>' +
 						'</tr>' +
 						'<tr>' +
-						'<th><label for="remove_cssjs_singles_' + single + '_includes">Pages to remove on:</label></th>' +
+						'<th><label for="remove_cssjs_singles_' + single + '_includes">Remove on these pages:</label></th>' +
 						'<td>' +
-						'<textarea id="remove_cssjs_singles_' + single + '_includes" name="user-experience-remove-cssjs-singles[' + single + '][includes]" rows="10" cols="50"></textarea>' +
-						'<p class="description">Specify page slugs that the above CSS/JS should be removed from. Include one entry per line.</p>' +
+						'<textarea id="remove_cssjs_singles_' + single + '_includes" name="user-experience-remove-cssjs-singles[' + single + '][includes]" rows="5" cols="50"></textarea>' +
+						'<p class="description">Specify relative/absolute page URLs that the above CSS/JS should be removed from. Include one entry per line.</p>' +
 						'</td>' +
 						'</tr>' +
 						'</table>' +

--- a/UserExperience_Remove_CssJs_Page_View.js
+++ b/UserExperience_Remove_CssJs_Page_View.js
@@ -1,0 +1,83 @@
+/**
+ * File: UserExperience_Remove_CssJs_Page_View.js
+ *
+ * @since 2.7.0
+ *
+ * @package W3TC
+ */
+
+jQuery(function() {
+	jQuery(document).on(
+		'click',
+		'#w3tc_remove_cssjs_singles_add',
+		function() {
+			var single = prompt('Enter CSS/JS URL.');
+
+			if (single !== null) {
+				var exists = false;
+
+				jQuery('.remove_cssjs_singles_path').each(
+					function() {
+						if (jQuery(this).html() == single) {
+							alert('Entry already exists!');
+							exists = true;
+							return false;
+						}
+					}
+				);
+
+				if (!exists) {
+					var li = jQuery(
+						'<li id="remove_cssjs_singles_' + single + '">' +
+						'<table class="form-table">' +
+						'<tr>' +
+						'<th>CSS/JS Path:</th>' +
+						'<td>' +
+						'<span class="remove_cssjs_singles_path">' + single + '</span> ' +
+						'<input type="button" class="button w3tc_remove_cssjs_singles_delete" value="Delete" />' +
+						'</td>' +
+						'</tr>' +
+						'<tr>' +
+						'<th><label for="remove_cssjs_singles_' + single + '_includes">Pages to remove on:</label></th>' +
+						'<td>' +
+						'<textarea id="remove_cssjs_singles_' + single + '_includes" name="user-experience-remove-cssjs-singles[' + single + '][includes]" rows="10" cols="50"></textarea>' +
+						'<p class="description">Specify page slugs that the above CSS/JS should be removed from. Include one entry per line.</p>' +
+						'</td>' +
+						'</tr>' +
+						'</table>' +
+						'</li>'
+					);
+
+					jQuery('#remove_cssjs_singles').append(li);
+					w3tc_remove_cssjs_singles_clear();
+					window.location.hash = '#remove_cssjs_singles_' + single;
+					li.find('textarea').focus();
+				}
+			} else {
+				alert('Empty CSS/JS URL!');
+			}
+		}
+	);
+
+	jQuery(document).on(
+		'click',
+		'.w3tc_remove_cssjs_singles_delete',
+		function () {
+			if (confirm('Are you sure want to delete this entry?')) {
+				jQuery(this).parents('#remove_cssjs_singles li').remove();
+				w3tc_remove_cssjs_singles_clear();
+				w3tc_beforeupload_bind();
+			}
+		}
+	);
+
+	w3tc_remove_cssjs_singles_clear();
+});
+
+function w3tc_remove_cssjs_singles_clear() {
+	if (!jQuery('#remove_cssjs_singles li').length) {
+		jQuery('#remove_cssjs_singles_empty').show();
+	} else {
+		jQuery('#remove_cssjs_singles_empty').hide();
+	}
+}

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * File: UserExperience_Remove_CssJs_Page_View.php
+ *
+ * Renders the remove CSS/JS setting block on the UserExperience advanced settings page.
+ *
+ * @since 2.4.2
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+if ( ! defined( 'W3TC' ) ) {
+	die();
+}
+
+$c = Dispatcher::config();
+
+$remove_cssjs_singles = array(
+	'value' => $c->get_array( 'user-experience-remove-cssjs-singles' ),
+);
+
+Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Everywhere', 'w3-total-cache' ), '', 'remove-cssjs' );
+?>
+<p>
+	<?php esc_html_e( 'CSS/JS entries added to the below textarea will be removed from all pages if present.', 'w3-total-cache' ); ?>
+</p>
+<table class="form-table">
+	<?php
+	Util_Ui::config_item(
+		array(
+			'key'         => array( 'user-experience-remove-cssjs', 'includes' ),
+			'label'       => esc_html__( 'Remove list:', 'w3-total-cache' ),
+			'control'     => 'textarea',
+			'description' => esc_html__( 'Specify URLs that should be removed. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+		)
+	);
+
+	?>
+</table>
+<?php
+Util_Ui::postbox_footer();
+
+Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cache' ), '', 'remove-cssjs-singles' );
+?>
+<p>
+	<?php esc_html_e( 'Use this area to manage individual CSS/JS entries. Defined CSS/JS URLs will include a textarea indicating which pages the given entry should be removed from.', 'w3-total-cache' ); ?>
+</p>
+<p>
+	<input id="w3tc_remove_cssjs_singles_add" type="button" class="button" value="<?php esc_html_e( 'Add', 'w3-total-cache' ); ?>" />
+</p>
+<ul id="remove_cssjs_singles" class="w3tc_remove_cssjs_singles">
+	<?php
+	foreach ( $remove_cssjs_singles['value'] as $single => $single_config ) {
+		?>
+		<li id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>">
+			<table class="form-table">
+				<tr>
+					<th>
+						<?php esc_html_e( 'CSS/JS Path:', 'w3-total-cache' ); ?>
+					</th>
+					<td>
+						<span class="remove_cssjs_singles_path"><?php echo htmlspecialchars( $single ); // phpcs:ignore ?></span>
+						<input type="button" class="button w3tc_remove_cssjs_singles_delete" value="<?php esc_html_e( 'Delete', 'w3-total-cache' ); ?>"/>
+					</td>
+				</tr>
+					<tr>
+					<th>
+						<label for="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes">
+							<?php esc_html_e( 'Pages to remove on:', 'w3-total-cache' ); ?>
+						</label>
+					</th>
+					<td>
+						<textarea id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes" name="user-experience-remove-cssjs-singles[<?php echo esc_attr( $single ); ?>][includes]" rows="10" cols="50" ><?php echo esc_textarea( implode( "\r\n", (array) $single_config['includes'] ) ); ?></textarea>
+						<p class="description">
+							<?php esc_html_e( 'Specify page slugs that the above CSS/JS should be removed from. Include one entry per line.', 'w3-total-cache' ); ?>
+						</p>
+					</td>
+				</tr>
+			</table>
+		</li>
+		<?php
+	}
+	?>
+</ul>
+<div id="remove_cssjs_singles_empty" style="display: none;"><?php esc_html_e( 'No CSS/JS removal entires added.', 'w3-total-cache' ); ?></div>
+<?php
+Util_Ui::postbox_footer();

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -21,10 +21,10 @@ $remove_cssjs_singles = array(
 	'value' => $c->get_array( 'user-experience-remove-cssjs-singles' ),
 );
 
-Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Everywhere', 'w3-total-cache' ), '', 'remove-cssjs' );
+Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cache' ), '', 'remove-cssjs' );
 ?>
 <p>
-	<?php esc_html_e( 'CSS/JS entries added to the below textarea will be removed from all pages if present.', 'w3-total-cache' ); ?>
+	<?php esc_html_e( 'CSS/JS entries added to the below textarea will be removed from the homepage if present.', 'w3-total-cache' ); ?>
 </p>
 <table class="form-table">
 	<?php

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -58,7 +58,7 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 			<table class="form-table">
 				<tr>
 					<th>
-						<?php esc_html_e( 'CSS/JS Path:', 'w3-total-cache' ); ?>
+						<?php esc_html_e( 'CSS/JS path to remove:', 'w3-total-cache' ); ?>
 					</th>
 					<td>
 						<span class="remove_cssjs_singles_path"><?php echo htmlspecialchars( $single ); // phpcs:ignore ?></span>
@@ -68,13 +68,13 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 					<tr>
 					<th>
 						<label for="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes">
-							<?php esc_html_e( 'Pages to remove on:', 'w3-total-cache' ); ?>
+							<?php esc_html_e( 'Remove on these pages:', 'w3-total-cache' ); ?>
 						</label>
 					</th>
 					<td>
-						<textarea id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes" name="user-experience-remove-cssjs-singles[<?php echo esc_attr( $single ); ?>][includes]" rows="10" cols="50" ><?php echo esc_textarea( implode( "\r\n", (array) $single_config['includes'] ) ); ?></textarea>
+						<textarea id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes" name="user-experience-remove-cssjs-singles[<?php echo esc_attr( $single ); ?>][includes]" rows="5" cols="50" ><?php echo esc_textarea( implode( "\r\n", (array) $single_config['includes'] ) ); ?></textarea>
 						<p class="description">
-							<?php esc_html_e( 'Specify page slugs that the above CSS/JS should be removed from. Include one entry per line.', 'w3-total-cache' ); ?>
+							<?php esc_html_e( 'Specify relative/absolute page URLs that the above CSS/JS should be removed from. Include one entry per line.', 'w3-total-cache' ); ?>
 						</p>
 					</td>
 				</tr>

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1857,11 +1857,16 @@ class Util_Ui {
 					$subnav_links = array( '<a href="#lazy-loading">' . esc_html__( 'Lazy Loading', 'w3-total-cache' ) . '</a>' );
 
 					if ( UserExperience_DeferScripts_Extension::is_enabled() ) {
-						$subnav_links[] = '<a href="#application">' . esc_html__( 'Delay Scripts', 'w3-total-cache' ) . '</a>';
+						$subnav_links[] = '<a href="#defer-scripts">' . esc_html__( 'Delay Scripts', 'w3-total-cache' ) . '</a>';
+					}
+
+					if ( UserExperience_Remove_CssJs_Extension::is_enabled() ) {
+						$subnav_links[] = '<a href="#remove-cssjs">' . esc_html__( 'Remove CSS/JS - All', 'w3-total-cache' ) . '</a>';
+						$subnav_links[] = '<a href="#remove-cssjs-singles">' . esc_html__( 'Remove CSS/JS - Singles', 'w3-total-cache' ) . '</a>';
 					}
 
 					if ( UserExperience_Preload_Requests_Extension::is_enabled() ) {
-						$subnav_links[] = '<a href="#application">' . esc_html__( 'Preload Requests', 'w3-total-cache' ) . '</a>';
+						$subnav_links[] = '<a href="#preload-requests">' . esc_html__( 'Preload Requests', 'w3-total-cache' ) . '</a>';
 					}
 
 					// If there's only 1 meta box on the page, no need for nav links.

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1861,7 +1861,7 @@ class Util_Ui {
 					}
 
 					if ( UserExperience_Remove_CssJs_Extension::is_enabled() ) {
-						$subnav_links[] = '<a href="#remove-cssjs">' . esc_html__( 'Remove CSS/JS - All', 'w3-total-cache' ) . '</a>';
+						$subnav_links[] = '<a href="#remove-cssjs">' . esc_html__( 'Remove CSS/JS - Homepage', 'w3-total-cache' ) . '</a>';
 						$subnav_links[] = '<a href="#remove-cssjs-singles">' . esc_html__( 'Remove CSS/JS - Singles', 'w3-total-cache' ) . '</a>';
 					}
 

--- a/inc/options/common/footer.php
+++ b/inc/options/common/footer.php
@@ -73,8 +73,14 @@ do_action( 'w3tc-dashboard-footer' );
 				<a class="w3tc-footer-link" target="_blank" href="<?php echo esc_url( 'https://www.boldgrid.com/support/w3-total-cache/delay-scripts-tool/' ); ?>" alt="<?php esc_attr_e( 'Delay Scripts', 'w3-total-cache' ); ?>">
 					<?php esc_html_e( 'Delay Scripts', 'w3-total-cache' ); ?>
 				</a>
+				<a class="w3tc-footer-link" target="_blank" href="<?php echo esc_url( 'https://www.boldgrid.com/support/w3-total-cache/preload-requests/' ); ?>" alt="<?php esc_attr_e( 'Preload Requests', 'w3-total-cache' ); ?>">
+					<?php esc_html_e( 'Preload Requests', 'w3-total-cache' ); ?>
+				</a>
 			</div>
 			<div class="w3tc-footer-inner-column-50">
+				<a class="w3tc-footer-link" target="_blank" href="<?php echo esc_url( 'https://www.boldgrid.com/support/w3-total-cache/remove-cssjs/' ); ?>" alt="<?php esc_attr_e( 'Remove CSS/JS', 'w3-total-cache' ); ?>">
+					<?php esc_html_e( 'Remove CSS/JS', 'w3-total-cache' ); ?>
+				</a>
 				<a class="w3tc-footer-link" target="_blank" href="<?php echo esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-lazy-loading-for-your-wordpress-website-with-w3-total-cache/' ); ?>" alt="<?php esc_attr_e( 'Lazy Load Google Maps', 'w3-total-cache' ); ?>">
 					<?php esc_html_e( 'Lazy Load Google Maps', 'w3-total-cache' ); ?>
 				</a>

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -297,16 +297,19 @@ textarea.w3tc-error {
 #mobile_groups th,
 #referrer_groups th,
 .w3tc_cachegroups th,
+.w3tc_remove_cssjs_singles th,
 #mobile_groups td,
 #referrer_groups td,
 .w3tc_cachegroups td,
+.w3tc_remove_cssjs_singles td,
 #cachegroups_form .form-table th {
 	padding: 10px 10px 10px 15px;
 }
 
 #mobile_groups li,
 #referrer_groups li,
-.w3tc_cachegroups li {
+.w3tc_cachegroups li,
+.w3tc_remove_cssjs_singles li {
 	cursor: ns-resize;
 	list-style: none;
 	background: #f9f9f9;
@@ -318,13 +321,15 @@ textarea.w3tc-error {
 
 #mobile_groups li:hover,
 #referrer_groups li:hover,
-.w3tc_cachegroups li:hover {
+.w3tc_cachegroups li:hover,
+.w3tc_remove_cssjs_singles li:hover {
 	background: #f5f5f5;
 }
 
 #mobile_groups li table,
 #referrer_groups li table,
-.w3tc_cachegroups li table {
+.w3tc_cachegroups li table,
+.w3tc_remove_cssjs_singles li table {
 	margin: 0;
 }
 

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -319,6 +319,10 @@ textarea.w3tc-error {
 	-moz-border-radius: 8px;
 }
 
+.w3tc_remove_cssjs_singles li {
+	cursor: default;
+}
+
 #mobile_groups li:hover,
 #referrer_groups li:hover,
 .w3tc_cachegroups li:hover,

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -311,7 +311,7 @@ textarea.w3tc-error {
 .w3tc_cachegroups li,
 .w3tc_remove_cssjs_singles li {
 	cursor: ns-resize;
-	list-style: none;
+	list-style: none !important;
 	background: #f9f9f9;
 	margin-bottom: 1em;
 	border-radius: 8px;


### PR DESCRIPTION
To test, navigate to the _General Settings -> User Experience_ and enable the _Remove Unwanted/Unused CSS/JS_ option. Then navigate to the _User Experience_ settings page where you should see 2 new metabox sections labeled _Remove CSS/JS Everywhere_ and _Remove CSS/JS Individually_.

The _Remove CSS/JS Everywhere_ is very simple in that you define relative/absolute file paths for CSS/JS that you wish to remove site-wide. These match on partial so it could be as simple as the file name

The _Remove CSS/JS Individually_ functions similarly to the cache groups in that you click the Add button and define a target CSS/JS file path you wish to remove. Once created it should focus on a textarea where you can define relative/absolute page/post URLs that the target CSS/JS file will be removed from. This too matches on partial so the target CSS/JS path can just be the file name but the pages/posts should be the full relative or absolute path.