### PR TITLE
php8 deprecated and removed functions

### DIFF
--- a/ConfigDbStorage.php
+++ b/ConfigDbStorage.php
@@ -227,9 +227,11 @@ class _WpdbEssentials {
 				}
 			}
 		} else {
-			if ( WP_DEBUG ) {
+			if ( WP_DEBUG ) {                
+                //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_connectDeprecatedRemoved
 				$this->dbh = mysql_connect( $this->dbhost, $this->dbuser, $this->dbpassword, $new_link, $client_flags );
-			} else {
+			} else {                
+                //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_connectDeprecatedRemoved
 				$this->dbh = @mysql_connect( $this->dbhost, $this->dbuser, $this->dbpassword, $new_link, $client_flags );
 			}
 		}
@@ -251,6 +253,7 @@ class _WpdbEssentials {
 		if ( $this->use_mysqli ) {
 			$success = mysqli_select_db( $dbh, $db );
 		} else {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_select_dbDeprecatedRemoved
 			$success = mysql_select_db( $db, $dbh );
 		}
 		if ( ! $success ) {
@@ -290,6 +293,7 @@ class _WpdbEssentials {
 		if ( $this->use_mysqli ) {
 			return mysqli_real_escape_string( $this->dbh, $string );
 		} else {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_real_escape_stringDeprecatedRemoved
 			return mysql_real_escape_string( $string, $this->dbh );
 		}
 	}
@@ -327,6 +331,7 @@ class _WpdbEssentials {
 			}
 		} else {
 			if ( is_resource( $this->dbh ) ) {
+                //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_errorDeprecatedRemoved
 				$this->last_error = mysql_error( $this->dbh );
 			} else {
 				$this->last_error = 'query: Unable to retrieve the error message from MySQL';
@@ -343,11 +348,13 @@ class _WpdbEssentials {
 		$num_rows = 0;
 		$this->last_result = array();
 		if ( $this->use_mysqli && $this->result instanceof \mysqli_result ) {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_fetch_objectDeprecatedRemoved
 			while ( $row = mysqli_fetch_object( $this->result ) ) {
 				$this->last_result[$num_rows] = $row;
 				$num_rows++;
 			}
 		} elseif ( is_resource( $this->result ) ) {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_fetch_objectDeprecatedRemoved
 			while ( $row = mysql_fetch_object( $this->result ) ) {
 				$this->last_result[$num_rows] = $row;
 				$num_rows++;
@@ -366,6 +373,7 @@ class _WpdbEssentials {
 		if ( ! empty( $this->dbh ) && $this->use_mysqli ) {
 			$this->result = mysqli_query( $this->dbh, $query );
 		} elseif ( ! empty( $this->dbh ) ) {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_queryDeprecatedRemoved
 			$this->result = mysql_query( $query, $this->dbh );
 		}
 	}
@@ -380,6 +388,7 @@ class _WpdbEssentials {
 		if ( $this->use_mysqli ) {
 			$closed = mysqli_close( $this->dbh );
 		} else {
+            //phpcs:ignore PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved,PHPCompatibility.FunctionUse.RemovedFunctions.mysql_closeDeprecatedRemoved
 			$closed = mysql_close( $this->dbh );
 		}
 

--- a/extension-example/w3-total-cache-example.php
+++ b/extension-example/w3-total-cache-example.php
@@ -43,6 +43,7 @@ function w3tc_example_class_autoload( $class ) {
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			if ( !file_exists( $filename ) ) {
+                //phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 				debug_print_backtrace();
 			}
 		}

--- a/lib/Azure/GuzzleHttp/Promise/functions.php
+++ b/lib/Azure/GuzzleHttp/Promise/functions.php
@@ -219,6 +219,7 @@ function unwrap($promises)
 function all($promises)
 {
     $results = [];
+	//phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.eachDeprecatedRemoved
     return each(
         $promises,
         function ($value, $idx) use (&$results) {
@@ -253,7 +254,7 @@ function some($count, $promises)
 {
     $results = [];
     $rejections = [];
-
+	//phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.eachDeprecatedRemoved
     return each(
         $promises,
         function ($value, $idx, PromiseInterface $p) use (&$results, $count) {
@@ -309,7 +310,7 @@ function any($promises)
 function settle($promises)
 {
     $results = [];
-
+	//phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.eachDeprecatedRemoved
     return each(
         $promises,
         function ($value, $idx) use (&$results) {

--- a/lib/Azure/MicrosoftAzureStorage/Common/Internal/Utilities.php
+++ b/lib/Azure/MicrosoftAzureStorage/Common/Internal/Utilities.php
@@ -690,7 +690,7 @@ class Utilities
             (strlen($initializationVector) == 16), 
             sprintf(Resources::INVALID_STRING_LENGTH, 'initializationVector', '16')
         );
-        
+
         $blockCount = ceil(strlen($data) / 16);
     
         $ctrData = '';
@@ -706,7 +706,6 @@ class Utilities
                 $j--;
             } while (($digit == 0x100) && ($j >= 0));
         }
-    
         $encryptCtrData = mcrypt_encrypt(
             MCRYPT_RIJNDAEL_128, 
             $key, 

--- a/lib/Db/mssql.php
+++ b/lib/Db/mssql.php
@@ -534,7 +534,7 @@ class DbCache_WpdbBase extends \SQL_Translations {
 "/*/WP_I18N_DB_CONN_ERROR*/, $dbhost ), 'db_connect_fail' );
                         if ( defined( 'WP_SETUP_CONFIG' ) )
                             return;
-
+                        //phpcs:ignore PHPCompatibility.FunctionDeclarations.RemovedCallingDestructAfterConstructorExit.Found
                         die();
                 }
 
@@ -862,6 +862,7 @@ class DbCache_WpdbBase extends \SQL_Translations {
                 if ( is_null( $query ) ) {
                         return;
                 }
+                //phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
                 $this->prepare_args = func_get_args();
                 array_shift($this->prepare_args);
                 // If args were passed as an array (as in vsprintf), move them up

--- a/lib/Google/Http/REST.php
+++ b/lib/Google/Http/REST.php
@@ -126,7 +126,7 @@ class W3TCG_Google_Http_REST
     }
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;

--- a/lib/Google/Signer/P12.php
+++ b/lib/Google/Signer/P12.php
@@ -67,7 +67,8 @@ class W3TCG_Google_Signer_P12 extends W3TCG_Google_Signer_Abstract
 
   public function __destruct()
   {
-    if ($this->privateKey) {
+    if ($this->privateKey && PHP_MAJOR_VERSION < 8) {
+      //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_pkey_freeDeprecated
       openssl_pkey_free($this->privateKey);
     }
   }

--- a/lib/Google/Verifier/Pem.php
+++ b/lib/Google/Verifier/Pem.php
@@ -45,9 +45,11 @@ class W3TCG_Google_Verifier_Pem extends W3TCG_Google_Verifier_Abstract
 
   public function __destruct()
   {
-    if ($this->publicKey) {
+    if ($this->publicKey && PHP_MAJOR_VERSION < 8) {
+      //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_x509_freeDeprecated
       openssl_x509_free($this->publicKey);
     }
+
   }
 
   /**

--- a/lib/Minify/HTTP/Encoder.php
+++ b/lib/Minify/HTTP/Encoder.php
@@ -90,9 +90,15 @@ class HTTP_Encoder {
 	 */
 	public function __construct($spec)
 	{
-		$this->_useMbStrlen = (function_exists('mb_strlen')
-							   && (ini_get('mbstring.func_overload') !== '')
-							   && ((int)ini_get('mbstring.func_overload') & 2));
+        if(PHP_MAJOR_VERSION < 8) { 
+            //phpcs:disable PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+            $this->_useMbStrlen = (function_exists('mb_strlen')
+                && (ini_get('mbstring.func_overload') !== '')
+                && ((int)ini_get('mbstring.func_overload') & 2));
+            //phpcs:enable PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+        } else {
+            $this->_useMbStrlen = false;
+        }
 		$this->_content = $spec['content'];
 		$this->_headers['Content-Length'] = $this->_useMbStrlen
 			? (string)mb_strlen($this->_content, '8bit')

--- a/lib/Minify/JSMin.php
+++ b/lib/Minify/JSMin.php
@@ -115,9 +115,12 @@ class JSMin {
 		}
 
 		$mbIntEnc = null;
-		if (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2)) {
-			$mbIntEnc = mb_internal_encoding();
-			mb_internal_encoding('8bit');
+		if(PHP_MAJOR_VERSION < 8) {
+			//phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+			if (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2)) {
+				$mbIntEnc = mb_internal_encoding();
+				mb_internal_encoding('8bit');
+			}
 		}
 		$this->input = str_replace("\r\n", "\n", $this->input);
 		$this->inputLength = strlen($this->input);

--- a/lib/Minify/JSMinPlus.php
+++ b/lib/Minify/JSMinPlus.php
@@ -1673,6 +1673,7 @@ class JSNode
 
 		if (($numargs = func_num_args()) > 2)
 		{
+			//phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 			$args = func_get_args();
 			for ($i = 2; $i < $numargs; $i++)
 				$this->addNode($args[$i]);

--- a/lib/Minify/Minify.php
+++ b/lib/Minify/Minify.php
@@ -358,13 +358,20 @@ class Minify {
 		}
 
 		// add headers
-		if ( !defined( 'W3TC_MINIFY_CONTENT_LENGTH_OFF' ) ) {
-			$headers['Content-Length'] = $cacheIsReady
-				? $cacheContentLength
-				: ((function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2))
-					? mb_strlen($content['content'], '8bit')
-					: strlen($content['content'])
-				);
+		if ( !defined( 'W3TC_MINIFY_CONTENT_LENGTH_OFF' ) ) {			
+            if($cacheIsReady) {
+                $headers['Content-Length'] = $cacheContentLength;
+            } else {
+                if(PHP_MAJOR_VERSION < 8) {
+                    if((function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2)) {
+                        $headers['Content-Length'] = mb_strlen($content['content'], '8bit');
+                    } else {
+                        $headers['Content-Length'] = strlen($content['content']);
+                    }
+                } else {
+                    $headers['Content-Length'] = strlen($content['content']);
+                }
+            }
 		}
 
 		$headers['Content-Type'] = self::$_options['contentTypeCharset']

--- a/lib/Minify/Minify/Cache/W3TCDerived.php
+++ b/lib/Minify/Minify/Cache/W3TCDerived.php
@@ -50,14 +50,21 @@ class Minify_Cache_W3TCDerived {
     public function getSize($id)
     {
         $v = $this->fetch($id);
-        if (!isset($v['content'])) {
+        if (!isset($v['content'])) 
+		{
             return false;
         }
-
-        return (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2))
-            ? mb_strlen($v['content'], '8bit')
-            : strlen($v['content']);
+        if(PHP_MAJOR_VERSION < 8) 
+		{
+            //phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+            return (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2))
+                ? mb_strlen($v['content'], '8bit')
+                : strlen($v['content']);
+        } else {
+            return strlen($v['content']);
+        }
     }
+
 
     /**
      * Does a valid cache entry exist?

--- a/lib/Minify/Minify/JS/ClosureCompiler.php
+++ b/lib/Minify/Minify/JS/ClosureCompiler.php
@@ -44,26 +44,30 @@ class Minify_JS_ClosureCompiler {
 			: array($this, '_fallback');
 	}
 
-	public function min($js)
-	{
-		if (trim($js) === '')
-			return $js;
-
-		$postBody = $this->_buildPostBody($js);
-		$bytes = (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2))
-			? mb_strlen($postBody, '8bit')
-			: strlen($postBody);
-		if ($bytes > 200000)
-			return $this->fail($js,
-				'File size is larger than Closure Compiler API limit (200000 bytes)');
-
-		$response = $this->_getResponse($postBody);
-		if (preg_match('/^Error\(\d\d?\):/', $response))
-			return $this->fail($response,
-				"Received errors from Closure Compiler API:\n$response");
-
-		return $response;
-	}
+    public function min($js) {
+        if (trim($js) === '') {
+            return $js;
+        }
+        $postBody = $this->_buildPostBody($js);
+        if(PHP_MAJOR_VERSION < 8) {
+            //phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+            $bytes = (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2))
+                ? mb_strlen($postBody, '8bit')
+                : strlen($postBody);
+        } else {
+            $bytes = strlen($postBody);
+        }
+        if ($bytes > 200000) {
+            return $this->fail($js,
+                'File size is larger than Closure Compiler API limit (200000 bytes)');
+        }
+        $response = $this->_getResponse($postBody);
+        if (preg_match('/^Error\(\d\d?\):/', $response)) {
+            return $this->fail($response,
+                "Received errors from Closure Compiler API:\n$response");
+        }
+        return $response;
+    }
 
 	private function fail($js, $errorMessage) {
 		Minify::$recoverableError = $errorMessage;

--- a/lib/Minify/Minify/YUI/CssCompressor.php
+++ b/lib/Minify/Minify/YUI/CssCompressor.php
@@ -102,9 +102,12 @@ class Minify_YUI_CssCompressor {
 
 			// make sure strlen returns byte count
 			$mbIntEnc = null;
-			if (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2)) {
-				$mbIntEnc = mb_internal_encoding();
-				mb_internal_encoding('8bit');
+            if (PHP_MAJOR_VERSION < 8) {
+				//phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
+			    if (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload') & 2)) {
+			    	$mbIntEnc = mb_internal_encoding();
+			    	mb_internal_encoding('8bit');
+			    }
 			}
 			$sbLength = strlen($css);
 			while ($i < $sbLength) {

--- a/lib/Nusoap/class.nusoap_base.php
+++ b/lib/Nusoap/class.nusoap_base.php
@@ -860,7 +860,7 @@ class nusoap_base {
 			$sec = time();
 			$usec = 0;
 		}
-		return strftime('%Y-%m-%d %H:%M:%S', $sec) . '.' . sprintf('%06d', $usec);
+        return date("Y-m-d H:i:s",$sec). '.' . sprintf('%06d', $usec);
 	}
 
 	/**

--- a/lib/Nusoap/class.soap_parser.php
+++ b/lib/Nusoap/class.soap_parser.php
@@ -419,8 +419,13 @@ class nusoap_parser extends nusoap_base {
 			// TODO: add an option to disable this for folks who want
 			// raw UTF-8 that, e.g., might not map to iso-8859-1
 			// TODO: this can also be handled with xml_parser_set_option($this->parser, XML_OPTION_TARGET_ENCODING, "ISO-8859-1");
-			if($this->decode_utf8){
-				$data = utf8_decode($data);
+			if($this->decode_utf8) {
+                if(PHP_MAJOR_VERSION < 8) {
+                    //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.utf8_decodeDeprecated
+                    $data = utf8_decode($data);
+                } else {
+                    $data = mb_convert_encoding($data, 'ISO-8859-1', 'UTF-8');
+                }
 			}
 		}
         $this->message[$pos]['cdata'] .= $data;

--- a/lib/Nusoap/nusoap.php
+++ b/lib/Nusoap/nusoap.php
@@ -860,7 +860,7 @@ class nusoap_base {
 			$sec = time();
 			$usec = 0;
 		}
-		return strftime('%Y-%m-%d %H:%M:%S', $sec) . '.' . sprintf('%06d', $usec);
+		return date("Y-m-d H:i:s",$sec) . '.' . sprintf('%06d', $usec);
 	}
 
 	/**
@@ -3666,6 +3666,7 @@ class nusoap_server extends nusoap_base {
 			$this->appendDebug($this->wsdl->getDebug());
 			$this->wsdl->clearDebug();
 			if($err = $this->wsdl->getError()){
+                //phpcs:ignore PHPCompatibility.FunctionDeclarations.RemovedCallingDestructAfterConstructorExit.NeedsInspection
 				die( 'WSDL ERROR: ' . esc_html( $err ) );
 			}
 		}
@@ -6902,7 +6903,12 @@ class nusoap_parser extends nusoap_base {
 			// raw UTF-8 that, e.g., might not map to iso-8859-1
 			// TODO: this can also be handled with xml_parser_set_option($this->parser, XML_OPTION_TARGET_ENCODING, "ISO-8859-1");
 			if($this->decode_utf8){
-				$data = utf8_decode($data);
+                if(PHP_MAJOR_VERSION < 8) {
+                    //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.utf8_decodeDeprecated
+                    $data = utf8_decode($data);
+                } else {
+                    $data = mb_convert_encoding($data, 'ISO-8859-1', 'UTF-8');
+                }
 			}
 		}
         $this->message[$pos]['cdata'] .= $data;

--- a/lib/OAuth/W3tcOAuth.php
+++ b/lib/OAuth/W3tcOAuth.php
@@ -198,8 +198,10 @@ abstract class W3tcOAuthSignatureMethod_RSA_SHA1 extends W3tcOAuthSignatureMetho
     $ok = openssl_sign($base_string, $signature, $privatekeyid);
 
     // Release the key resource
-    openssl_free_key($privatekeyid);
-
+    if(PHP_MAJOR_VERSION < 8) {
+        //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_free_keyDeprecated
+        openssl_free_key($privatekeyid);
+    }
     return base64_encode($signature);
   }
 
@@ -218,7 +220,10 @@ abstract class W3tcOAuthSignatureMethod_RSA_SHA1 extends W3tcOAuthSignatureMetho
     $ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
 
     // Release the key resource
-    openssl_free_key($publickeyid);
+    if(PHP_MAJOR_VERSION < 8) {
+        //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_free_keyDeprecated
+        openssl_free_key($publickeyid);
+    }
 
     return $ok == 1;
   }

--- a/lib/S3Compatible.php
+++ b/lib/S3Compatible.php
@@ -332,13 +332,16 @@ class S3Compatible
 
 	/**
 	* Free signing key from memory, MUST be called if you are using setSigningKey()
-	*
+	* Does nothing if PHP>8.0, as PHP automatically destroys the instance when out of scope.
 	* @return void
 	*/
-	public static function freeSigningKey()
-	{
-		if (self::$__signingKeyResource !== false)
-			openssl_free_key(self::$__signingKeyResource);
+	public static function freeSigningKey() {
+        if(PHP_MAJOR_VERSION < 8) {
+            if (self::$__signingKeyResource !== false) {
+                //phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.openssl_free_keyDeprecated
+                openssl_free_key(self::$__signingKeyResource);
+            }
+        }
 	}
 
 

--- a/lib/SNS/sdk.class.php
+++ b/lib/SNS/sdk.class.php
@@ -877,7 +877,7 @@ class CFRuntime
 		{
 			$signature_version = 2;
 		}
-
+        //phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue
 		$method_arguments = func_get_args();
 		$headers = array();
 		$signed_headers = array();

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -205,6 +205,7 @@ function w3tc_class_autoload( $class ) {
 					$filename
 				)
 			);
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue
 			debug_print_backtrace();
 		}
 	}


### PR DESCRIPTION
Commit message:

PHPCompatibility ignore comments for backfills.
A few php8 fixes.

===

I fixed a few problems that phpCompatibility found in one of our clients websites inside this plugin when the site wouldn't work on PHP8. Providing the fixes back as per GPL. 

This may need further testing, I only checked that this particular site now works. Most changes are just comments and should be fine.

I also made changes to these files, but they are not present in the repository: 

```
vendor/aws/aws-php-sns-message-validator/tests/MessageValidatorTest.php
vendor/aws/aws-sdk-php/src/CloudFront/Signer.php
vendor/aws/aws-sdk-php/src/Credentials/CredentialProvider.php
vendor/aws/aws-sdk-php/src/Credentials/Credentials.php
vendor/symfony/polyfill-intl-idn/bootstrap.php
vendor/symfony/polyfill-intl-normalizer/Normalizer.php
vendor/aws/aws-sdk-php/src/Api/DocModel.php
vendor/aws/aws-sdk-php/src/ClientResolver.php
vendor/aws/aws-php-sns-message-validator/tests/MessageValidatorTest.php
```
 