### PR TITLE
Added proof block for REST API caching

### DIFF
--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -150,6 +150,7 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 			'disabled'          => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
 			'show_learn_more'   => false,
 			'score'             => '+27',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
 			'score_description' => wp_kses(
 				sprintf(
 					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -55,6 +55,7 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 			'excerpt'           => esc_html__( 'Specify absolute or relative URLs, or file names to be excluded from loading on the homepage. Include one entry per line, e.g. (googletagmanager.com, /wp-content/plugins/woocommerce/, myscript.js, name="myscript", etc.)', 'w3-total-cache' ),
 			'show_learn_more'   => false,
 			'score'             => '+27',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
 			'score_description' => wp_kses(
 				sprintf(
 					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -701,7 +701,9 @@ class Util_Ui {
 	 */
 	public static function radiogroup( $name, $value, $values,
 			$disabled = false, $separator = '' ) {
-		$first = true;
+		$c      = Dispatcher::config();
+		$is_pro = Util_Environment::is_w3tc_pro( $c );
+		$first  = true;
 		foreach ( $values as $key => $label_or_array ) {
 			if ( $first ) {
 				$first = false;
@@ -743,7 +745,13 @@ class Util_Ui {
 					$name . '__' . $key
 				);
 
-				self::pro_wrap_maybe_end( $name . '__' . $key );
+				if ( ! $is_pro && isset( $label_or_array['score'] ) && isset( $label_or_array['score_label'] ) && isset( $label_or_array['score_description'] ) ) {
+					$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $label_or_array['score'] . '</div><p>' . $label_or_array['score_label'] . '</p></div><div class="w3tc-test-description">' . $label_or_array['score_description'] . '</div></div>';
+					echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
+				}
+
+				$show_learn_more = isset( $label_or_array['show_learn_more'] ) && is_bool( $label_or_array['show_learn_more'] ) ? $label_or_array['show_learn_more'] : true;
+				self::pro_wrap_maybe_end( $name . '__' . $key, $show_learn_more );
 			}
 		}
 	}
@@ -1192,8 +1200,8 @@ class Util_Ui {
 			self::pro_wrap_description( $a['excerpt'], $a['description'], $a['control_name'] );
 		}
 
-		if ( ! $is_pro && isset( $a['score'] ) && isset( $a['score_description'] ) ) {
-			$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $a['score'] . '</div><p>' . esc_html( 'Points', 'w3-total-cache' ) . '</p></div><div class="w3tc-test-description">' . $a['score_description'] . '</div></div>';
+		if ( ! $is_pro && isset( $a['score'] ) && isset( $a['score_label'] ) && isset( $a['score_description'] ) ) {
+			$score_block = '<div class="w3tc-test-container"><div class="w3tc-test-score-container"><div class="w3tc-test-score">' . $a['score'] . '</div><p>' . $a['score_label'] . '</p></div><div class="w3tc-test-description">' . $a['score_description'] . '</div></div>';
 			echo wp_kses( $score_block, self::get_allowed_html_for_wp_kses_from_content( $score_block ) );
 		}
 

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -1028,6 +1028,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 					'label_class'    => 'w3tc_single_column',
 					'wrap_separate'  => true,
 					'score'             => '+9',
+					'score_label'       => __( 'Points', 'w3-total-cache' ),
 					'score_description' => wp_kses(
 						sprintf(
 							// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -439,6 +439,34 @@ if ( ! defined( 'W3TC' ) ) {
 							'pro_description' => array(
 								esc_html__( 'If you use WordPress as a backend for integrations, API caching may be for you. Similar to page caching, repeat requests will benefit by having significantly lower response times and consume fewer resources to deliver. If WordPress is not used as a backend, for additional security, the API can be disabled completely.', 'w3-total-cache' ),
 							),
+							'show_learn_more'   => false,
+							'score'             => '84.5%',
+							'score_label'       => __( 'API Response Time', 'w3-total-cache' ),
+							'score_description' => wp_kses(
+								sprintf(
+									// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.
+									__(
+										'In a recent test, enabling REST API Caching increased API response times by 84.5&#37;! %1$sReview the testing results%2$s to see how.%3$s and improve your PageSpeed Scores today!',
+										'w3-total-cache'
+									),
+									'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/rest-api-testing/?utm_source=w3tc&utm_medium=rest-api-caching&utm_campaign=proof' ) . '">',
+									'</a>',
+									'<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+								),
+								array(
+									'a'      => array(
+										'href'   => array(),
+										'target' => array(),
+									),
+									'br'     => array(),
+									'input'  => array(
+										'type'     => array(),
+										'class'    => array(),
+										'data-src' => array(),
+										'value'    => array(),
+									),
+								)
+							),
 						),
 						'disable' => wp_kses(
 							sprintf(

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -793,7 +793,7 @@ table:not(.w3tc-pro-feature) .w3tc-gopro {
 	padding: 10px;
 	background-image: linear-gradient( to right, #f0f0f1, #f0f0f1, #f0f0f1, #f0f0f1, #e7f3f3, #56bec1, #16252c);
 	position: relative;
-	padding-right: 280px;
+	padding-right: 270px;
 	border: 1px solid #c3c4c7;
 }
 
@@ -1569,8 +1569,8 @@ td .w3tc-control-after span {
     flex: 0 0 50px;
     align-items: center;
     justify-content: center;
-    width: 50px;
-    height: 50px;
+    width: 60px;
+    height: 60px;
     border: 2px solid #68D500;
     border-radius: 50%;
 	background: #EEFAEC;
@@ -1581,6 +1581,7 @@ td .w3tc-control-after span {
 }
 
 .w3tc-test-score-container p {
+	white-space: nowrap;
 	margin: 4px 15px 4px 0;
 	font-weight: 600;
 }


### PR DESCRIPTION
This PR adds a proof block for the REST API Caching feature under Page Cache -> REST API section

Additionally this PR adds the option to add score blocks to radiogroups if values are configured as pro, as well as making the score block label configurable