### PR TITLE
Fix CloudFront purge button

### DIFF
--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -97,8 +97,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 				<p>
 					<?php
 					$cdn_purge_button        = $can_purge ?
-						'<input id="cdn_purge" class="button {nonce: ' . esc_attr( wp_create_nonce( 'w3tc' ) ) .
-							'}" type="button" value="Purge" /> objects from the <acronym title="Content Delivery Network">CDN</acronym>' :
+						'<input id="cdn_purge" class="button {nonce: \'' . esc_attr( wp_create_nonce( 'w3tc' ) ) .
+							'\'}" type="button" value="Purge" /> objects from the <acronym title="Content Delivery Network">CDN</acronym>' :
 						'';
 					$cdn_mirror_purge_button = $cdn_mirror_purge_all ?
 						( $can_purge ? ' or ' : '' ) . '<input class="button" type="submit" name="w3tc_flush_cdn" value="purge CDN completely" />' :

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -87,7 +87,13 @@ require W3TC_INC_DIR . '/options/common/header.php';
 						'acronym' => array(
 							'title' => array(),
 						),
-					)
+						'input'   => array(
+							'class' => array(),
+							'id'    => array(),
+							'type'  => array(),
+							'value' => array(),
+						),
+					),
 				);
 				?>
 			</p>


### PR DESCRIPTION
To test:
1. Configure Amazon CloudFront as a CDN for objects.
2. Go to `wp-admin/admin.php?page=w3tc_cdn`
3. Click the "Purge" button.
4. See a popup modal.
