### PR TITLE
Browser Cache lifetime causes all cache to be expired if set too high

### DIFF
--- a/Cache_File_Cleaner_Generic.php
+++ b/Cache_File_Cleaner_Generic.php
@@ -30,8 +30,10 @@ class Cache_File_Cleaner_Generic extends Cache_File_Cleaner {
 
 		$this->_expire = ( isset( $config['expire'] ) ? (int) $config['expire'] : 0 );
 
-		if ( !$this->_expire || $this->_expire > W3TC_CACHE_FILE_EXPIRE_MAX ) {
+		if ( ! $this->_expire ) {
 			$this->_expire = 0;
+		} elseif ( $this->_expire > W3TC_CACHE_FILE_EXPIRE_MAX ) {
+			$this->_expire = W3TC_CACHE_FILE_EXPIRE_MAX;
 		}
 	}
 

--- a/inc/options/browsercache.php
+++ b/inc/options/browsercache.php
@@ -587,6 +587,21 @@ $security_session_values = array(
 						<?php Util_Ui::sealing_disabled( 'browsercache.' ); ?>
 						value="<?php echo esc_attr( $this->_config->get_integer( 'browsercache.html.lifetime' ) ); ?>"
 						size="8" /> <?php esc_html_e( 'seconds', 'w3-total-cache' ); ?>
+					<p class="description">
+						<?php
+						echo esc_html(
+							sprintf(
+								// translators: 1 W3TC_CACHE_FILE_EXPIRE_MAX constant name, 2 W3TC_CACHE_FILE_EXPIRE_MAX value.
+								__(
+									'Max lifetime is limited by the %1$s constant (%2$s seconds) which can be overridden in wp_config.php.',
+									'w3-total-cache'
+								),
+								'W3TC_CACHE_FILE_EXPIRE_MAX',
+								W3TC_CACHE_FILE_EXPIRE_MAX
+							)
+						);
+						?>
+					</p>
 				</td>
 			</tr>
 			<tr>

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -888,6 +888,21 @@ if ( ! defined( 'W3TC' ) ) {
 						?>
 						/> <?php esc_html_e( 'seconds', 'w3-total-cache' ); ?>
 					<p class="description"><?php esc_html_e( 'If caching to disk, specify how frequently expired cache data is removed. For busy sites, a lower value is best.', 'w3-total-cache' ); ?></p>
+					<p class="description">
+						<?php
+						echo esc_html(
+							sprintf(
+								// translators: 1 W3TC_CACHE_FILE_EXPIRE_MAX constant name, 2 W3TC_CACHE_FILE_EXPIRE_MAX value.
+								__(
+									'Max interval is limited by the %1$s constant (%2$s seconds) which can be overridden in wp_config.php.',
+									'w3-total-cache'
+								),
+								'W3TC_CACHE_FILE_EXPIRE_MAX',
+								W3TC_CACHE_FILE_EXPIRE_MAX
+							)
+						);
+						?>
+					</p>
 				</td>
 			</tr>
 			<tr>

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -538,17 +538,30 @@ if ( ! defined( 'W3TC' ) ) {
 					</td>
 				</tr>
 			<?php endif; ?>
-			<?php if ( 'file_generic' !== $this->_config->get_string( 'pgcache.engine' ) ) : ?>
-				<tr>
-					<th><label for="pgcache_lifetime"><?php Util_Ui::e_config_label( 'pgcache.lifetime' ); ?></label></th>
-					<td>
-						<input id="pgcache_lifetime" type="text" name="pgcache__lifetime"
-							<?php Util_Ui::sealing_disabled( 'pgcache.' ); ?>
-							value="<?php echo esc_attr( $this->_config->get_integer( 'pgcache.lifetime' ) ); ?>" size="8" /> <?php esc_html_e( 'seconds', 'w3-total-cache' ); ?>
-						<p class="description"><?php esc_html_e( 'Determines the natural expiration time of unchanged cache items. The higher the value, the larger the cache.', 'w3-total-cache' ); ?></p>
-					</td>
-				</tr>
-			<?php endif; ?>
+			<tr>
+				<th><label for="pgcache_lifetime"><?php Util_Ui::e_config_label( 'pgcache.lifetime' ); ?></label></th>
+				<td>
+					<input id="pgcache_lifetime" type="text" name="pgcache__lifetime"
+						<?php Util_Ui::sealing_disabled( 'pgcache.' ); ?>
+						value="<?php echo esc_attr( $this->_config->get_integer( 'pgcache.lifetime' ) ); ?>" size="8" /> <?php esc_html_e( 'seconds', 'w3-total-cache' ); ?>
+					<p class="description"><?php esc_html_e( 'Determines the natural expiration time of cache items. The higher the value, the larger the cache.', 'w3-total-cache' ); ?></p>
+					<p class="description">
+						<?php
+						echo esc_html(
+							sprintf(
+								// translators: 1 W3TC_CACHE_FILE_EXPIRE_MAX constant name, 2 W3TC_CACHE_FILE_EXPIRE_MAX value.
+								__(
+									'Max lifetime is limited by the %1$s constant (%2$s seconds) which can be overridden in wp_config.php.',
+									'w3-total-cache'
+								),
+								'W3TC_CACHE_FILE_EXPIRE_MAX',
+								W3TC_CACHE_FILE_EXPIRE_MAX
+							)
+						);
+						?>
+					</p>
+				</td>
+			</tr>
 			<tr>
 				<th><label for="pgcache_file_gc"><?php Util_Ui::e_config_label( 'pgcache.file.gc' ); ?></label></th>
 				<td>


### PR DESCRIPTION
The Browser Cache lifetime (browsercache.html.lifetime) setting can cause all cache entries to be flagged as expired if set above the W3TC_CACHE_FILE_EXPIRE_MAX constant

This PR addresses that by setting the expired value to W3TC_CACHE_FILE_EXPIRE_MAX instead of 0, thereby forcing the max rather than flagging as expired

This PR also makes the Page Cache lifetime (pgcache.lifetime) setting visible when using the Page Cache "Disk Enhanced" engine as the value is used to determine the lifetime of cache files. Previously it was hidden if the engine was set to "Disk Enhanced" but if a value was stored in the config it would apply

Lastly, this PR adds information to various settings concerning the W3TC_CACHE_FILE_EXPIRE_MAX constant indicating that there is a hidden max value that can be overridden via wp-config. These settings include Page Cache Lifetime, Browser Cache HTML/XML lifetime, and Minify Garbage Collection Interval 