### PR TITLE
#793 Fix deprecation errors dynamic property assignment

### DIFF
--- a/UserExperience_LazyLoad_Mutator_Unmutable.php
+++ b/UserExperience_LazyLoad_Mutator_Unmutable.php
@@ -3,7 +3,7 @@ namespace W3TC;
 
 class UserExperience_LazyLoad_Mutator_Unmutable {
 	private $placeholders = array();
-
+	private $placeholder_base = '';
 
 
 	public function __construct() {

--- a/lib/Minify/Minify/CSS/Compressor.php
+++ b/lib/Minify/Minify/CSS/Compressor.php
@@ -49,6 +49,9 @@ class Minify_CSS_Compressor {
     protected $_inHack = false;
 
 
+	protected $_replacementHash = '';
+	protected $_placeholders = [];
+	
     /**
      * Constructor
      *

--- a/lib/Minify/Minify/CSS/Compressor.php
+++ b/lib/Minify/Minify/CSS/Compressor.php
@@ -50,7 +50,7 @@ class Minify_CSS_Compressor {
 
 
 	protected $_replacementHash = '';
-	protected $_placeholders = [];
+	protected $_placeholders = array();
 	
     /**
      * Constructor

--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -7,7 +7,12 @@ namespace W3TCL\Minify;
  */
 
 class Minify_Cache_File {
-
+	private $_path = null;
+	private $_exclude = null;
+	private $_locking = null;
+	private $_flushTimeLimit = null;
+	private $_flush_path = null;
+	
 	public function __construct($path = '', $exclude = array(), $locking = false, $flushTimeLimit = 0, $flush_path = null) {
 		if (! $path) {
 			$path = self::tmp();
@@ -243,11 +248,6 @@ class Minify_Cache_File {
 	public function getPath() {
 		return $this->_path;
 	}
-
-	private $_path = null;
-	private $_exclude = null;
-	private $_locking = null;
-	private $_flushTimeLimit = null;
 
 	/**
 	 * Returns size statistics about cache files

--- a/lib/Minify/Minify/HTML.php
+++ b/lib/Minify/Minify/HTML.php
@@ -23,6 +23,11 @@ class Minify_HTML {
 	 * @var boolean
 	 */
 	protected $_jsCleanComments = true;
+	
+	/**
+	 * @var string
+	 */
+	protected $_html = '';
 
 	/**
 	 * "Minify" an HTML page


### PR DESCRIPTION
Fixes a couple `Creation of dynamic property is deprecated` errors.

Question: Should the libs be fully updated instead of locally modified? If so, they should be moved to composer in my opinion. 
To keep impact low I chose to only fix the deprecation warnings for now.