### PR TITLE
Lazy Load Google Maps Proof

### DIFF
--- a/UserExperience_GeneralPage_View.php
+++ b/UserExperience_GeneralPage_View.php
@@ -46,11 +46,11 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 
 	Util_Ui::config_item_pro(
 		array(
-			'key'         => 'lazyload_googlemaps_general_settings',
-			'control'     => 'none',
-			'label_class' => 'w3tc_single_column',
-			'none_label'  => esc_html__( 'Lazy Load Google Maps', 'w3-total-cache' ),
-			'excerpt'     => wp_kses(
+			'key'               => 'lazyload_googlemaps_general_settings',
+			'control'           => 'none',
+			'label_class'       => 'w3tc_single_column',
+			'none_label'        => esc_html__( 'Lazy Load Google Maps', 'w3-total-cache' ),
+			'excerpt'           => wp_kses(
 				sprintf(
 					// translators: 1 opening HTML strong tag, 2 closing HTML strong tag, 3 opening HTML strong tag, 4 closing HTML strong tag,
 					// translators: 5 opening HTML a tag to W3TC User Experience page, 6 closing HTML a tag.
@@ -72,7 +72,13 @@ Util_Ui::config_overloading_button( array( 'key' => 'lazyload.configuration_over
 					'strong' => array(),
 				)
 			),
-			'description' => array(),
+			'description'       => array(),
+			'show_learn_more'   => false,
+			'intro_label'       => __( 'Potential Google PageSpeed Gain', 'w3-total-cache' ),
+			'score'             => '+10',
+			'score_label'       => __( 'Points', 'w3-total-cache' ),
+			'score_description' => __( 'In a recent test, using the Lazy Load Google Maps feature added 10 points to the Google PageSpeed mobile score!', 'w3-total-cache' ),
+			'score_link'        => 'https://www.boldgrid.com/support/w3-total-cache/pagespeed-tests/lazy-load-maps/?utm_source=w3tc&utm_medium=lazy-load-maps&utm_campaign=proof'
 		)
 	);
 


### PR DESCRIPTION
This PR adds the missing proof block on the General Settings page under the User Experience section for the lazy load google maps setting