### PR TITLE
Fix issue with w3tc_processed_content filter

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -551,7 +551,6 @@ class Generic_Plugin {
 					'newrelic',
 					'cdn',
 					'browsercache',
-					//'pagecache',
 				),
 				$buffer
 			);

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -551,12 +551,18 @@ class Generic_Plugin {
 					'newrelic',
 					'cdn',
 					'browsercache',
-					'pagecache',
+					//'pagecache',
 				),
 				$buffer
 			);
 
 			$buffer = apply_filters( 'w3tc_processed_content', $buffer );
+
+			// Apply the w3tc_processed_content filter before pagecache callback.
+			$buffer = Util_Bus::do_ob_callbacks(
+				array( 'pagecache' ),
+				$buffer
+			);
 		}
 
 		return $buffer;


### PR DESCRIPTION
Without this PR change the w3tc_processed_content filter will not apply if PageCache is enabled

Add this to the theme's functions.php to test

`function modify_processed_content( $buffer ) {
    return $buffer . "
	/**
	 * test w3tc_processed_content filter 2
	 */
	";
}
add_filter( 'w3tc_processed_content', 'modify_processed_content' );`

This PR moves the do_obj_callback call for pagecache after the filter which appears to allow the filter to apply