### PR TITLE
Fix Redis test

### DIFF
--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -44,7 +44,7 @@ class Generic_AdminActions_Test {
 		$password                = Util_Request::get_string('password', '');
 		$dbid                    = Util_Request::get_integer( 'dbid', 0 );
 
-		if ( count( $servers ) <= 0 ) {
+		if ( empty( $servers ) ) {
 			$success = false;
 		} else {
 			$success = true;
@@ -61,7 +61,7 @@ class Generic_AdminActions_Test {
 					)
 				);
 
-				if ( is_null( $cache ) ) {
+				if ( empty( $cache ) ) {
 					$success = false;
 				}
 
@@ -72,7 +72,7 @@ class Generic_AdminActions_Test {
 
 				$test_value = $cache->get( $test_string );
 
-				if ( isset( $test_value['content'] ) && $test_value['content'] !== $test_string ) {
+				if ( empty( $test_value['content'] ) || $test_value['content'] !== $test_string ) {
 					$success = false;
 				}
 			}

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -23,7 +23,7 @@ if ( ! defined( 'W3TC' ) ) {
 			<?php Util_Ui::sealing_disabled( $module ); ?>
 			type="button" value="<?php esc_attr_e( 'Test', 'w3-total-cache' ); ?>" />
 		<span class="w3tc_common_redis_test_result w3tc-status w3tc-process"></span>
-		<p class="description"><?php esc_html_e( 'Enter one server definition per line: e.g. 127.0.0.1:11211 or domain.com:11211. To use TLS, prefix server with tls://', 'w3-total-cache' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Enter one server definition per line: e.g. 127.0.0.1:6379 or domain.com:6379. To use TLS, prefix server with tls://', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
 <?php


### PR DESCRIPTION
To test:
1. Configure Page Cache to use Redis.
2. Go to `wp-admin/admin.php?page=w3tc_pgcache` and click the test button.
3. See the test pass.
4. Change the server IP and/or port number to something else/invalid.
5. Click the test button.
6. See the test fail.

I also fixed the example port number in the description.
