### PR TITLE
Remove CSS/JS Upsell

### DIFF
--- a/Extension_ImageService_Page_View.php
+++ b/Extension_ImageService_Page_View.php
@@ -109,35 +109,43 @@ Util_Ui::postbox_footer();
 Util_Ui::postbox_header( esc_html__( 'Tools', 'w3-total-cache' ), '', 'tools' );
 
 if ( ! $is_pro ) {
-	Util_Ui::print_score_block(
-		'9+',
-		wp_kses(
-			sprintf(
-				// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
-				__(
-					'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
-					'w3-total-cache'
+	?>
+	<div class="w3tc-gopro-manual-wrap">
+		<?php
+		Util_Ui::pro_wrap_maybe_start();
+		Util_Ui::print_score_block(
+			'9+',
+			wp_kses(
+				sprintf(
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+					__(
+						'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+						'w3-total-cache'
+					),
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
+					'</a>',
+					'<br /><br />',
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
-				'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
-				'</a>',
-				'<br /><br />',
-				'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
-			),
-			array(
-				'a'      => array(
-					'href'   => array(),
-					'target' => array(),
-				),
-				'br'     => array(),
-				'input'  => array(
-					'type'     => array(),
-					'class'    => array(),
-					'data-src' => array(),
-					'value'    => array(),
-				),
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
 			)
-		)
-	);
+		);
+		Util_Ui::pro_wrap_maybe_end( 'imageservice_settings', false );
+		?>
+	</div>
+	<?php
 }
 ?>
 

--- a/Extension_ImageService_Page_View.php
+++ b/Extension_ImageService_Page_View.php
@@ -105,34 +105,47 @@ Util_Ui::postbox_footer();
 
 Util_Ui::postbox_header( esc_html__( 'Tools', 'w3-total-cache' ), '', 'tools' );
 
+$score_block_pro = ! Util_Environment::is_w3tc_pro( $c )
+	? wp_kses(
+	   sprintf(
+		   // translators: 1 two HTML br tags followed by HTML input button to purchase pro license.
+		   __(
+			   '%1$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+			   'w3-total-cache'
+		   ),
+		   '<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+	   ),
+	   array(
+		   'br'     => array(),
+		   'input'  => array(
+			   'type'     => array(),
+			   'class'    => array(),
+			   'data-src' => array(),
+			   'value'    => array(),
+		   ),
+	   )
+	)
+	: '';
+
 Util_Ui::print_score_block(
 	'9+',
 	wp_kses(
 		sprintf(
-			// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+			// translators: 1  opening HTML a tag, 2 closing HTML a tag.
 			__(
-				'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+				'In a recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.',
 				'w3-total-cache'
 			),
 			'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
 			'</a>',
-			'<br /><br />',
-			'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 		),
 		array(
-			'a'      => array(
+			'a' => array(
 				'href'   => array(),
 				'target' => array(),
 			),
-			'br'     => array(),
-			'input'  => array(
-				'type'     => array(),
-				'class'    => array(),
-				'data-src' => array(),
-				'value'    => array(),
-			),
 		)
-	)
+	) . $score_block_pro
 );
 ?>
 

--- a/Extension_ImageService_Page_View.php
+++ b/Extension_ImageService_Page_View.php
@@ -125,7 +125,7 @@ if ( ! $is_pro ) {
 					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
 					'</a>',
 					'<br /><br />',
-					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(

--- a/Extension_ImageService_Page_View.php
+++ b/Extension_ImageService_Page_View.php
@@ -104,6 +104,36 @@ Util_Ui::config_item(
 Util_Ui::postbox_footer();
 
 Util_Ui::postbox_header( esc_html__( 'Tools', 'w3-total-cache' ), '', 'tools' );
+
+Util_Ui::print_score_block(
+	'9+',
+	wp_kses(
+		sprintf(
+			// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+			__(
+				'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+				'w3-total-cache'
+			),
+			'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
+			'</a>',
+			'<br /><br />',
+			'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+		),
+		array(
+			'a'      => array(
+				'href'   => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'input'  => array(
+				'type'     => array(),
+				'class'    => array(),
+				'data-src' => array(),
+				'value'    => array(),
+			),
+		)
+	)
+);
 ?>
 
 	<table class="form-table" id="w3tc-imageservice-tools">

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -634,7 +634,7 @@ class Generic_Plugin_Admin {
 						array(
 							'lang' => array(
 								'singlesPrompt'                     => __( 'Enter target CSS/JS match pattern.', 'w3-total-cache' ),
-								'singlesNoEntries'                  => __( 'No CSS/JS entires added.', 'w3-total-cache' ),
+								'singlesNoEntries'                  => __( 'No CSS/JS entries added.', 'w3-total-cache' ),
 								'singlesExists'                     => __( 'Entry already exists!', 'w3-total-cache' ),
 								'singlesPathLabel'                  => __( 'Target CSS/JS:', 'w3-total-cache' ),
 								'singlesDelete'                     => __( 'Delete', 'w3-total-cache' ),

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -625,17 +625,15 @@ class Generic_Plugin_Admin {
 				);
 				// No break.
 			case 'w3tc_userexperience':
-				if ( UserExperience_Remove_CssJs_Extension::is_enabled() ) {
-					wp_enqueue_script(
-						'w3tc_remove_cssjs',
-						plugins_url( 'UserExperience_Remove_CssJs_Page_View.js', W3TC_FILE ),
-						array(
-							'jquery',
-						),
-						W3TC_VERSION,
-						true
-					);
-				}
+				wp_enqueue_script(
+					'w3tc_remove_cssjs',
+					plugins_url( 'UserExperience_Remove_CssJs_Page_View.js', W3TC_FILE ),
+					array(
+						'jquery',
+					),
+					W3TC_VERSION,
+					true
+				);
 				// No break.
 			case 'w3tc_cdn':
 				wp_enqueue_script( 'jquery-ui-sortable' );

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -160,7 +160,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
 					'</a>',
 					'<br /><br />',
-					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -160,7 +160,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
 					'</a>',
 					'<br /><br />',
-					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -158,14 +158,15 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 							'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 							'w3-total-cache'
 						),
-						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+						'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
 						'</a>',
 						'<br /><br />',
 						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 					),
 					array(
 						'a'      => array(
-							'href' => array(),
+							'href'   => array(),
+							'target' => array(),
 						),
 						'br'     => array(),
 						'input'  => array(

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -120,9 +120,9 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 
 	Util_Ui::config_item_extension_enabled(
 		array(
-			'extension_id'   => 'user-experience-remove-cssjs',
-			'checkbox_label' => esc_html__( 'Remove Unwanted/Unused CSS/JS', 'w3-total-cache' ),
-			'description'    => __(
+			'extension_id'      => 'user-experience-remove-cssjs',
+			'checkbox_label'    => esc_html__( 'Remove Unwanted/Unused CSS/JS', 'w3-total-cache' ),
+			'description'       => __(
 				'Removes specfied CSS/JS tags from the homepage or on a per page basis.',
 				'w3-total-cache'
 			) . (
@@ -145,9 +145,41 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 				)
 				: ''
 			),
-			'label_class'    => 'w3tc_single_column',
-			'pro'            => true,
-			'disabled'       => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+			'label_class'       => 'w3tc_single_column',
+			'pro'               => true,
+			'disabled'          => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+			'score'             => '27+',
+			'score_description' => ! Util_Environment::is_w3tc_pro( $config )
+				? wp_kses(
+					sprintf(
+						// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
+						// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+						__(
+							'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+							'w3-total-cache'
+						),
+						'<strong>',
+						'</strong>',
+						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+						'</a>',
+						'<br /><br />',
+						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					),
+					array(
+						'a'      => array(
+							'href' => array(),
+						),
+						'strong' => array(),
+						'br'     => array(),
+						'input'  => array(
+							'type'     => array(),
+							'class'    => array(),
+							'data-src' => array(),
+							'value'    => array(),
+						),
+					)
+				)
+				: '',
 		)
 	);
 

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -148,18 +148,16 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 			'label_class'       => 'w3tc_single_column',
 			'pro'               => true,
 			'disabled'          => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+			'show_learn_more'   => false,
 			'score'             => '27+',
 			'score_description' => ! Util_Environment::is_w3tc_pro( $config )
 				? wp_kses(
 					sprintf(
-						// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
-						// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+						// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
 						__(
-							'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+							'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 							'w3-total-cache'
 						),
-						'<strong>',
-						'</strong>',
 						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
 						'</a>',
 						'<br /><br />',
@@ -169,7 +167,6 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 						'a'      => array(
 							'href' => array(),
 						),
-						'strong' => array(),
 						'br'     => array(),
 						'input'  => array(
 							'type'     => array(),

--- a/UserExperience_Remove_CssJs_Extension.php
+++ b/UserExperience_Remove_CssJs_Extension.php
@@ -48,6 +48,13 @@ class UserExperience_Remove_CssJs_Extension {
 	 * @return void
 	 */
 	public function run() {
+		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 12 );
+
+		/**
+		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
+		*/
+		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
+
 		if ( ! Util_Environment::is_w3tc_pro( $this->config ) ) {
 			$this->config->set_extension_active_frontend( 'user-experience-remove-cssjs', false );
 			return;
@@ -56,13 +63,6 @@ class UserExperience_Remove_CssJs_Extension {
 		Util_Bus::add_ob_callback( 'removecssjs', array( $this, 'ob_callback' ) );
 
 		add_filter( 'w3tc_save_options', array( $this, 'w3tc_save_options' ) );
-
-		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 12 );
-
-		/**
-		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
-		*/
-		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
 	}
 
 	/**
@@ -169,9 +169,7 @@ class UserExperience_Remove_CssJs_Extension {
 	 * @return void
 	 */
 	public function w3tc_userexperience_page() {
-		if ( self::is_enabled() ) {
-			include __DIR__ . '/UserExperience_Remove_CssJs_Page_View.php';
-		}
+		include __DIR__ . '/UserExperience_Remove_CssJs_Page_View.php';
 	}
 
 	/**

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -89,38 +89,6 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 <p>
 	<?php esc_html_e( 'Use this area to manage individual CSS/JS entries. The target CSS/JS for each rule can be either an absolute/relative URL or file name, e.g. (googletagmanager.com, /wp-content/plugins/woocommerce/, myscript.js, name="myscript", etc.)', 'w3-total-cache' ); ?>
 </p>
-<?php
-if ( ! $is_pro ) {
-	Util_Ui::print_score_block(
-		'27+',
-		wp_kses(
-			sprintf(
-				// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.
-				__(
-					'In a recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s and improve your PageSpeed Scores today!',
-					'w3-total-cache'
-				),
-				'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
-				'</a>',
-				'<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
-			),
-			array(
-				'a'      => array(
-					'href'   => array(),
-					'target' => array(),
-				),
-				'br'     => array(),
-				'input'  => array(
-					'type'     => array(),
-					'class'    => array(),
-					'data-src' => array(),
-					'value'    => array(),
-				),
-			)
-		)
-	);
-}
-?>
 <div class="w3tc-gopro-manual-wrap">
 	<?php Util_Ui::pro_wrap_maybe_start(); ?>
 	<p>
@@ -196,7 +164,7 @@ if ( ! $is_pro ) {
 		} else {
 			?>
 			<li id="remove_cssjs_singles_empty">
-				<?php esc_html_e( 'No CSS/JS entires added.', 'w3-total-cache' ); ?>
+				<?php esc_html_e( 'No CSS/JS entries added.', 'w3-total-cache' ); ?>
 				<input type="hidden" name="user-experience-remove-cssjs-singles[]">
 			</li>
 			<?php
@@ -204,7 +172,38 @@ if ( ! $is_pro ) {
 		?>
 	</ul>
 	<?php
-	Util_Ui::pro_wrap_maybe_end( 'remove_cssjs_singles' );
+	if ( ! $is_pro ) {
+		Util_Ui::print_score_block(
+			'27+',
+			wp_kses(
+				sprintf(
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.
+					__(
+						'In a recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s and improve your PageSpeed Scores today!',
+						'w3-total-cache'
+					),
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
+					'</a>',
+					'<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				),
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
+			)
+		);
+	}
+
+	Util_Ui::pro_wrap_maybe_end( 'remove_cssjs_singles', false );
 	?>
 </div>
 <?php

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -15,7 +15,8 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
-$c = Dispatcher::config();
+$c      = Dispatcher::config();
+$is_pro = Util_Environment::is_w3tc_pro( $c );
 
 $remove_cssjs_singles = array(
 	'value' => $c->get_array( 'user-experience-remove-cssjs-singles' ),
@@ -28,12 +29,46 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 </p>
 <table class="form-table">
 	<?php
-	Util_Ui::config_item(
+	Util_Ui::config_item_pro(
 		array(
-			'key'         => array( 'user-experience-remove-cssjs', 'includes' ),
-			'label'       => esc_html__( 'Remove list:', 'w3-total-cache' ),
-			'control'     => 'textarea',
-			'description' => esc_html__( 'Specify URLs that should be removed. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+			'key'               => array( 'user-experience-remove-cssjs', 'includes' ),
+			'label'             => esc_html__( 'Remove list:', 'w3-total-cache' ),
+			'control'           => 'textarea',
+			'disabled'          => ( $is_pro ? null : true ),
+			'description'       => array(),
+			'excerpt'           => esc_html__( 'Specify URLs that should be removed. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+			'score'             => '27+',
+			'score_description' => ! $is_pro
+				? wp_kses(
+					sprintf(
+						// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
+						// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+						__(
+							'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+							'w3-total-cache'
+						),
+						'<strong>',
+						'</strong>',
+						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+						'</a>',
+						'<br /><br />',
+						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					),
+					array(
+						'a'      => array(
+							'href' => array(),
+						),
+						'strong' => array(),
+						'br'     => array(),
+						'input'  => array(
+							'type'     => array(),
+							'class'    => array(),
+							'data-src' => array(),
+							'value'    => array(),
+						),
+					)
+				)
+				: '',
 		)
 	);
 
@@ -47,43 +82,84 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 <p>
 	<?php esc_html_e( 'Use this area to manage individual CSS/JS entries. Defined CSS/JS URLs will include a textarea indicating which pages the given entry should be removed from.', 'w3-total-cache' ); ?>
 </p>
-<p>
-	<input id="w3tc_remove_cssjs_singles_add" type="button" class="button" value="<?php esc_html_e( 'Add', 'w3-total-cache' ); ?>" />
-</p>
-<ul id="remove_cssjs_singles" class="w3tc_remove_cssjs_singles">
-	<?php
-	foreach ( $remove_cssjs_singles['value'] as $single => $single_config ) {
-		?>
-		<li id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>">
-			<table class="form-table">
-				<tr>
-					<th>
-						<?php esc_html_e( 'CSS/JS path to remove:', 'w3-total-cache' ); ?>
-					</th>
-					<td>
-						<span class="remove_cssjs_singles_path"><?php echo htmlspecialchars( $single ); // phpcs:ignore ?></span>
-						<input type="button" class="button w3tc_remove_cssjs_singles_delete" value="<?php esc_html_e( 'Delete', 'w3-total-cache' ); ?>"/>
-					</td>
-				</tr>
-					<tr>
-					<th>
-						<label for="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes">
-							<?php esc_html_e( 'Remove on these pages:', 'w3-total-cache' ); ?>
-						</label>
-					</th>
-					<td>
-						<textarea id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes" name="user-experience-remove-cssjs-singles[<?php echo esc_attr( $single ); ?>][includes]" rows="5" cols="50" ><?php echo esc_textarea( implode( "\r\n", (array) $single_config['includes'] ) ); ?></textarea>
-						<p class="description">
-							<?php esc_html_e( 'Specify relative/absolute page URLs that the above CSS/JS should be removed from. Include one entry per line.', 'w3-total-cache' ); ?>
-						</p>
-					</td>
-				</tr>
-			</table>
-		</li>
+<div class="w3tc-gopro-manual-wrap">
+	<?php Util_Ui::pro_wrap_maybe_start(); ?>
+	<p>
+		<input id="w3tc_remove_cssjs_singles_add" type="button" class="button" value="<?php esc_html_e( 'Add', 'w3-total-cache' ); ?>" <?php echo $is_pro ? '' : 'disabled="disabled"'; ?>/>
+	</p>
+	<ul id="remove_cssjs_singles" class="w3tc_remove_cssjs_singles">
 		<?php
+		foreach ( $remove_cssjs_singles['value'] as $single => $single_config ) {
+			?>
+			<li id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>">
+				<table class="form-table">
+					<tr>
+						<th>
+							<?php esc_html_e( 'CSS/JS path to remove:', 'w3-total-cache' ); ?>
+						</th>
+						<td>
+							<span class="remove_cssjs_singles_path"><?php echo htmlspecialchars( $single ); // phpcs:ignore ?></span>
+							<input type="button" class="button w3tc_remove_cssjs_singles_delete" value="<?php esc_html_e( 'Delete', 'w3-total-cache' ); ?>" <?php echo $is_pro ? '' : 'disabled="disabled"'; ?>/>
+						</td>
+					</tr>
+						<tr>
+						<th>
+							<label for="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes">
+								<?php esc_html_e( 'Remove on these pages:', 'w3-total-cache' ); ?>
+							</label>
+						</th>
+						<td>
+							<textarea id="remove_cssjs_singles_<?php echo esc_attr( $single ); ?>_includes" name="user-experience-remove-cssjs-singles[<?php echo esc_attr( $single ); ?>][includes]" rows="5" cols="50" <?php echo $is_pro ? '' : 'disabled'; ?>><?php echo esc_textarea( implode( "\r\n", (array) $single_config['includes'] ) ); ?></textarea>
+							<p class="description">
+								<?php esc_html_e( 'Specify relative/absolute page URLs that the above CSS/JS should be removed from. Include one entry per line.', 'w3-total-cache' ); ?>
+							</p>
+						</td>
+					</tr>
+				</table>
+			</li>
+			<?php
+		}
+		?>
+	</ul>
+	<div id="remove_cssjs_singles_empty" style="display: none;"><?php esc_html_e( 'No CSS/JS removal entires added.', 'w3-total-cache' ); ?></div>
+	<?php
+	if ( ! $is_pro ) {
+		Util_Ui::print_score_block(
+			'27+',
+			wp_kses(
+				sprintf(
+					// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
+					// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+					__(
+						'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+						'w3-total-cache'
+					),
+					'<strong>',
+					'</strong>',
+					'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+					'</a>',
+					'<br /><br />',
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				),
+				array(
+					'a'      => array(
+						'href' => array(),
+					),
+					'strong' => array(),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
+			)
+		);
 	}
+
+	Util_Ui::pro_wrap_maybe_end( 'remove_cssjs_singles' );
 	?>
-</ul>
-<div id="remove_cssjs_singles_empty" style="display: none;"><?php esc_html_e( 'No CSS/JS removal entires added.', 'w3-total-cache' ); ?></div>
+</div>
 <?php
 Util_Ui::postbox_footer();

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -42,15 +42,14 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 			'score_description' => ! $is_pro
 				? wp_kses(
 					sprintf(
-						// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+						// translators: 1  opening HTML a tag, 2 closing HTML a tag followed by two HTML br tags, 3 HTML input button to purchase pro license.
 						__(
-							'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
+							'In a recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 							'w3-total-cache'
 						),
 						'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
-						'</a>',
-						'<br /><br />',
-						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+						'</a><br /><br />',
+						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 					),
 					array(
 						'a'      => array(
@@ -126,15 +125,14 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 			'27+',
 			wp_kses(
 				sprintf(
-					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag followed by two HTML br tags, 4 HTML input button to purchase pro license.
 					__(
-						'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
+						'In a recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 						'w3-total-cache'
 					),
 					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
-					'</a>',
-					'<br /><br />',
-					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'</a><br /><br />',
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -47,14 +47,15 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 							'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 							'w3-total-cache'
 						),
-						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+						'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
 						'</a>',
 						'<br /><br />',
 						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 					),
 					array(
 						'a'      => array(
-							'href' => array(),
+							'href'   => array(),
+							'target' => array(),
 						),
 						'br'     => array(),
 						'input'  => array(
@@ -130,14 +131,15 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 						'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 						'w3-total-cache'
 					),
-					'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/?utm_source=w3tc&utm_medium=remove-css-js&utm_campaign=proof' ) . '">',
 					'</a>',
 					'<br /><br />',
 					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(
-						'href' => array(),
+						'href'   => array(),
+						'target' => array(),
 					),
 					'br'     => array(),
 					'input'  => array(

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -37,28 +37,25 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 			'disabled'          => ( $is_pro ? null : true ),
 			'description'       => array(),
 			'excerpt'           => esc_html__( 'Specify URLs that should be removed. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+			'show_learn_more'   => false,
 			'score'             => '27+',
 			'score_description' => ! $is_pro
 				? wp_kses(
 					sprintf(
-						// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
-						// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+						// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
 						__(
-							'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+							'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 							'w3-total-cache'
 						),
-						'<strong>',
-						'</strong>',
 						'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
 						'</a>',
 						'<br /><br />',
-						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+						'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 					),
 					array(
 						'a'      => array(
 							'href' => array(),
 						),
-						'strong' => array(),
 						'br'     => array(),
 						'input'  => array(
 							'type'     => array(),
@@ -128,24 +125,20 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 			'27+',
 			wp_kses(
 				sprintf(
-					// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML a tag, 4 closing HTML a tag,
-					// translators: 5 two HTML br tags, 6 HTML input button to purchase pro license.
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
 					__(
-						'In a recent test, removing unused CSS and JS added over 27 points to the %1$sGoogle PageSpeed Score%2$s! %3$sRead the documentation%4$s to learn how you can remove unused CSS and JS.%5$s%6$s and improve your PageSpeed Scores today!',
+						'In one recent test, removing unused CSS and JS added over 27 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
 						'w3-total-cache'
 					),
-					'<strong>',
-					'</strong>',
 					'<a href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/remove-scripts/' ) . '">',
 					'</a>',
 					'<br /><br />',
-					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
 				),
 				array(
 					'a'      => array(
 						'href' => array(),
 					),
-					'strong' => array(),
 					'br'     => array(),
 					'input'  => array(
 						'type'     => array(),

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1095,6 +1095,11 @@ class Util_Ui {
 			);
 		}
 
+		if ( isset( $a['score'] ) && isset( $a['score_description'] ) ) {
+			$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $a['score'] . '</div><p>' . esc_html( 'Points', 'w3-total-cache' ) . '</p></div><div class="w3tc-test-description">' . $a['score_description'] . '</div></div>';
+			echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
+		}
+
 		echo ( isset( $a['style'] ) ? '</th>' : '</td>' );
 		echo "</tr>\n";
 	}
@@ -1128,6 +1133,11 @@ class Util_Ui {
 
 		if ( isset( $a['description'] ) ) {
 			echo '<p class="description">' . wp_kses( $a['description'], self::get_allowed_html_for_wp_kses_from_content( $a['description'] ) ) . '</p>';
+		}
+
+		if ( isset( $a['score'] ) && isset( $a['score_description'] ) ) {
+			$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $a['score'] . '</div><p>' . esc_html( 'Points', 'w3-total-cache' ) . '</p></div><div class="w3tc-test-description">' . $a['score_description'] . '</div></div>';
+			echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
 		}
 
 		if ( isset( $a['pro'] ) ) {
@@ -1175,6 +1185,11 @@ class Util_Ui {
 
 		if ( isset( $a['description'] ) ) {
 			self::pro_wrap_description( $a['excerpt'], $a['description'], $a['control_name'] );
+		}
+
+		if ( isset( $a['score'] ) && isset( $a['score_description'] ) ) {
+			$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $a['score'] . '</div><p>' . esc_html( 'Points', 'w3-total-cache' ) . '</p></div><div class="w3tc-test-description">' . $a['score_description'] . '</div></div>';
+			echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
 		}
 
 		self::pro_wrap_maybe_end( $a['control_name'] );
@@ -1988,5 +2003,17 @@ class Util_Ui {
 				<?php
 				break;
 		}
+	}
+
+	/**
+	 * Prints the Google PageSpeed score block that is built into the config_item_xxx methods.
+	 * This allows for manual printing in places that may need it.
+	 *
+	 * @param string $score
+	 * @param string $score_description
+	 */
+	public static function print_score_block( $score, $score_description ) {
+		$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $score . '</div><p>' . esc_html( 'Points', 'w3-total-cache' ) . '</p></div><div class="w3tc-test-description">' . $score_description . '</div></div>';
+		echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
 	}
 }

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1141,7 +1141,8 @@ class Util_Ui {
 		}
 
 		if ( isset( $a['pro'] ) ) {
-			self::pro_wrap_maybe_end( 'extension__' . self::config_key_to_http_name( $a['extension_id'] ) );
+			$show_learn_more = isset( $a['show_learn_more'] ) && is_bool( $a['show_learn_more'] ) ? $a['show_learn_more'] : true;
+			self::pro_wrap_maybe_end( 'extension__' . self::config_key_to_http_name( $a['extension_id'] ), $show_learn_more );
 		}
 
 		echo ( isset( $a['style'] ) ? '</th>' : '</td>' );
@@ -1192,7 +1193,8 @@ class Util_Ui {
 			echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
 		}
 
-		self::pro_wrap_maybe_end( $a['control_name'] );
+		$show_learn_more = isset( $a['show_learn_more'] ) && is_bool( $a['show_learn_more'] ) ? $a['show_learn_more'] : true;
+		self::pro_wrap_maybe_end( $a['control_name'], $show_learn_more );
 
 		if ( 'w3tc_no_trtd' !== $a['label_class'] ) {
 			echo ( isset( $a['style'] ) ? '</th>' : '</td>' );
@@ -1328,18 +1330,20 @@ class Util_Ui {
 		}
 	}
 
-	public static function pro_wrap_maybe_end( $button_data_src ) {
+	public static function pro_wrap_maybe_end( $button_data_src, $show_learn_more = true ) {
 		if ( Util_Environment::is_w3tc_pro( Dispatcher::config() ) ) {
 			return;
 		}
 
 		?>
 			</div>
+			<?php if ( $show_learn_more ) { ?>
 			<div class="w3tc-gopro-action">
 				<button class="button w3tc-gopro-button button-buy-plugin" data-src="<?php echo esc_attr( $button_data_src ); ?>">
 					Learn more about Pro
 				</button>
 			</div>
+			<?php } ?>
 		</div>
 		<?php
 	}
@@ -1355,18 +1359,20 @@ class Util_Ui {
 		<?php
 	}
 
-	public static function pro_wrap_maybe_end2( $button_data_src ) {
+	public static function pro_wrap_maybe_end2( $button_data_src, $show_unlock_feature = true ) {
 		if ( Util_Environment::is_w3tc_pro( Dispatcher::config() ) ) {
 			return;
 		}
 
 		?>
 			</p>
+			<?php if ( $show_unlock_feature ) { ?>
 			<div style="text-align: right">
 				<button class="button w3tc-gopro-button button-buy-plugin" data-src="<?php echo esc_attr( $button_data_src ); ?>">
 					Unlock Feature
 				</button>
 			</div>
+			<?php } ?>
 		</div>
 		<?php
 	}

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -358,39 +358,39 @@ class Util_Ui {
 					);
 				}
 				if ( $config->get_boolean( 'pgcache.enabled' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_pgcache" value="' . esc_html__( 'Empty Page Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_pgcache" value="' . esc_attr__( 'Empty Page Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->get_boolean( 'browsercache.cssjs.replace' ) || $config->get_boolean( 'browsercache.other.replace' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_browser_cache" value="' . esc_html__( 'Empty Browser Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_browser_cache" value="' . esc_attr__( 'Empty Browser Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->get_boolean( 'minify.enabled' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_minify" value="' . esc_html__( 'Empty Minify Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_minify" value="' . esc_attr__( 'Empty Minify Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->get_boolean( 'dbcache.enabled' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_dbcache" value="' . esc_html__( 'Empty Database Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_dbcache" value="' . esc_attr__( 'Empty Database Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->getf_boolean( 'objectcache.enabled' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_objectcache" value="' . esc_html__( 'Empty Object Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_objectcache" value="' . esc_attr__( 'Empty Object Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->get_boolean( 'cdn.enabled' ) || $config->get_boolean( 'cdnfsd.enabled' ) ) {
 					$disable = ( $config->get_boolean( 'cdn.enabled' ) && Cdn_Util::can_purge_all( $config->get_string( 'cdn.engine' ) ) ) ||
 						( $config->get_boolean( 'cdnfsd.enabled' ) && Cdn_Util::can_purge_all( $config->get_string( 'cdnfsd.engine' ) ) ) ?
 							'' : ' disabled="disabled" ';
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_cdn"' . $disable . ' value="' . esc_html__( 'Empty CDN Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_cdn"' . $disable . ' value="' . esc_attr__( 'Empty CDN Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->is_extension_active_frontend( 'fragmentcache' ) && Util_Environment::is_w3tc_pro( $config ) && ! empty( $config->get_string( array( 'fragmentcache', 'engine' ) ) ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_fragmentcache" value="' . esc_html__( 'Empty Fragment Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_fragmentcache" value="' . esc_attr__( 'Empty Fragment Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->get_boolean( 'varnish.enabled' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_varnish" value="' . esc_html__( 'Empty Varnish Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_flush_varnish" value="' . esc_attr__( 'Empty Varnish Cache', 'w3-total-cache' ) . '"/>';
 				}
 				if ( $config->is_extension_active_frontend( 'cloudflare' ) ) {
-					echo '<input type="submit" class="dropdown-item" name="w3tc_cloudflare_flush" value="' . esc_html__( 'Empty CloudFlare Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_cloudflare_flush" value="' . esc_attr__( 'Empty CloudFlare Cache', 'w3-total-cache' ) . '"/>';
 				}
 				$opcode_enabled = ( Util_Installed::opcache() || Util_Installed::apc_opcache() );
 				if ( $opcode_enabled ) {
 					$disable = $opcode_enabled ? '' : ' disabled="disabled" ';
-					echo '<input type="submit" class="dropdown-item" name="w3tc_opcache_flush"' . $disable . ' value="' . esc_html__( 'Empty OpCode Cache', 'w3-total-cache' ) . '"/>';
+					echo '<input type="submit" class="dropdown-item" name="w3tc_opcache_flush"' . $disable . ' value="' . esc_attr__( 'Empty OpCode Cache', 'w3-total-cache' ) . '"/>';
 				}
 				?>
 			</div>

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -971,6 +971,28 @@ require W3TC_INC_DIR . '/options/common/header.php';
 					'<a href="' . Util_UI::admin_url( 'upload.php?page=w3tc_extension_page_imageservice' ) . '">',
 					'</a>'
 				) : '';
+			$score_block_pro    = ! Util_Environment::is_w3tc_pro( $c )
+				? wp_kses(
+				   sprintf(
+					   // translators: 1 two HTML br tags followed by HTML input button to purchase pro license.
+					   __(
+						   '%1$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+						   'w3-total-cache'
+					   ),
+					   '<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				   ),
+				   array(
+					   'br'     => array(),
+					   'input'  => array(
+						   'type'     => array(),
+						   'class'    => array(),
+						   'data-src' => array(),
+						   'value'    => array(),
+					   ),
+				   )
+				)
+				: '';
+
 			Util_Ui::config_item_pro(
 				array(
 					'key'            => 'extension.imageservice',
@@ -1028,35 +1050,24 @@ require W3TC_INC_DIR . '/options/common/header.php';
 					'label_class'    => 'w3tc_single_column',
 					'wrap_separate'  => true,
 					'score'             => '9+',
-					'score_description' => ! $this->_config->is_extension_active( 'imageservice' )
-						? wp_kses(
-							sprintf(
-								// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
-								__(
-									'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
-									'w3-total-cache'
-								),
-								'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
-								'</a>',
-								'<br /><br />',
-								'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+					'score_description' => wp_kses(
+						sprintf(
+							// translators: 1  opening HTML a tag, 2 closing HTML a tag.
+							__(
+								'In a recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.',
+								'w3-total-cache'
 							),
-							array(
-								'a'      => array(
-									'href'   => array(),
-									'target' => array(),
-								),
-								'br'     => array(),
-								'input'  => array(
-									'type'     => array(),
-									'class'    => array(),
-									'data-src' => array(),
-									'value'    => array(),
-								),
-							)
+							'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
+							'</a>',
+						),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
 						)
-						: '',
-						)
+					) . $score_block_pro,
+				)
 			);
 			?>
 		</table>

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -1027,7 +1027,36 @@ require W3TC_INC_DIR . '/options/common/header.php';
 					'description'    => array(),
 					'label_class'    => 'w3tc_single_column',
 					'wrap_separate'  => true,
-				)
+					'score'             => '9+',
+					'score_description' => ! $this->_config->is_extension_active( 'imageservice' )
+						? wp_kses(
+							sprintf(
+								// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+								__(
+									'In one recent test, converting images to the WebP format added over 9 points to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s to unlock conversion queue priority and higher hourly/monthly limits today!',
+									'w3-total-cache'
+								),
+								'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/webp/?utm_source=w3tc&utm_medium=webp&utm_campaign=proof' ) . '">',
+								'</a>',
+								'<br /><br />',
+								'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_html__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+							),
+							array(
+								'a'      => array(
+									'href'   => array(),
+									'target' => array(),
+								),
+								'br'     => array(),
+								'input'  => array(
+									'type'     => array(),
+									'class'    => array(),
+									'data-src' => array(),
+									'value'    => array(),
+								),
+							)
+						)
+						: '',
+						)
 			);
 			?>
 		</table>

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -770,6 +770,16 @@ table:not(.w3tc-pro-feature) .w3tc-gopro {
 	border: 1px solid #c3c4c7;
 }
 
+.w3tc-gopro-manual-wrap .w3tc-gopro {
+	box-shadow: 0 5px 5px -3px #888;
+	background: #efefef;
+	padding: 10px;
+	background-image: linear-gradient( to right, #f0f0f1, #f0f0f1, #f0f0f1, #f0f0f1, #e7f3f3, #56bec1, #16252c);
+	position: relative;
+	padding-right: 280px;
+	border: 1px solid #c3c4c7;
+}
+
 .w3tc-gopro-ribbon {
 	height: 75px;
 	overflow: hidden;
@@ -885,7 +895,8 @@ table.w3tc-pro-feature {
 }
 
 table.w3tc-pro-feature:after,
-table:not(.w3tc-pro-feature) .w3tc-gopro:after {
+table:not(.w3tc-pro-feature) .w3tc-gopro:after,
+.w3tc-gopro-manual-wrap .w3tc-gopro:after {
 	background-image: url("../img/transparent-comet.png");
 	background-repeat: no-repeat;
 	background-position: top right;
@@ -920,7 +931,8 @@ table.w3tc-pro-feature td {
 }
 
 /* Size of comet background for pro features not in a pro table */
-table:not(.w3tc-pro-feature) .w3tc-gopro:after {
+table:not(.w3tc-pro-feature) .w3tc-gopro:after,
+.w3tc-gopro-manual-wrap .w3tc-gopro:after {
 	width: 280px;
 	height: 152px;
 }
@@ -1343,7 +1355,6 @@ td .w3tc-control-after span {
     margin-left: auto;
 }
 
-
 /**
  * Button Save Dropdown
  */
@@ -1513,6 +1524,53 @@ td .w3tc-control-after span {
 	display: none;
 }
 
+/**
+ * W3TC pro wrapper test score block
+ */
+
+ .w3tc-test-container {
+    display: flex;
+    align-items: center;
+	margin: 10px 0;
+}
+
+.w3tc-test-score-container {
+	text-align: center;
+}
+
+.w3tc-test-score {
+    display: inline-flex;
+    flex: 0 0 50px;
+    align-items: center;
+    justify-content: center;
+    width: 50px;
+    height: 50px;
+    border: 2px solid #68D500;
+    border-radius: 50%;
+	background: #EEFAEC;
+    color: #000000;
+    font-size: 18px;
+    font-weight: 600;
+    margin-right: 15px;
+}
+
+.w3tc-test-score-container p {
+	margin: 4px 15px 4px 0;
+	font-weight: 600;
+}
+
+.w3tc-test-description {
+	border-left: 1px solid #ddd;
+	padding-left: 15px;
+    display: inline-block;
+    vertical-align: middle;
+	font-weight: 600;
+}
+
+.w3tc-test-description input {
+	font-weight: 600;
+}
+
 @media screen and (max-width: 1200px) {
 	.w3tc_form_bar>#w3tc-options-menu,
 	.w3tc_form_bar>.w3tc-button-control-container {
@@ -1641,7 +1699,8 @@ td .w3tc-control-after span {
 		background: #efefef;
 		margin: 5px 0;
 	}
-	table:not(.w3tc-pro-feature) .w3tc-gopro:after {
+	table:not(.w3tc-pro-feature) .w3tc-gopro:after,
+	.w3tc-gopro-manual-wrap .w3tc-gopro:after {
 		background: none;
 	}
 	.w3tc-button-control-container .dropdown-menu .dropdown-item {

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -1527,18 +1527,17 @@ td .w3tc-control-after span {
 /**
  * W3TC pro wrapper test score block
  */
-
- .w3tc-test-container {
+.w3tc-test-container {
     display: flex;
     align-items: center;
-	margin: 10px 0;
+	margin: 25px 0;
 }
 
 .w3tc-test-score-container {
 	text-align: center;
 }
 
-.w3tc-test-score {
+.w3tc-test-score-container .w3tc-test-score {
     display: inline-flex;
     flex: 0 0 50px;
     align-items: center;
@@ -1694,8 +1693,9 @@ td .w3tc-control-after span {
 	}
 
 	/* Pro features that aren't a <table>. A <tr> for example - User Experience > Lazy Load Google Maps. */
-	table:not(.w3tc-pro-feature) .w3tc-gopro {
-		padding-right: initial;
+	table:not(.w3tc-pro-feature) .w3tc-gopro,
+	.w3tc-gopro-manual-wrap .w3tc-gopro {
+		padding: 10px;
 		background: #efefef;
 		margin: 5px 0;
 	}
@@ -1711,6 +1711,26 @@ td .w3tc-control-after span {
 	#redis_test_status {
 		display: inline-block;
 		vertical-align: middle;
+	}
+
+	.w3tc-test-container {
+		display: block;
+		align-items: unset;
+	}
+
+	.w3tc-test-score-container {
+		margin: 15px 0;
+		display: inline-flex;
+		align-items: center;
+	}
+
+	.w3tc-test-score-container .w3tc-test-score {
+		margin-right: 10px;
+	}
+
+	.w3tc-test-description {
+		border-left: unset;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
This PR updates the config_item_xxx methods to include new options for "score" and "score_description" that will display a new block under the setting description that shows as

![image](https://github.com/BoldGrid/w3-total-cache/assets/88040916/4e40d158-28b4-4580-a150-37af16d5d156)

This also addresses a minor display issue with certain config_item_xxx methods displaying inappropriately for phone resolutions