### PR TITLE
Remove CSS/JS error/warning fixes

### DIFF
--- a/UserExperience_Remove_CssJs_Extension.php
+++ b/UserExperience_Remove_CssJs_Extension.php
@@ -63,13 +63,6 @@ class UserExperience_Remove_CssJs_Extension {
 		Util_Bus::add_ob_callback( 'removecssjs', array( $this, 'ob_callback' ) );
 
 		add_filter( 'w3tc_save_options', array( $this, 'w3tc_save_options' ), 10, 2 );
-
-		add_action( 'w3tc_userexperience_page', array( $this, 'w3tc_userexperience_page' ), 12 );
-
-		/**
-		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
-		*/
-		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
 	}
 
 	/**

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -127,6 +127,10 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 		<?php
 		if ( ! empty( $remove_cssjs_singles ) ) {
 			foreach ( $remove_cssjs_singles as $single_id => $single_config ) {
+				if ( ! is_array( $single_config ) ) {
+					continue;
+				}
+
 				$single_config['includes']         = isset( $single_config['includes'] ) && ! empty( $single_config['includes'] ) ? implode( "\r\n", (array) $single_config['includes'] ) : '';
 				$single_config['includes_content'] = isset( $single_config['includes_content'] ) && ! empty( $single_config['includes_content'] ) ? implode( "\r\n", (array) $single_config['includes_content'] ) : '';
 				?>

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1218,7 +1218,7 @@ class Util_Ui {
 		$c = Dispatcher::config();
 
 		if ( ! isset( $a['value'] ) || is_null( $a['value'] ) ) {
-			$a['value'] = $c->get( $a['key'] );
+			$a['value'] = $c->get( $a['key'] ) ?? '';
 			if ( is_array( $a['value'] ) ) {
 				$a['value'] = implode( "\n", $a['value'] );
 			}


### PR DESCRIPTION
When no singles are defined, the singles block would throw an error when displaying due to how it saves a completely blank section. A check was added to skip processing if the sub-config wasn't an array

This PR also addresses a PHP warning that is thrown for textarea settings that were blank and removes some duplicated hook calls for the Remove CSS/JS feature