### PR TITLE
Fix minify stats output and warnings

### DIFF
--- a/Minify_Plugin_Admin.php
+++ b/Minify_Plugin_Admin.php
@@ -263,10 +263,10 @@ class Minify_Plugin_Admin {
 			}
 
 			if ( isset( $v['size_used'] ) ) {
-				$a['size_used'] = $v['size_used'];
-				$a['size_items'] = $v['size_items'];
-				$a['size_compression_css'] = $v['size_compression_css'];
-				$a['size_compression_js'] = $v['size_compression_js'];
+				$a['size_used']            = $v['size_used'];
+				$a['size_items']           = empty( $v['size_items'] ) ? null : $v['size_items'];
+				$a['size_compression_css'] = empty( $v['size_compression_css'] ) ? null : $v['size_compression_css'];
+				$a['size_compression_js']  = empty( $v['size_compression_js'] ) ? null : $v['size_compression_js'];
 			}
 		}
 

--- a/UsageStatistics_Page.php
+++ b/UsageStatistics_Page.php
@@ -159,7 +159,7 @@ class UsageStatistics_Page {
 
 
 	public function summary_item( $id, $name, $checked = false, $extra_class = '', $column_background = '', $link_key = '' ) {
-		echo '<div class="ustats_' . esc_attr( $id ) . ' ' . esc_attr( $extra_class ) . '">\n';
+		echo '<div class="ustats_' . esc_attr( $id ) . ' ' . esc_attr( $extra_class ) . '"><br />';
 		echo '<label>';
 		echo '<input type="checkbox" name="' . esc_attr( 'w3tcus_chart_check_' . $id ) . '" data-name="' .
 			esc_attr( $name ) . '" data-column="' . esc_attr( $id ) . '" ';
@@ -172,11 +172,12 @@ class UsageStatistics_Page {
 		checked( $checked );
 		echo ' />';
 		if ( ! empty( $link_key ) ) {
-			echo '<a href="' . esc_url( 'admin.php?page=w3tc_stats&view=pagecache_requests&status=' . rawurlencode( $link_key ) . '&status_name=' . rawurlencode( $name ) ) . '">$name</a>';
+			echo '<a href="' . esc_url( 'admin.php?page=w3tc_stats&view=pagecache_requests&status=' . rawurlencode( $link_key ) .
+				'&status_name=' . rawurlencode( $name ) ) . '">' . esc_html( $name ) . '</a>';
 		} else {
 			echo esc_html( $name );
 		}
-		echo ": <span></span>\n";
+		echo ': <span></span><br />';
 
 		echo '</label>';
 		echo '</div>';


### PR DESCRIPTION
This fix resolves the following PHP warnings:
````
PHP Warning:  Undefined array key "size_items" in wp-content/plugins/w3-total-cache/Minify_Plugin_Admin.php on line 268
PHP Warning:  Undefined array key "size_compression_css" in wp-content/plugins/w3-total-cache/Minify_Plugin_Admin.php on line 269
PHP Warning:  Undefined array key "size_compression_js" in wp-content/plugins/w3-total-cache/Minify_Plugin_Admin.php on line 270
````

It also corrects bad output on the usage statistics page (`wp-admin/admin.php?page=w3tc_stats`).

To test:
Load the statistics page while tailing the error log (when enabled).
Enable usage statistics and load the Performance Dashboard and the usage statistics pages while tailing the error log.
The statistics page should not contain `\n` or `$name`.
