### PR TITLE
Fix Nginx feature and permission policy header syntax

### DIFF
--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -344,11 +344,11 @@ class BrowserCache_Environment_Nginx {
 				}
 
 				if ( ! empty( $feature_v ) ) {
-					$rules[] = '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
+					$rules[] = 'add_header Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
 				}
 
 				if ( ! empty( $permission_v ) ) {
-					$rules[] = '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
+					$rules[] = 'add_header Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
 				}
 			}
 		}


### PR DESCRIPTION
See https://wordpress.org/support/topic/feature-policy-permissions-policy-issue-with-nginx/

To test, set the `Feature-Policy` and `Permissions-Policy` headers in the Browser Cache Security Headers section (`wp-admin/admin.php?page=w3tc_browsercache`) when using Nginx as a web server.  Review the generated "nginx.conf" file in the WordPress ABSPATH directory.
