### PR TITLE
Add Delay Scripts GPS proof

### DIFF
--- a/UserExperience_DeferScripts_Extension.php
+++ b/UserExperience_DeferScripts_Extension.php
@@ -48,6 +48,13 @@ class UserExperience_DeferScripts_Extension {
 	 * @return void
 	 */
 	public function run() {
+		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 11 );
+
+		/**
+		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
+		*/
+		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
+
 		if ( ! Util_Environment::is_w3tc_pro( $this->config ) ) {
 			$this->config->set_extension_active_frontend( 'user-experience-defer-scripts', false );
 			return;
@@ -57,13 +64,6 @@ class UserExperience_DeferScripts_Extension {
 
 		add_filter( 'w3tc_minify_js_script_tags', array( $this, 'w3tc_minify_js_script_tags' ) );
 		add_filter( 'w3tc_save_options', array( $this, 'w3tc_save_options' ) );
-
-		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 11 );
-
-		/**
-		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
-		*/
-		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
 	}
 
 	/**
@@ -233,9 +233,7 @@ class UserExperience_DeferScripts_Extension {
 	 * @return void
 	 */
 	public function w3tc_userexperience_page() {
-		if ( self::is_enabled() ) {
-			include __DIR__ . '/UserExperience_DeferScripts_Page_View.php';
-		}
+		include __DIR__ . '/UserExperience_DeferScripts_Page_View.php';
 	}
 
 	/**

--- a/UserExperience_DeferScripts_Page_View.php
+++ b/UserExperience_DeferScripts_Page_View.php
@@ -15,7 +15,9 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
-$c = Dispatcher::config();
+$c      = Dispatcher::config();
+$is_pro = Util_Environment::is_w3tc_pro( $c );
+
 if ( is_null( $c->get( array( 'user-experience-defer-scripts', 'timeout' ) ) ) ) {
 	$c->set( array( 'user-experience-defer-scripts', 'timeout' ), 5000 );
 	$c->save();
@@ -46,24 +48,106 @@ if ( is_null( $c->get( array( 'user-experience-defer-scripts', 'timeout' ) ) ) )
 </p>
 <table class="form-table">
 	<?php
-	Util_Ui::config_item(
+	Util_Ui::config_item_pro(
 		array(
-			'key'         => array( 'user-experience-defer-scripts', 'timeout' ),
-			'label'       => esc_html__( 'Timeout:', 'w3-total-cache' ),
-			'control'     => 'textbox',
-			'description' => esc_html__( 'Timeout (in milliseconds) to delay the loading of delayed scripts if no user action is taken during page load', 'w3-total-cache' ),
+			'key'               => array( 'user-experience-defer-scripts', 'timeout' ),
+			'label'             => esc_html__( 'Timeout:', 'w3-total-cache' ),
+			'control'           => 'textbox',
+			'disabled'          => ! UserExperience_DeferScripts_Extension::is_enabled(),
+			'description'       => array(),
+			'excerpt'           => esc_html__( 'Timeout (in milliseconds) to delay the loading of delayed scripts if no user action is taken during page load', 'w3-total-cache' ),
+			'show_learn_more'   => false,
+			'score'             => '+18',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
+			'score_description' => wp_kses(
+				sprintf(
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.
+					__(
+						'In a recent test, using the Delay Scripts feature added 18 points on mobile devices to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s and improve your PageSpeed Scores today!',
+						'w3-total-cache'
+					),
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/delay-scripts-test/?utm_source=w3tc&utm_medium=defer-js&utm_campaign=proof' ) . '">',
+					'</a>',
+					'<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				),
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
+			),
 		)
 	);
 
-	Util_Ui::config_item(
+	Util_Ui::config_item_pro(
 		array(
-			'key'         => array( 'user-experience-defer-scripts', 'includes' ),
-			'label'       => esc_html__( 'Delay list:', 'w3-total-cache' ),
-			'control'     => 'textarea',
-			'description' => esc_html__( 'Specify keywords to match any attribute of script tags containing the "src" attribute. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+			'key'               => array( 'user-experience-defer-scripts', 'includes' ),
+			'label'             => esc_html__( 'Delay list:', 'w3-total-cache' ),
+			'control'           => 'textarea',
+			'disabled'          => ! UserExperience_DeferScripts_Extension::is_enabled(),
+			'description'       => array(),
+			'excerpt'           => esc_html__( 'Specify keywords to match any attribute of script tags containing the "src" attribute. Include one entry per line, e.g. (googletagmanager.com, gtag/js, myscript.js, and name="myscript")', 'w3-total-cache' ),
+			'show_learn_more'   => false,
+			'score'             => '+18',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
+			'score_description' => wp_kses(
+				sprintf(
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags followed by a HTML input button to purchase pro license.
+					__(
+						'In a recent test, using the Delay Scripts feature added 18 points on mobile devices to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s and improve your PageSpeed Scores today!',
+						'w3-total-cache'
+					),
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/delay-scripts-test/?utm_source=w3tc&utm_medium=defer-js&utm_campaign=proof' ) . '">',
+					'</a>',
+					'<br /><br /><input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				),
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
+			),
 		)
 	);
-
 	?>
 </table>
-<?php Util_Ui::postbox_footer(); ?>
+<?php
+if ( $is_pro && ! UserExperience_DeferScripts_Extension::is_enabled() ) {
+	echo wp_kses(
+		sprintf(
+			// translators: 1: Opening HTML em tag, 2: Closing HTML em tag, 3: Opening HTML a tag with a link to General Settings, 4: Closing HTML a tag.
+			__(
+				'%1$sDelay Scripts%2$s is not enabled in the %3$sGeneral Settings%4$s.',
+				'w3-total-cache'
+			),
+			'<em>',
+			'</em>',
+			'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
+			'</a>'
+		),
+		array(
+			'a'  => array(
+				'href' => array(),
+			),
+			'em' => array(),
+		)
+	);
+}
+
+Util_Ui::postbox_footer(); ?>

--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -87,9 +87,9 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 
 	Util_Ui::config_item_extension_enabled(
 		array(
-			'extension_id'   => 'user-experience-defer-scripts',
-			'checkbox_label' => esc_html__( 'Delay Scripts', 'w3-total-cache' ),
-			'description'    => __(
+			'extension_id'      => 'user-experience-defer-scripts',
+			'checkbox_label'    => esc_html__( 'Delay Scripts', 'w3-total-cache' ),
+			'description'       => __(
 				'Delay the loading of specified internal/external JavaScript sources on your pages separate from Minify.',
 				'w3-total-cache'
 			) . (
@@ -112,9 +112,38 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 				)
 				: ''
 			),
-			'label_class'    => 'w3tc_single_column',
-			'pro'            => true,
-			'disabled'       => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+			'label_class'       => 'w3tc_single_column',
+			'pro'               => true,
+			'disabled'          => ! Util_Environment::is_w3tc_pro( $config ) ? true : false,
+			'show_learn_more'   => false,
+			'score'             => '+18',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
+			'score_description' => wp_kses(
+				sprintf(
+					// translators: 1  opening HTML a tag, 2 closing HTML a tag, 3 two HTML br tags, 4 HTML input button to purchase pro license.
+					__(
+						'In a recent test, using the Delay Scripts feature added 18 points on mobile devices to the Google PageSpeed score! %1$sReview the testing results%2$s to see how.%3$s%4$s and improve your PageSpeed Scores today!',
+						'w3-total-cache'
+					),
+					'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/delay-scripts-test/?utm_source=w3tc&utm_medium=defer-js&utm_campaign=proof' ) . '">',
+					'</a>',
+					'<br /><br />',
+					'<input type="button" class="button-primary btn button-buy-plugin" data-src="test_score_upgrade" value="' . esc_attr__( 'Upgrade to', 'w3-total-cache' ) . ' W3 Total Cache Pro">'
+				),
+				array(
+					'a'      => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+					'br'     => array(),
+					'input'  => array(
+						'type'     => array(),
+						'class'    => array(),
+						'data-src' => array(),
+						'value'    => array(),
+					),
+				)
+			),
 		)
 	);
 

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -83,7 +83,6 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 			),
 		)
 	);
-
 	?>
 </table>
 <?php


### PR DESCRIPTION
This PR simply adds score blocks for the Delay Scripts feature. It also adjusts the extension so that the setting blocks are always visible on the User Experience settings page even if the feature is disabled or not pro. If not pro, the fields will be disabled and pro wrapped, and if pro but not enabled, they will simply be disabled and a message will indicate that the feature needs to be enabled