### PR TITLE
Fixed PageCache File Cleaner using wrong expire value

### DIFF
--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -94,7 +94,7 @@ class PgCache_Plugin_Admin {
 						'.htaccess'
 					),
 					'cache_dir' => $flush_dir,
-					'expire' => $this->_config->get_integer( 'browsercache.html.lifetime' ),
+					'expire' => $this->_config->get_integer( 'pgcache.lifetime' ),
 					'clean_timelimit' => $this->_config->get_integer( 'timelimit.cache_gc' )
 				) );
 


### PR DESCRIPTION
This PR simply changes the cleanup_local method which calls the Cache_File_Cleaner_Generic under the Disk: Enhanced engine to use the PageCache Lifetime setting instead of the Browser Cache HTML Lifetime setting

Additionally, I've reviewed the Garbage Collection process and it appears that it does use the PageCache Garbage Collection Interval setting and will both rename expired cached files to _old and remove expired _old files

```
function _clean( $path, $remove = false ) {
    $dir = false;
    if ( is_dir( $path ) ) {
	$dir = @opendir( $path );
    }
    if ( $dir ) {
	while ( ( $entry = @readdir( $dir ) ) !== false ) {
            if ( $entry == '.' || $entry == '..' ) {
		continue;
	    }
	    $full_path = $path . DIRECTORY_SEPARATOR . $entry;
            if ( substr( $entry, -4 ) === '_old' && !$this->is_old_file_expired( $full_path ) ) {
		continue;
	    }
	    foreach ( $this->_exclude as $mask ) {
                if ( fnmatch( $mask, basename( $entry ) ) ) {
		    continue 2;
		}
            }
	    if ( @is_dir( $full_path ) ) {
                $this->_clean( $full_path );
	    } else {
		$this->_clean_file( $entry, $full_path );
	    }
	}
        @closedir( $dir );
	if ( $this->is_empty_dir( $path ) )
	    @rmdir( $path );
    }
}

function _clean_file( $entry, $full_path ) {
    if ( substr( $entry, -4 ) === '_old' ) {
	$this->processed_count++;
	@unlink( $full_path );
    } elseif ( !$this->is_valid( $full_path ) ) {
	$old_entry_path = $full_path . '_old';
	$this->processed_count++;
	if ( !@rename( $full_path, $old_entry_path ) ) {
	    // if we can delete old entry -
	    // do second attempt to store in old-entry file
            if ( @unlink( $old_entry_path ) ) {
		if ( !@rename( $full_path, $old_entry_path ) ) {
		    // last attempt - just remove entry
		    @unlink( $full_path );
		}
	    }
	}
    }
}

function is_valid( $file ) {
    if ( $this->_expire <= 0 )
	return false;
    if ( file_exists( $file ) ) {
	$ftime = @filemtime( $file );
	if ( $ftime && $ftime > ( time() - $this->_expire ) ) {
	    return true;
	}
    }
    return false;
}

function is_old_file_expired( $file ) {
    $ftime = @filemtime( $file );
    $expire = $this->_expire ? $this->_expire * 5 : W3TC_CACHE_FILE_EXPIRE_MAX;
    if ( $ftime && $ftime < ( time() - $expire ) ) {
	return true;
    }
    return false;
}
```

