### PR TITLE
Fixed sitemap purge not occuring on post creation/edit

### DIFF
--- a/Cache_File.php
+++ b/Cache_File.php
@@ -274,11 +274,19 @@ class Cache_File extends Cache_Base {
 	 */
 	function flush( $group = '' ) {
 		@set_time_limit( $this->_flush_timelimit );
-		$flush_dir = $group ?
-			$this->_cache_dir . DIRECTORY_SEPARATOR . $group .
-			DIRECTORY_SEPARATOR :
-			$this->_flush_dir;
-		Util_File::emptydir( $flush_dir, $this->_exclude );
+
+		if ( 'sitemaps' === $group ) {
+			$config = Dispatcher::config();
+			$sitemap_regex = $config->get_string( 'pgcache.purge.sitemap_regex' );
+			$this->_flush_based_on_regex( $sitemap_regex );
+		} else {
+			$flush_dir = $group ?
+				$this->_cache_dir . DIRECTORY_SEPARATOR . $group .
+				DIRECTORY_SEPARATOR :
+				$this->_flush_dir;
+			Util_File::emptydir( $flush_dir, $this->_exclude );
+		}
+
 		return true;
 	}
 
@@ -452,5 +460,39 @@ class Cache_File extends Cache_Base {
 
 		$fp = @fopen( $path, $mode );
 		return $fp;
+	}
+
+	/**
+	 * Flush cache based on regex
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string  $regex
+	 */
+	private function _flush_based_on_regex( $regex ) {
+		if ( Util_Environment::is_wpmu() && ! Util_Environment::is_wpmu_subdomain() ) {
+			$domain    = get_home_url();
+			$parsed    = parse_url( $domain );
+			$host      = $parsed['host'];
+			$path      = isset( $parsed['path'] ) ? '/' . trim( $parsed['path'], '/' ) : '';
+			$flush_dir = W3TC_CACHE_PAGE_ENHANCED_DIR . DIRECTORY_SEPARATOR . $host . $path;
+		} else {
+			$flush_dir = W3TC_CACHE_PAGE_ENHANCED_DIR . DIRECTORY_SEPARATOR . Util_Environment::host();
+		}
+
+		$dir = @opendir( $flush_dir );
+		if ( $dir ) {
+			while ( ( $entry = @readdir( $dir ) ) !== false ) {
+				if ( '.' === $entry || '..' === $entry ) {
+					continue;
+				}
+
+				if ( preg_match( '~' . $regex . '~', basename( $entry ) ) ) {
+					Util_File::rmdir( $flush_dir . DIRECTORY_SEPARATOR . $entry );
+				}
+			}
+
+			@closedir( $dir );
+		}
 	}
 }

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -672,7 +672,7 @@ $keys = array(
 	),
 	'pgcache.purge.sitemap_regex' => array(
 		'type' => 'string',
-		'default' => '([a-z0-9_\-]*?)sitemap([a-z0-9_\-]*)?\.xml'
+		'default' => '([a-z0-9_\-]*?)sitemap([a-z0-9_\-]*)?\.(?:xml|xsl)'
 	),
 	'pgcache.prime.enabled' => array(
 		'type' => 'boolean',

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -175,7 +175,7 @@ class PgCache_Plugin_Admin {
 		if ( !Util_Environment::is_url( $url ) )
 			$url = home_url( $url );
 
-		$urls = array();
+		$urls = array( $url );
 		$response = Util_Http::get( $url );
 
 		if ( !is_wp_error( $response ) && $response['response']['code'] == 200 ) {

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -218,7 +218,7 @@ class PgCache_Plugin_Admin {
 
 				arsort( $locs );
 
-				$urls = array_keys( $locs );
+				$urls = array_merge( $urls, array_keys( $locs ) );
 			} elseif ( preg_match_all( '~<rss[^>]*>(.*?)</rss>~is', $response['body'], $sitemap_matches ) ) {
 
 				// rss feed format


### PR DESCRIPTION
With the sitemap cached via PageCache Disk: Enhanced engine, creating new posts or modifying existing posts would not flush the sitemap. This PR fixes that so it will be purged on post creation/edit

To test, set the PageCache engine to Disk: Enhanced and either set the prime cache with the sitemap URL as domain/wp-sitemap.xml (or other sitemap URL) or visit directly to cache the sitemap. Confirm that it was cached in /wp-content/cache/page_enhanced/domain/wp-sitemap.xml(or other sitemap filename)/

Once confirmed as cached either create or modify a post, then confirm that the sitemap cache folder/file was purged

This PR also modifies the default sitemap purge regex to include .xsl files and adjust the prime cache so it will also prime the sitemap files