### PR TITLE
Fixes an uncaught type error on the Install page.

### DIFF
--- a/Generic_Page_Install.php
+++ b/Generic_Page_Install.php
@@ -18,6 +18,7 @@ class Generic_Page_Install extends Base_Page_Settings {
 	 */
 	function view() {
 		$rewrite_rules_descriptors = array();
+		$other_areas = array();
 
 		if ( Util_Rule::can_check_rules() ) {
 			$e = Dispatcher::component( 'Root_Environment' );


### PR DESCRIPTION
When `Util_Rule::can_check_rules()` returns `false` (as it does on the Caddy web server,) `$other_areas` is left undefined which causes an uncaught type error on https://github.com/BoldGrid/w3-total-cache/blob/f043f6eb1d4c3a8327b8c63867a4d37296c94dff/inc/options/install.php#L281

This change has `$other_areas` behave the same as `$rewrite_rules_descriptors`.