### PR TITLE
Fixed exentions count(s) on Extensions page

### DIFF
--- a/Extensions_Page.php
+++ b/Extensions_Page.php
@@ -55,7 +55,19 @@ class Extensions_Page extends Base_Page_Settings {
 			$sub_view = 'settings';
 		} else {
 			$extensions_all = Extensions_Util::get_extensions( $this->_config );
+			foreach ( $extensions_all as $key => $extension ) {
+				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
+					unset( $extensions_all[ $key ] );
+				}
+			}
+
 			$extensions_inactive = Extensions_Util::get_inactive_extensions( $this->_config );
+			foreach ( $extensions_inactive as $key => $extension ) {
+				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
+					unset( $extensions_inactive[ $key ] );
+				}
+			}
+
 			$var = "extensions_{$extension_status}";
 			$extensions = $$var;
 			$extension_keys = array_keys($extensions);
@@ -65,7 +77,9 @@ class Extensions_Page extends Base_Page_Settings {
 			$page = 1;
 		}
 
-		$config = Dispatcher::config();
+		Util_Debug::debug('extensions_all',$extensions_all);
+		Util_Debug::debug('extensions_inactive',$extensions_inactive);
+
 		include W3TC_INC_OPTIONS_DIR . '/extensions.php';
 	}
 

--- a/Extensions_Page.php
+++ b/Extensions_Page.php
@@ -48,11 +48,11 @@ class Extensions_Page extends Base_Page_Settings {
 		$view       = ( ! empty( $action_val ) && 'view' === $action_val );
 
 		$extensions_active = Extensions_Util::get_active_extensions( $this->_config );
-			foreach ( $extensions_active as $key => $extension ) {
-				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
-					unset( $extensions_active[ $key ] );
-				}
+		foreach ( $extensions_active as $key => $extension ) {
+			if ( isset( $extension['public'] ) && false === $extension['public'] ) {
+				unset( $extensions_active[ $key ] );
 			}
+		}
 
 		if ( $extension && $view ) {
 			$all_settings = $this->_config->get_array( 'extensions.settings' );
@@ -61,14 +61,14 @@ class Extensions_Page extends Base_Page_Settings {
 		} else {
 			$extensions_all = Extensions_Util::get_extensions( $this->_config );
 			foreach ( $extensions_all as $key => $extension ) {
-				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
+				if ( isset( $extension['public'] ) && false === $extension['public'] ) {
 					unset( $extensions_all[ $key ] );
 				}
 			}
 
 			$extensions_inactive = Extensions_Util::get_inactive_extensions( $this->_config );
 			foreach ( $extensions_inactive as $key => $extension ) {
-				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
+				if ( isset( $extension['public'] ) && false === $extension['public'] ) {
 					unset( $extensions_inactive[ $key ] );
 				}
 			}

--- a/Extensions_Page.php
+++ b/Extensions_Page.php
@@ -38,48 +38,45 @@ class Extensions_Page extends Base_Page_Settings {
 			}
 		}
 
-		$extension     = '';
 		$extension_val = Util_Request::get_string( 'extension' );
-		if ( ! empty( $extension_val ) ) {
-			$extension = esc_attr( $extension_val );
-		}
+		$extension     = ( ! empty( $extension_val ) ? esc_attr( $extension_val ) : '' );
 
 		$action_val = Util_Request::get_string( 'action' );
 		$view       = ( ! empty( $action_val ) && 'view' === $action_val );
 
 		$extensions_active = Extensions_Util::get_active_extensions( $this->_config );
-		foreach ( $extensions_active as $key => $extension ) {
-			if ( isset( $extension['public'] ) && false === $extension['public'] ) {
+		foreach ( $extensions_active as $key => $ext ) {
+			if ( isset( $ext['public'] ) && false === $ext['public'] ) {
 				unset( $extensions_active[ $key ] );
 			}
 		}
 
 		if ( $extension && $view ) {
 			$all_settings = $this->_config->get_array( 'extensions.settings' );
-			$meta = $extensions_active[$extension];
-			$sub_view = 'settings';
+			$meta         = $extensions_active[ $extension ];
+			$sub_view     = 'settings';
 		} else {
 			$extensions_all = Extensions_Util::get_extensions( $this->_config );
-			foreach ( $extensions_all as $key => $extension ) {
-				if ( isset( $extension['public'] ) && false === $extension['public'] ) {
+			foreach ( $extensions_all as $key => $ext ) {
+				if ( isset( $ext['public'] ) && false === $ext['public'] ) {
 					unset( $extensions_all[ $key ] );
 				}
 			}
 
 			$extensions_inactive = Extensions_Util::get_inactive_extensions( $this->_config );
-			foreach ( $extensions_inactive as $key => $extension ) {
-				if ( isset( $extension['public'] ) && false === $extension['public'] ) {
+			foreach ( $extensions_inactive as $key => $ext ) {
+				if ( isset( $ext['public'] ) && false === $ext['public'] ) {
 					unset( $extensions_inactive[ $key ] );
 				}
 			}
 
-			$var = "extensions_{$extension_status}";
-			$extensions = $$var;
-			$extension_keys = array_keys($extensions);
-			sort($extension_keys);
+			$var            = "extensions_{$extension_status}";
+			$extensions     = $$var;
+			$extension_keys = array_keys( $extensions );
+			sort( $extension_keys );
 
 			$sub_view = 'list';
-			$page = 1;
+			$page     = 1;
 		}
 
 		include W3TC_INC_OPTIONS_DIR . '/extensions.php';

--- a/Extensions_Page.php
+++ b/Extensions_Page.php
@@ -48,7 +48,6 @@ class Extensions_Page extends Base_Page_Settings {
 		$view       = ( ! empty( $action_val ) && 'view' === $action_val );
 
 		$extensions_active = Extensions_Util::get_active_extensions( $this->_config );
-		$extensions_active = Extensions_Util::get_extensions( $this->_config );
 			foreach ( $extensions_active as $key => $extension ) {
 				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
 					unset( $extensions_active[ $key ] );

--- a/Extensions_Page.php
+++ b/Extensions_Page.php
@@ -48,6 +48,12 @@ class Extensions_Page extends Base_Page_Settings {
 		$view       = ( ! empty( $action_val ) && 'view' === $action_val );
 
 		$extensions_active = Extensions_Util::get_active_extensions( $this->_config );
+		$extensions_active = Extensions_Util::get_extensions( $this->_config );
+			foreach ( $extensions_active as $key => $extension ) {
+				if ( isset( $extension['public'] ) && $extension['public'] === false ) {
+					unset( $extensions_active[ $key ] );
+				}
+			}
 
 		if ( $extension && $view ) {
 			$all_settings = $this->_config->get_array( 'extensions.settings' );
@@ -76,9 +82,6 @@ class Extensions_Page extends Base_Page_Settings {
 			$sub_view = 'list';
 			$page = 1;
 		}
-
-		Util_Debug::debug('extensions_all',$extensions_all);
-		Util_Debug::debug('extensions_inactive',$extensions_inactive);
 
 		include W3TC_INC_OPTIONS_DIR . '/extensions.php';
 	}

--- a/inc/options/extensions/list.php
+++ b/inc/options/extensions/list.php
@@ -25,7 +25,7 @@ if ( ! defined( 'W3TC' ) ) {
 
 <div class="tablenav top">
 
-	<?php if ( ! $config->is_sealed( 'extensions.active' ) ) : ?>
+	<?php if ( ! $this->_config->is_sealed( 'extensions.active' ) ) : ?>
 		<div class="alignleft actions">
 			<select name="action">
 				<option value="-1" selected="selected"><?php esc_html_e( 'Bulk Actions', 'w3-total-cache' ); ?></option>
@@ -84,7 +84,7 @@ if ( ! defined( 'W3TC' ) ) {
 			do_action( "w3tc_extension_before_row-{$extension}" );
 
 			?>
-			<tr id="<?php echo esc_attr( $extension ); ?>" class="<?php echo $config->is_extension_active( $extension ) ? 'active' : 'inactive'; ?>">
+			<tr id="<?php echo esc_attr( $extension ); ?>" class="<?php echo $this->_config->is_extension_active( $extension ) ? 'active' : 'inactive'; ?>">
 				<th scope="row" class="check-column">
 					<label class="screen-reader-text" for="checkbox_<?php echo esc_attr( $cb_id ); ?>"><?php echo esc_html( sprintf( /* translators: 1 label for Extension select/deselect checkobox */ __( 'Select %1$s', 'w3-total-cache' ), $meta['name'] ) ); ?></label>
 					<input type="checkbox" name="checked[]" value="<?php echo esc_attr( $extension ); ?>" id="checkbox_<?php echo esc_attr( $cb_id ); ?>" class="w3tc_extensions_input_active" <?php disabled( ! $meta['enabled'] ); ?>>
@@ -93,7 +93,7 @@ if ( ! defined( 'W3TC' ) ) {
 					<strong><?php echo esc_html( $meta['name'] ); ?></strong>
 					<div class="row-actions-visible">
 						<?php
-						if ( $config->is_extension_active( $extension ) ) :
+						if ( $this->_config->is_extension_active( $extension ) ) :
 							$extra_links = array();
 
 							if ( isset( $meta['settings_exists'] ) && $meta['settings_exists'] ) {
@@ -125,7 +125,7 @@ if ( ! defined( 'W3TC' ) ) {
 
 							<span class="0"></span>
 
-							<?php if ( ! $config->is_sealed( 'extensions.active' ) ) : ?>
+							<?php if ( ! $this->_config->is_sealed( 'extensions.active' ) ) : ?>
 								<?php echo $links ? ' | ' : ''; ?>
 								<span class="deactivate">
 									<a href="<?php echo esc_url( wp_nonce_url( Util_Ui::admin_url( sprintf( 'admin.php?page=w3tc_extensions&action=deactivate&extension=%s&amp;extension_status=%s&amp;paged=%d', $extension, $extension_status, $page ) ), 'w3tc' ) ); ?>" title="<?php esc_attr_e( 'Deactivate this extension', 'w3-total-cache' ); ?> ">
@@ -136,7 +136,7 @@ if ( ! defined( 'W3TC' ) ) {
 						<?php else : ?>
 							<span class="activate">
 								<?php if ( $meta['enabled'] ) : ?>
-									<?php if ( ! $config->is_sealed( 'extensions.active' ) ) : ?>
+									<?php if ( ! $this->_config->is_sealed( 'extensions.active' ) ) : ?>
 										<a href="<?php echo esc_url( wp_nonce_url( Util_Ui::admin_url( sprintf( 'admin.php?page=w3tc_extensions&action=activate&extension=%s&amp;extension_status=%s&amp;paged=%d', $extension, $extension_status, $page ) ), 'w3tc' ) ); ?>" title="<?php esc_attr_e( 'Activate this extension', 'w3-total-cache' ); ?> ">
 											<?php esc_html_e( 'Activate' ); ?>
 										</a>
@@ -183,7 +183,7 @@ if ( ! defined( 'W3TC' ) ) {
 						</p>
 					</div>
 
-					<div class="<?php echo $config->is_extension_active( $extension ) ? 'active' : 'inactive'; ?> second plugin-version-author-uri">
+					<div class="<?php echo $this->_config->is_extension_active( $extension ) ? 'active' : 'inactive'; ?> second plugin-version-author-uri">
 						<?php
 						echo esc_html(
 							sprintf(
@@ -230,7 +230,7 @@ if ( ! defined( 'W3TC' ) ) {
 </table>
 <div class="tablenav bottom">
 
-	<?php if ( ! $config->is_sealed( 'extensions.active' ) ) : ?>
+	<?php if ( ! $this->_config->is_sealed( 'extensions.active' ) ) : ?>
 		<div class="alignleft actions">
 			<select name="action2">
 				<option value="-1" selected="selected"><?php esc_html_e( 'Bulk Actions', 'w3-total-cache' ); ?></option>


### PR DESCRIPTION
On the extensions page, the All, Active, and Inactive counts were incorrect due to internal non-public "extensions" being counted. This PR filters those out so the counts are correct on the extensions page