### PR TITLE
Feature Showcase New Cards Version Fix

### DIFF
--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -254,6 +254,7 @@ class FeatureShowcase_Plugin_Admin {
 						'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
 					'is_premium' => true,
 					'is_new'     => true,
+					'version'    => '2.7.0',
 				),
 				'preload-requests' => array(
 					'title'      => esc_html__( 'Preload Requests', 'w3-total-cache' ),
@@ -269,6 +270,7 @@ class FeatureShowcase_Plugin_Admin {
 						'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
 					'is_premium' => true,
 					'is_new'     => true,
+					'version'    => '2.6.1',
 				),
 				'defer-scripts'    => array(
 					'title'      => esc_html__( 'Delay Scripts', 'w3-total-cache' ),
@@ -284,6 +286,7 @@ class FeatureShowcase_Plugin_Admin {
 						'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
 					'is_premium' => true,
 					'is_new'     => true,
+					'version'    => '2.6.1',
 				),
 			),
 			'old' => array(

--- a/FeatureShowcase_Plugin_Admin_View.php
+++ b/FeatureShowcase_Plugin_Admin_View.php
@@ -44,7 +44,6 @@ foreach ( $cards_data as $card_type => $cards ) {
 		$card_classes  = 'w3tc-card';
 		$title_classes = 'w3tc-card-title';
 		$is_premium    = ! empty( $card['is_premium'] );
-		$is_new        = ! empty( $card['is_new'] );
 
 		if ( $is_premium ) {
 			$card_classes  .= ' w3tc-card-premium';
@@ -80,13 +79,13 @@ foreach ( $cards_data as $card_type => $cards ) {
 				</div><div class="w3tc-card-links"><?php echo $card['link']; ?></div>
 			</div>
 			<?php
-			if ( $is_new ) {
+			if ( ! empty( $card['is_new'] ) && ! empty( $card['version'] ) ) {
 				?>
 				<div class="w3tc-card-ribbon-new">
 					<span class="dashicons dashicons-awards"></span>
 					<b><?php esc_html_e( 'New', 'w3-total-cache' ); ?></b>
 					<span>
-						<?php esc_html_e( 'in', 'w3-total-cache' ); ?> W3 Total Cache Pro <?php echo W3TC_VERSION; ?>!
+						<?php esc_html_e( 'in', 'w3-total-cache' ); ?> W3 Total Cache <?php echo $card['version']; ?> !
 					</span>
 				</div>
 				<?php


### PR DESCRIPTION
This PR makes the "new" cards show a configured version number instead of defaulting to the current plugin version number. This will allow for accurately reflecting the version a feature was released