### PR TITLE
Check API2 status for non-200

### DIFF
--- a/Generic_Plugin_AdminNotices.php
+++ b/Generic_Plugin_AdminNotices.php
@@ -122,7 +122,7 @@ class Generic_Plugin_AdminNotices {
 
 		$api_response = wp_remote_get( esc_url( W3TC_NOTICE_FEED ) );
 
-		if ( is_wp_error( $api_response ) ) {
+		if ( is_wp_error( $api_response ) || wp_remote_retrieve_response_code( $api_response ) !== 200 ) {
 			return null;
 		}
 


### PR DESCRIPTION
When the API2 server returns a non-200 HTTP status, the message is usually something like the following:
```
<p>There has been a critical error on this website.</p>
<p>
    <a href="https://wordpress.org/documentation/article/faq-troubleshooting/">Learn more about troubleshooting WordPress.</a>
</p>
```
The admin-ajax call does not return the actual markup returned; it sends JSON like the following:
```
{"message": "server error"}
```
... which is valid JSON, so the method continues and expects a certain structure that does not exist and hits a fatal error.
```
PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in wp-content/plugins/w3-total-cache/Generic_Plugin_AdminNotices.php:142
```

I noticed this issue when the development API2 MySQL server was down.
