### PR TITLE
Fix PHP 8 warnings for Redis connect in PHP 8.1

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -96,9 +96,9 @@ class Cache_Redis extends Cache_Base {
 		$this->_verify_tls_certificates = ( isset( $config['verify_tls_certificates'] ) && $config['verify_tls_certificates'] );
 		$this->_password                = $config['password'];
 		$this->_dbid                    = $config['dbid'];
-		$this->_timeout                 = $config['timeout'];
-		$this->_retry_interval          = $config['retry_interval'];
-		$this->_read_timeout            = $config['read_timeout'];
+		$this->_timeout                 = $config['timeout'] ?? 3600000;
+		$this->_retry_interval          = $config['retry_interval'] ?? 3600000;
+		$this->_read_timeout            = $config['read_timeout'] ?? 60.0;
 
 		/**
 		 * When disabled - no extra requests are made to obtain key version,


### PR DESCRIPTION
To test:

1. Switch PHP to 8.1 with error logging enabled.
2. Configure Page Cache or Fragment Cache to use Redis.
3. GO to the Page Cache or Fragment Cache settings page.
4. Click the "Test" button.
5. See the test passed and no errors logged.

Our minimum PHP version is now 7.2.5, so we can use the [Null coalescing operator](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op) (`??`), which was introduced in PHP 7.0.
