### PR TITLE
Update StackPath message and CDN default to none

### DIFF
--- a/Cdn_GeneralPage_View.php
+++ b/Cdn_GeneralPage_View.php
@@ -74,7 +74,7 @@ Util_Ui::config_overloading_button(
 					'class'  => array(),
 					'src'    => array(),
 					'alt'    => array(),
-					'width' => array(),
+					'width'  => array(),
 					'height' => array(),
 				),
 				'input'  => array(

--- a/Cdn_GeneralPage_View.php
+++ b/Cdn_GeneralPage_View.php
@@ -71,14 +71,10 @@ Util_Ui::config_overloading_button(
 			array(
 				'strong' => array(),
 				'img'    => array(
-					'src'   => array(),
-					'alt'   => array(),
-					'width' => array(),
-				),
-				'img'    => array(
 					'class'  => array(),
 					'src'    => array(),
 					'alt'    => array(),
+					'width' => array(),
 					'height' => array(),
 				),
 				'input'  => array(
@@ -106,14 +102,13 @@ Util_Ui::config_overloading_button(
 			<p>
 				<?php
 				// StackPath sunset is 12:00 am Central (UTC-6:00) on November, 22, 2023 (1700629200).
-				$date_time_format = \get_option( 'date_format' ) . ' ' . \get_option( 'time_format' );
 				\printf(
 					// translators: 1 StackPath sunset datetime.
 					\esc_html__(
-						'StackPath will cease operations at %1$s.',
+						'StackPath ceased operations on %1$s.',
 						'w3-total-cache'
 					),
-					\wp_date( $date_time_format, '1700629200' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					\wp_date( \get_option( 'date_format' ), '1700629200' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				);
 				?>
 			</p>
@@ -125,14 +120,13 @@ Util_Ui::config_overloading_button(
 			<p>
 				<?php
 				// HighWinds sunset is 12:00 am Central (UTC-6:00) on November, 22, 2023 (1700629200).
-				$date_time_format = \get_option( 'date_format' ) . ' ' . \get_option( 'time_format' );
 				\printf(
 					// translators: 1 HighWinds sunset datetime.
 					\esc_html__(
-						'HighWinds will cease operations at %1$s.',
+						'HighWinds ceased operations on %1$s.',
 						'w3-total-cache'
 					),
-					\wp_date( $date_time_format, '1700629200' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					\wp_date( \get_option( 'date_format' ), '1700629200' ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				);
 				?>
 			</p>

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1183,7 +1183,7 @@ $keys = array(
 	),
 	'cdn.engine' => array(
 		'type' => 'string',
-		'default' => 'stackpath2'
+		'default' => ''
 	),
 	'cdn.uploads.enable' => array(
 		'type' => 'boolean',


### PR DESCRIPTION
To test:
1. Select StackPath as the CDN and save settings.
2. See the notice above the selection.

New installations will default to no CDN selected.

Ref: https://github.com/BoldGrid/w3-total-cache-internal/issues/1814
