### PR TITLE
us-east-1 (default region) is not used in the Cloudfront hostname

### DIFF
--- a/CdnEngine_CloudFront.php
+++ b/CdnEngine_CloudFront.php
@@ -23,10 +23,10 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 	}
 
 	/**
-	 * Initialize
+	 * Initialize.
 	 */
-	function _init() {
-		if ( !is_null( $this->api ) ) {
+	public function _init() {
+		if ( ! is_null( $this->api ) ) {
 			return;
 		}
 
@@ -35,13 +35,15 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 		} else {
 			$credentials = new \Aws\Credentials\Credentials(
 				$this->_config['key'],
-				$this->_config['secret'] );
+				$this->_config['secret']
+			);
 		}
 
-		$this->api = new \Aws\CloudFront\CloudFrontClient( array(
+		$this->api = new \Aws\CloudFront\CloudFrontClient(
+			array(
 				'credentials' => $credentials,
-				'region' => $this->_config['bucket_location'],
-				'version' => '2018-11-05'
+				'region'      => $this->_config['bucket_location'],
+				'version'     => '2018-11-05',
 			)
 		);
 
@@ -144,15 +146,37 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 	}
 
 	/**
-	 * Returns origin
+	 * Get the S3 bucket region id.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string
 	 */
-	function _get_origin() {
-		if ( $this->_config['bucket_location'] === 'us-east-1' ) {
-			$region = "";
-		} else {
-			$region = $this->_config['bucket_location'] . '.';
+	public function get_region() {
+		switch ( $this->_config['bucket_location'] ) {
+			case 'us-east-1':
+				$region = '';
+				break;
+			case 'us-east-1-e':
+				$region = 'us-east-1.';
+				break;
+			default:
+				$region = $this->_config['bucket_location'] . '.';
+				break;
 		}
-		return sprintf( '%s.s3.%samazonaws.com', $this->_config['bucket'], $region );
+
+		return $region;
+	}
+
+	/**
+	 * Get the S3 bucket origin hostname.
+	 *
+	 * @see self::get_region()
+	 *
+	 * @return string
+	 */
+	public function _get_origin() {
+		return sprintf( '%1$s.s3.%2$samazonaws.com', $this->_config['bucket'], $this->get_region() );
 	}
 
 	/**
@@ -204,7 +228,7 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 		}
 
 		if ( !$dist['Enabled'] ) {
-			$error = sprintf( 'Distribution for origin "%s" is disabled.', $origin );
+			$error = sprintf( 'Distribution for origin "%s" is disabled.', $this->_get_origin() );
 			return false;
 		}
 

--- a/CdnEngine_CloudFront.php
+++ b/CdnEngine_CloudFront.php
@@ -24,6 +24,8 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 
 	/**
 	 * Initialize.
+	 *
+	 * @see Cdn_Core::get_region_id()
 	 */
 	public function _init() {
 		if ( ! is_null( $this->api ) ) {
@@ -42,7 +44,7 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 		$this->api = new \Aws\CloudFront\CloudFrontClient(
 			array(
 				'credentials' => $credentials,
-				'region'      => $this->_config['bucket_location'],
+				'region'      => Cdn_Core::get_region_id( $this->_config['bucket_location'] ),
 				'version'     => '2018-11-05',
 			)
 		);
@@ -146,9 +148,9 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 	}
 
 	/**
-	 * Get the S3 bucket region id.
+	 * Get the S3 bucket region id used for the hostname.
 	 *
-	 * @since X.X.X
+	 * @since 2.7.2
 	 *
 	 * @return string
 	 */

--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -14,6 +14,7 @@ class CdnEngine_S3 extends CdnEngine_Base {
 	/**
 	 * Regions list.
 	 *
+	 * @see  Cdn_Core::get_region_id()
 	 * @link https://docs.aws.amazon.com/general/latest/gr/rande.html
 	 *
 	 * @return array
@@ -56,6 +57,8 @@ class CdnEngine_S3 extends CdnEngine_Base {
 				'cname' => array(),
 			), $config );
 
+		$config['bucket_location'] = Cdn_Core::get_region_id( $config['bucket_location'] );
+
 		parent::__construct( $config );
 	}
 
@@ -81,11 +84,13 @@ class CdnEngine_S3 extends CdnEngine_Base {
 	/**
 	 * Inits S3 object
 	 *
-	 * @param string  $error
-	 * @return boolean
+	 * @see Cdn_Core::get_region_id()
+	 *
+	 * @return bool
+	 * @throws \Exception Exception.
 	 */
 	public function _init() {
-		if ( !is_null( $this->api ) ) {
+		if ( ! is_null( $this->api ) ) {
 			return;
 		}
 
@@ -106,17 +111,19 @@ class CdnEngine_S3 extends CdnEngine_Base {
 
 			$credentials = new \Aws\Credentials\Credentials(
 				$this->_config['key'],
-				$this->_config['secret'] );
+				$this->_config['secret']
+			);
 		}
 
 		if ( isset( $this->_config['public_objects'] ) && 'enabled' === $this->_config['public_objects'] ) {
 			$this->_config['s3_acl'] = 'public-read';
 		}
 
-		$this->api = new \Aws\S3\S3Client( array(
-				'credentials' => $credentials,
-				'region' => $this->_config['bucket_location'],
-				'version' => '2006-03-01',
+		$this->api = new \Aws\S3\S3Client(
+			array(
+				'credentials'    => $credentials,
+				'region'         => Cdn_Core::get_region_id( $this->_config['bucket_location'] ),
+				'version'        => '2006-03-01',
 				'use_arn_region' => true,
 			)
 		);

--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -18,9 +18,10 @@ class CdnEngine_S3 extends CdnEngine_Base {
 	 *
 	 * @return array
 	 */
-	static public function regions_list() {
+	public static function regions_list() {
 		return array(
-			'us-east-1'      => __( 'US East (N. Virginia)', 'w3-total-cache' ),
+			'us-east-1'      => __( 'US East (N. Virginia) (default)', 'w3-total-cache' ), // Default; region not included in hostnmae.
+			'us-east-1-e'    => __( 'US East (N. Virginia) (long hostname)', 'w3-total-cache' ), // Explicitly included in hostname.
 			'us-east-2'      => __( 'US East (Ohio)', 'w3-total-cache' ),
 			'us-west-1'      => __( 'US West (N. California)', 'w3-total-cache' ),
 			'us-west-2'      => __( 'US West (Oregon)', 'w3-total-cache' ),

--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -396,7 +396,7 @@ class Cdn_Core {
 						'key'             => $c->get_string( 'cdn.cf.key' ),
 						'secret'          => $c->get_string( 'cdn.cf.secret' ),
 						'bucket'          => $c->get_string( 'cdn.cf.bucket' ),
-						'bucket_location' => $c->get_string( 'cdn.cf.bucket.location' ),
+						'bucket_location' => self::get_region_id( $c->get_string( 'cdn.cf.bucket.location' ) ),
 						'id'              => $c->get_string( 'cdn.cf.id' ),
 						'cname'           => $c->get_array( 'cdn.cf.cname' ),
 						'ssl'             => $c->get_string( 'cdn.cf.ssl' ),
@@ -533,7 +533,7 @@ class Cdn_Core {
 						'key'             => $c->get_string( 'cdn.s3.key' ),
 						'secret'          => $c->get_string( 'cdn.s3.secret' ),
 						'bucket'          => $c->get_string( 'cdn.s3.bucket' ),
-						'bucket_location' => $c->get_string( 'cdn.s3.bucket.location' ),
+						'bucket_location' => self::get_region_id( $c->get_string( 'cdn.s3.bucket.location' ) ),
 						'cname'           => $c->get_array( 'cdn.s3.cname' ),
 						'ssl'             => $c->get_string( 'cdn.s3.ssl' ),
 						'public_objects'  => $c->get_string( 'cdn.s3.public_objects' ),
@@ -781,5 +781,27 @@ class Cdn_Core {
 		);
 
 		return apply_filters( 'w3tc_build_cdn_file_array', $file );
+	}
+
+	/**
+	 * Get the S3 bucket region ID.
+	 *
+	 * @since  2.7.2
+	 * @static
+	 *
+	 * @param string $bucket_location S3 bucket location.
+	 * @return string
+	 */
+	public static function get_region_id( $bucket_location ) {
+		switch ( $bucket_location ) {
+			case 'us-east-1-e':
+				$region = 'us-east-1';
+				break;
+			default:
+				$region = $bucket_location;
+				break;
+		}
+
+		return $region;
 	}
 }

--- a/inc/options/cdn/cf.php
+++ b/inc/options/cdn/cf.php
@@ -61,7 +61,7 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_cf_bucket"><?php esc_html_e( 'Bucket:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cf_bucket" type="text" name="cdn__cf__bucket"
+		<input id="cdn_cf_bucket" type="text" name="cdn__cf__bucket" maxlength="63"
 		<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> value="<?php echo esc_attr( strtolower( $this->_config->get_string( 'cdn.cf.bucket' ) ) ); ?>" size="30" />
 			<?php
 			Util_Ui::selectbox(
@@ -73,6 +73,7 @@ if ( ! defined( 'W3TC' ) ) {
 			?>
 		<b>or</b>
 		<input id="cdn_create_container" class="button {type: 'cf', nonce: '<?php echo esc_attr( wp_create_nonce( 'w3tc' ) ); ?>'}" type="button" value="<?php esc_attr_e( 'Create as new bucket with distribution', 'w3-total-cache' ); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
+		<br /><?php echo esc_html__( 'Bucket hostname', 'w3-total-cache' ); ?>: <span id="cdn-cf-bucket-hostname"><?php echo esc_html__( 'Unknown', 'w3-total-cache' ); ?></span>
 	</td>
 </tr>
 <tr>

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -325,6 +325,15 @@ textarea.w3tc-error {
 	color: #999;
 }
 
+#cdn_cf_bucket_location {
+	vertical-align: unset;
+}
+
+#cdn_create_container_status,
+#cdn_test_status {
+	display: inline-block;
+}
+
 #mobile_groups th,
 #referrer_groups th,
 .w3tc_cachegroups th,

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -471,7 +471,7 @@ function get_bucket_region( location ) {
 /**
  * Event callback for changing CDN Cloudfront (push) S3 bucket location.
  *
- * @since X.X.X
+ * @since 2.7.2
  *
  * @see get_bucket_region()
  */
@@ -871,11 +871,6 @@ jQuery(function() {
 
 			case 'cf':
 				let region = jQuery('#cdn_cf_bucket_location').val();
-
-				// Exception for 'us-east-1-e'.
-				if ( 'us-east-1-e' === region ) {
-					region = 'us-east-1';
-				}
 
 				jQuery.extend(params, {
 					engine: 'cf',

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -441,6 +441,47 @@ function debounce(func){
 	};
 }
 
+/**
+ * Get the S3 bucket region from the selected location to be used for the hostname.
+ *
+ * The default location (us-east-1) returns an empty string.  All other regions return the region with a trailing dot.
+ *
+ * @since X.X.X
+ *
+ * @param {string} location Bucket location.
+ * @returns string
+ */
+function get_bucket_region( location ) {
+	let region = '';
+
+	switch ( location ) {
+		case 'us-east-1':
+			break;
+		case 'us-east-1-e':
+			region = 'us-east-1.';
+			break;
+		default:
+			region = location + '.';
+			break;
+	}
+
+	return region;
+}
+
+/**
+ * Event callback for changing CDN Cloudfront (push) S3 bucket location.
+ *
+ * @since X.X.X
+ *
+ * @see get_bucket_region()
+ */
+function cdn_cf_bucket_location() {
+	const id = jQuery( '#cdn_cf_bucket' ).val();
+
+	jQuery( '#cdn-cf-bucket-hostname' )
+		.text( id + '.s3.' + get_bucket_region( jQuery( '#cdn_cf_bucket_location' ).val() ) + 'amazonaws.com' );
+}
+
 // On document ready.
 jQuery(function() {
 	// Global vars.
@@ -829,12 +870,19 @@ jQuery(function() {
 				break;
 
 			case 'cf':
+				let region = jQuery('#cdn_cf_bucket_location').val();
+
+				// Exception for 'us-east-1-e'.
+				if ( 'us-east-1-e' === region ) {
+					region = 'us-east-1';
+				}
+
 				jQuery.extend(params, {
 					engine: 'cf',
 					'config[key]': jQuery('#cdn_cf_key').val(),
 					'config[secret]': jQuery('#cdn_cf_secret').val(),
 					'config[bucket]': jQuery('#cdn_cf_bucket').val(),
-					'config[bucket_location]': jQuery('#cdn_cf_bucket_location').val(),
+					'config[bucket_location]': region,
 					'config[id]': jQuery('#cdn_cf_id').val()
 				});
 
@@ -1704,6 +1752,12 @@ jQuery(function() {
         jQuery(this).addClass('inline');
     });
 
+	// Update the CDN Cloudfront (push) S3 bucket location hostname.
+	jQuery( 'body' ).on( 'change', '#cdn_cf_bucket_location', cdn_cf_bucket_location );
+	jQuery( 'body' ).on( 'keyup', '#cdn_cf_bucket', cdn_cf_bucket_location );
+
+	// Run functions after the page is loaded.
+	cdn_cf_bucket_location();
 	set_sticky_bar_positions();
 	set_footer_position();
 });


### PR DESCRIPTION
Fixes https://github.com/BoldGrid/w3-total-cache/issues/845

This enhancement also adds a display span for the effective hostname, visible on the settings page.

To test:
- Create or have an existing Cloudfront distribution using an S3 bucket for storage in the "us-east-1" default region.
- Enter the CDN details in the CDN Cloudfront S3 push configuration.
- Use the test button to see that it passes for both US East selections for "bucket".
