### PR TITLE
PageCache Brotli & Gzip 

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -687,18 +687,23 @@ class PgCache_Environment {
 		$cache_path = str_replace( Util_Environment::document_root(), '', $cache_dir );
 
 		/**
-		 * Set Accept-Encoding
+		 * Set Accept-Encoding brotli
 		 */
 		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.brotli' ) ) {
 			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} br\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_br]\n";
 			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
 		}
+
+		/**
+		 * Set Accept-Encoding gzip
+		 */
 		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.compression' ) ) {
 			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} gzip\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_gzip]\n";
 			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
 		}
+
 		$rules .= "    RewriteCond %{HTTP_COOKIE} w3tc_preview [NC]\n";
 		$rules .= "    RewriteRule .* - [E=W3TC_PREVIEW:_preview]\n";
 		$env_W3TC_PREVIEW = '%{ENV:W3TC_PREVIEW}';

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -693,7 +693,8 @@ class PgCache_Environment {
 			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} br\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_br]\n";
 			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
-		} else if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.compression' ) ) {
+		}
+		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.compression' ) ) {
 			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} gzip\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_gzip]\n";
 			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -687,20 +687,20 @@ class PgCache_Environment {
 		$cache_path = str_replace( Util_Environment::document_root(), '', $cache_dir );
 
 		/**
-		 * Set Accept-Encoding brotli
-		 */
-		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.brotli' ) ) {
-			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} br\n";
-			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_br]\n";
-			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
-		}
-
-		/**
 		 * Set Accept-Encoding gzip
 		 */
 		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.compression' ) ) {
 			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} gzip\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_gzip]\n";
+			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
+		}
+
+		/**
+		 * Set Accept-Encoding brotli
+		 */
+		if ( $config->get_boolean( 'browsercache.enabled' ) && $config->get_boolean( 'browsercache.html.brotli' ) ) {
+			$rules .= "    RewriteCond %{HTTP:Accept-Encoding} br\n";
+			$rules .= "    RewriteRule .* - [E=W3TC_ENC:_br]\n";
 			$env_W3TC_ENC = '%{ENV:W3TC_ENC}';
 		}
 
@@ -1102,22 +1102,22 @@ class PgCache_Environment {
 		}
 
 		if ( $config->get_boolean( 'browsercache.enabled' ) &&
-			 $config->get_boolean( 'browsercache.html.brotli' ) ) {
+			$config->get_boolean( 'browsercache.html.compression' ) ) {
 			$rules .= "set \$w3tc_enc \"\";\n";
 
-			$rules .= "if (\$http_accept_encoding ~ br) {\n";
-			$rules .= "    set \$w3tc_enc _br;\n";
+			$rules .= "if (\$http_accept_encoding ~ gzip) {\n";
+			$rules .= "    set \$w3tc_enc _gzip;\n";
 			$rules .= "}\n";
 
 			$env_w3tc_enc = '$w3tc_enc';
 		}
 
 		if ( $config->get_boolean( 'browsercache.enabled' ) &&
-			$config->get_boolean( 'browsercache.html.compression' ) ) {
+			$config->get_boolean( 'browsercache.html.brotli' ) ) {
 			$rules .= "set \$w3tc_enc \"\";\n";
 
-			$rules .= "if (\$http_accept_encoding ~ gzip) {\n";
-			$rules .= "    set \$w3tc_enc _gzip;\n";
+			$rules .= "if (\$http_accept_encoding ~ br) {\n";
+			$rules .= "    set \$w3tc_enc _br;\n";
 			$rules .= "}\n";
 
 			$env_w3tc_enc = '$w3tc_enc';


### PR DESCRIPTION
This PR simply modifies the apache rules for PageCache so the Accept-Encoding applies for both brotli and gzip if both are enabled. Previously if both were enabled only brotli would apply