### PR TITLE
Changed PageSpeed data to not be autoloaded

### DIFF
--- a/PageSpeed_Page.php
+++ b/PageSpeed_Page.php
@@ -155,7 +155,7 @@ class PageSpeed_Page {
 			} else {
 				$api_response['time']         = time();
 				$api_response['display_time'] = \current_time( 'M jS, Y g:ia', false );
-				update_option( 'w3tc_pagespeed_data_' . $encoded_url, wp_json_encode( $api_response ), 'yes' );
+				update_option( 'w3tc_pagespeed_data_' . $encoded_url, wp_json_encode( $api_response ), 'no' );
 			}
 		}
 

--- a/PageSpeed_Widget.php
+++ b/PageSpeed_Widget.php
@@ -174,7 +174,7 @@ class PageSpeed_Widget {
 			} else {
 				$api_response['time']         = time();
 				$api_response['display_time'] = \current_time( 'M jS, Y g:ia', false );
-				update_option( 'w3tc_pagespeed_data_' . $home_url, wp_json_encode( $api_response ), 'yes' );
+				update_option( 'w3tc_pagespeed_data_' . $home_url, wp_json_encode( $api_response ), 'no' );
 			}
 		}
 


### PR DESCRIPTION
This PR simply changes the PageSpeed data option to not autoload on WordPress startup. It should now only load on demand on pages that require it