### PR TITLE
Fix Redis connect port for unix sockets

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -460,9 +460,9 @@ class Cache_Redis extends Cache_Base {
 
 		if ( substr( $server, 0, 5 ) === 'unix:' ) {
 			$connect_args[] = trim( substr( $server, 5 ) );
-			$connect_args[] = null; // port.
+			$connect_args[] = 0; // Port (int).  For no port, use integer 0.
 		} else {
-			list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
+			list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, 0 ); // Port (int).  For no port, use integer 0.
 			$connect_args[]    = $ip;
 			$connect_args[]    = $port;
 		}


### PR DESCRIPTION
Reported in https://wordpress.org/support/topic/persist-deprecation-error-on-php/

The reported error when using PHP 8.1 was:
```
PHP Deprecated:  Redis::connect(): Passing null to parameter #2 ($port) of type int is deprecated in wp-content/plugins/w3-total-cache/Cache_Redis.php on line 525
```

Uses an integer instead of a null value for the port parameter.

To test,:
1. Configure Redis to listen on a UNIX socket and a port.
2. Configure Page Cache to use Redis.
3. Go to the `wp-admin/admin.php?page=w3tc_pgcache#advanced` page and test the socket with `unix:/tmp/redis.sock` or whatever was configured in Redis.
4. See "Test passed."
