### PR TITLE
Flush better on actions

### DIFF
--- a/DbCache_Plugin.php
+++ b/DbCache_Plugin.php
@@ -59,9 +59,34 @@ class DbCache_Plugin {
 		// Profile.
 		add_action( 'edit_user_profile_update', array( $this, 'on_change' ), 0 );
 
+		// Multisite.
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'wp_uninitialize_site', array( $this, 'on_change' ), 0 );
-			add_action( 'wp_update_site', array( $this, 'on_change' ), 0 );
+			$util_attachtoactions = new Util_AttachToActions();
+
+			/**
+			 * Fires once a site has been deleted from the database.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @see w3tc_flush_posts()
+			 *
+			 * @link https://developer.wordpress.org/reference/hooks/wp_delete_site/
+			 *
+			 * @param WP_Site $old_site Deleted site object.
+			 */
+			add_action( 'wp_delete_site', 'w3tc_flush_posts', 0, 0 );
+
+			/**
+			 * Fires once a site has been updated in the database.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @link https://developer.wordpress.org/reference/hooks/wp_update_site/
+			 *
+			 * @param WP_Site $new_site New site object.
+			 * @param WP_Site $old_site Old site object.
+			 */
+			add_action( 'wp_update_site', array( $util_attachtoactions, 'on_update_site' ), 0, 2 );
 		}
 
 		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );

--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File: Util_AttachToActions.php
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
 /**
@@ -36,23 +42,107 @@ class Util_AttachToActions {
 		add_action( 'trackback_post', array( $o, 'on_comment_change' ), 0 );
 		add_action( 'pingback_post', array( $o, 'on_comment_change' ), 0 );
 
-		// theme.
-		add_action( 'switch_theme', array( $o, 'on_change' ), 0 );
+		/**
+		 * Fires after the theme is switched.
+		 *
+		 * See 'after_switch_theme'.
+		 *
+		 * @since 1.5.0
+		 * @since 4.5.0 Introduced the `$old_theme` parameter.
+		 *
+		 * @see w3tc_flush_posts()
+		 *
+		 * @link https://developer.wordpress.org/reference/hooks/switch_theme/
+		 *
+		 * @param string   $new_name  Name of the new theme.
+		 * @param WP_Theme $new_theme WP_Theme instance of the new theme.
+		 * @param WP_Theme $old_theme WP_Theme instance of the old theme.
+		 */
+		add_action( 'switch_theme', 'w3tc_flush_posts', 0, 0 );
 
-		// navigation menu.
-		add_action( 'wp_update_nav_menu', array( $o, 'on_change' ), 0 );
+		/**
+		 * Fires after a navigation menu has been successfully updated.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @see w3tc_flush_posts()
+		 *
+		 * @link https://developer.wordpress.org/reference/hooks/wp_update_nav_menu/
+		 *
+		 * @param int   $menu_id   ID of the updated menu.
+		 * @param array $menu_data An array of menu data.
+		 */
+		add_action( 'wp_update_nav_menu', 'w3tc_flush_posts', 0, 0 );
 
-		// user profile.
-		add_action( 'edit_user_profile_update', array( $o, 'on_change' ), 0 );
+		/**
+		 * Terms.
+		 */
 
-		// terms.
-		add_action( 'edited_term', array( $o, 'on_change' ), 0 );
-		add_action( 'delete_term', array( $o, 'on_change' ), 0 );
+		/**
+		 * Fires immediately before the given terms are edited (inserted or updated).
+		 *
+		 * @since 2.9.0
+		 * @since 6.1.0 The `$args` parameter was added.
+		 *
+		 * @see w3tc_flush_posts()
+		 *
+		 * @link https://developer.wordpress.org/reference/hooks/edited_terms/
+		 *
+		 * @param int    $term_id  Term ID.
+		 * @param string $taxonomy Taxonomy slug.
+		 * @param array  $args     Arguments passed to wp_update_term().
+		 */
+		add_action( 'edited_term', 'w3tc_flush_posts', 0, 0 );
 
-		// multisite.
+		/**
+		 * Fires after a term is deleted from the database and the cache is cleaned.
+		 *
+		 * The 'delete_$taxonomy' hook is also available for targeting a specific
+		 * taxonomy.
+		 *
+		 * @since 2.5.0
+		 * @since 4.5.0 Introduced the `$object_ids` argument.
+		 *
+		 * @see w3tc_flush_posts()
+		 *
+		 * @link https://developer.wordpress.org/reference/hooks/delete_term/
+		 *
+		 * @param int     $term         Term ID.
+		 * @param int     $tt_id        Term taxonomy ID.
+		 * @param string  $taxonomy     Taxonomy slug.
+		 * @param WP_Term $deleted_term Copy of the already-deleted term.
+		 * @param array   $object_ids   List of term object IDs.
+		 */
+		add_action( 'delete_term', 'w3tc_flush_posts', 0, 0 );
+
+		/**
+		 * Multisite.
+		 */
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'wp_uninitialize_site', array( $o, 'on_change' ), 0 );
-			add_action( 'wp_update_site', array( $o, 'on_change' ), 0 );
+			/**
+			 * Fires once a site has been deleted from the database.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @see w3tc_flush_posts()
+			 *
+			 * @link https://developer.wordpress.org/reference/hooks/wp_delete_site/
+			 *
+			 * @param WP_Site $old_site Deleted site object.
+			 */
+			add_action( 'wp_delete_site', 'w3tc_flush_posts', 0, 0 );
+
+			/**
+			 * Fires once a site has been updated in the database.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @link https://developer.wordpress.org/reference/hooks/wp_update_site/
+			 *
+			 * @param WP_Site $new_site New site object.
+			 * @param WP_Site $old_site Old site object.
+			 */
+			add_action( 'wp_update_site', array( $o, 'on_update_site' ), 0, 2 );
 		}
 	}
 
@@ -151,10 +241,23 @@ class Util_AttachToActions {
 	}
 
 	/**
-	 * Change action
+	 * Callback: Flush posts after a multisite blog is updated.
+	 *
+	 * @since X.X.X
+	 *
+	 * @link https://developer.wordpress.org/reference/hooks/wp_update_site/
+	 * @param \WP_Site $new_site New site object.
+	 * @param \WP_Site $old_site Old site object.
 	 */
-	public function on_change() {
-		$cacheflush = Dispatcher::component( 'CacheFlush' );
-		$cacheflush->flush_posts();
+	public function on_update_site( \WP_Site $new_site, \WP_Site $old_site ) {
+		if (
+			$new_site->domain !== $old_site->domain ||
+			$new_site->path !== $old_site->path ||
+			$new_site->public !== $old_site->public ||
+			$new_site->archived !== $old_site->archived ||
+			$new_site->lang_id !== $old_site->lang_id
+		) {
+			w3tc_flush_posts();
+		}
 	}
 }


### PR DESCRIPTION
This update better handles the flushing of Page, Object, and Database caches on certain actions.
Fixes #929

To test:
1. Enable Page, Object, and Database cache on a multisite installation.
2. Create a test blog site.
3. Browse around in incognito/private browsing to build cache objects.
4. Delete the test blog site.  Caches should flush.
5. On any WordPress installation, repeat step 3 and each of the following actions:
  a. Switch theme.
  b. Create or edit a nav menu item.
  c. Take action to create or edit a taxonomy term.
  d. Take action to delete a taxonomy term.