### PR TITLE
Handle XML and Cache Feeds settings tweak

### DIFF
--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -44,8 +44,6 @@ class PgCache_Plugin {
 		// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
 		add_filter( 'cron_schedules', array( $this, 'cron_schedules' ) );
 
-		add_action( 'w3tc_config_save', array( $this, 'w3tc_config_save' ), 10, 1 );
-
 		$o = Dispatcher::component( 'PgCache_ContentGrabber' );
 
 		add_filter( 'w3tc_footer_comment', array( $o, 'w3tc_footer_comment' ) );
@@ -449,17 +447,5 @@ class PgCache_Plugin {
 		}
 
 		return $header;
-	}
-
-	/**
-	 * Save config item
-	 *
-	 * @param array $config Config.
-	 */
-	public function w3tc_config_save( $config ) {
-		// frontend activity.
-		if ( $config->get_boolean( 'pgcache.cache.feed' ) ) {
-			$config->set( 'pgcache.cache.nginx_handle_xml', true );
-		}
 	}
 }

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -263,6 +263,10 @@ class PgCache_Plugin_Admin {
 		$new_config = $data['new_config'];
 		$old_config = $data['old_config'];
 
+		if ( $new_config->get_boolean( 'pgcache.cache.feed' ) ) {
+			$new_config->set( 'pgcache.cache.nginx_handle_xml', true );
+		}
+
 		if ( ( !$new_config->get_boolean( 'pgcache.cache.home' ) && $old_config->get_boolean( 'pgcache.cache.home' ) ) ||
 			$new_config->get_boolean( 'pgcache.reject.front_page' ) && !$old_config->get_boolean( 'pgcache.reject.front_page' ) ||
 			!$new_config->get_boolean( 'pgcache.cache.feed' ) && $old_config->get_boolean( 'pgcache.cache.feed' ) ||

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -54,6 +54,33 @@ if ( ! defined( 'W3TC' ) ) {
 					<p class="description"><?php esc_html_e( 'Even if using a feed proxy service enabling this option is still recommended.', 'w3-total-cache' ); ?></p>
 				</th>
 			</tr>
+			<?php if ( 'file_generic' === $this->_config->get_string( 'pgcache.engine' ) ) : ?>
+				<tr>
+					<th>
+						<?php $this->checkbox( 'pgcache.cache.nginx_handle_xml' ); ?> <?php Util_Ui::e_config_label( 'pgcache.cache.nginx_handle_xml' ); ?></label>
+						<p class="description">
+							<?php
+							echo wp_kses(
+								sprintf(
+									// translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
+									__(
+										'Return correct Content-Type header for %1$sXML%2$s files (e.g., feeds and sitemaps).',
+										'w3-total-cache'
+									),
+									'<acronym title="' . esc_attr__( 'Extensible Markup Language', 'w3-total-cache' ) . '">',
+									'</acronym>'
+								),
+								array(
+									'acronym' => array(
+										'title' => array(),
+									),
+								)
+							);
+							?>
+						</p>
+					</th>
+				</tr>
+			<?php endif; ?>
 			<tr>
 				<th>
 					<?php $this->checkbox( 'pgcache.cache.ssl' ); ?> <?php Util_Ui::e_config_label( 'pgcache.cache.ssl' ); ?></label>
@@ -761,34 +788,6 @@ if ( ! defined( 'W3TC' ) ) {
 					<p class="description"><?php esc_html_e( 'Specify additional page headers to cache.', 'w3-total-cache' ); ?></p>
 				</td>
 			</tr>
-			<?php if ( 'file_generic' === $this->_config->get_string( 'pgcache.engine' ) ) : ?>
-				<tr>
-					<th><?php Util_Ui::e_config_label( 'pgcache.cache.nginx_handle_xml' ); ?></th>
-					<td>
-						<?php $this->checkbox( 'pgcache.cache.nginx_handle_xml' ); ?> <?php Util_Ui::e_config_label( 'pgcache.cache.nginx_handle_xml' ); ?></label>
-						<p class="description">
-							<?php
-							echo wp_kses(
-								sprintf(
-									// translators: 1 opening HTML acronym tag, 2 closing HTML acronym tag.
-									__(
-										'Return correct Content-Type header for %1$sXML%2$s files (e.g., feeds and sitemaps). Slows down cache engine.',
-										'w3-total-cache'
-									),
-									'<acronym title="' . esc_attr__( 'Extensible Markup Language', 'w3-total-cache' ) . '">',
-									'</acronym>'
-								),
-								array(
-									'acronym' => array(
-										'title' => array(),
-									),
-								)
-							);
-							?>
-						</p>
-					</td>
-				</tr>
-			<?php endif; ?>
 		</table>
 
 		<?php Util_Ui::postbox_footer(); ?>

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -506,14 +506,6 @@ jQuery(function() {
 		w3tc_input_enable('#pgcache_reject_roles input[type=checkbox]', jQuery('#pgcache__reject__logged_roles:checked').length);
 	});
 
-	if (jQuery('#pgcache__cache__nginx_handle_xml').is('*'))
-		jQuery('#pgcache__cache__nginx_handle_xml').attr('checked', jQuery('#pgcache__cache__feed').is(':checked'));
-
-	jQuery('#pgcache__cache__feed').on('change', function() {
-		if (jQuery('#pgcache__cache__nginx_handle_xml').is('*'))
-			jQuery('#pgcache__cache__nginx_handle_xml').attr('checked', this.checked);
-	});
-
 	// Browsercache page.
 	w3tc_toggle2('browsercache_last_modified', ['browsercache__cssjs__last_modified', 'browsercache__html__last_modified',
 		'browsercache__other__last_modified'


### PR DESCRIPTION
This PR addresses some issues with the Handle XML and Cache Feeds settings

Specifically it:

- Removes the JS that auto-toggles Handle XML if Cache Feeds is enabled/disabled
- Fixes the auto-toggle on save that occurs in the background where it enables Handle XML if Cache Feeds is enabled (won't auto-disable if Cache Feeds is disabled afterwards)
- Removes the "slows down cache" in Handle XML description
- Moves the Handle XML setting from the bottom of the Advanced block to the General block under the Cache Feeds setting

We had discussed the possibility of making Handle XML enabled by default or even remove the setting and have the plugin always handle the XML mime type...but after speaking with Max it was decided to leave as is due to concerns about it slowing down the cache (albeit marginally)

For sitemaps or other non-feed XML, users will need to enable the Handle XML setting in order for XML files to cache correctly

