### PR TITLE
Update support link color in admin bar and menu

### DIFF
--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -734,16 +734,12 @@ td.w3tc_config_value_text {
 	margin-right: auto;
 }
 
-.w3tc_menu_item_pro {
+.w3tc_menu_item_pro, #toplevel_page_w3tc_dashboard li a[href="admin.php?page=w3tc_support"] {
 	color: #0FA9B5;
 }
 
-.w3tc_menu_item_pro:hover {
+.w3tc_menu_item_pro:hover, #toplevel_page_w3tc_dashboard li a[href="admin.php?page=w3tc_support"]:hover {
 	color: #ddd;
-}
-
-#toplevel_page_w3tc_dashboard li a[href="admin.php?page=w3tc_support"] {
-	color: #72aee6;
 }
 
 .w3tc_popup_form {

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -743,7 +743,7 @@ td.w3tc_config_value_text {
 }
 
 #toplevel_page_w3tc_dashboard li a[href="admin.php?page=w3tc_support"] {
-	color: red;
+	color: #72aee6;
 }
 
 .w3tc_popup_form {
@@ -1685,7 +1685,7 @@ td .w3tc-control-after span {
 		float: none;
 		margin: 1em auto;
 	}
-	
+
 	#w3tc-bunnycdn-ad-cdn,
 	#w3tc-bunnycdn-ad-general {
         flex-direction: column;


### PR DESCRIPTION
Fixes [internal-1816](https://github.com/BoldGrid/w3-total-cache-internal/issues/1816)

### Testing

- Suppot link in the admin menu is now blue instead of red.