### PR TITLE
Small fix for config save split button missing ID attribute

### DIFF
--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -302,7 +302,7 @@ class Util_Ui {
 			<?php
 			if ( ! is_network_admin() ) {
 				?>
-				<input type="submit" class="w3tc-button-save btn btn-primary btn-sm" name="w3tc_save_options" value="<?php esc_html_e( 'Save Settings', 'w3-total-cache' ); ?>"/>
+				<input type="submit" id="<?php echo esc_attr( $b1_id ); ?>" class="w3tc-button-save btn btn-primary btn-sm" name="w3tc_save_options" value="<?php esc_html_e( 'Save Settings', 'w3-total-cache' ); ?>"/>
 				<button type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 					<span class="sr-only">Toggle Dropdown</span>
 				</button>


### PR DESCRIPTION
On general settings page, the Save Settings button was missing the ID attribute due to the code not applying the $b1_id as the ID. This simple PR addresses that. Testing the save appears to work and no obvious functionality or CSS issues occur as a result of the added ID