### PR TITLE
License Status Fix

### DIFF
--- a/Generic_WidgetAccount_View.php
+++ b/Generic_WidgetAccount_View.php
@@ -19,7 +19,13 @@ $license     = Licensing_Core::check_license( $license_key, W3TC_VERSION );
 <table>
 	<tr>
 		<td><b><?php esc_html_e( 'License:', 'w3-total-cache' ); ?></b></td>
-		<td><?php echo ! empty( $license ) && $license->license_status === 'active.by_rooturi' ? __( 'Pro', 'w3-total-cache' ) : __( 'Free', 'w3-total-cache' ); ?></td>
+		<td>
+			<?php
+				echo ! empty( $license ) && in_array( $license->license_status, array( 'active.by_rooturi', 'active.by_ip' ), true )
+					? esc_html__( 'Pro', 'w3-total-cache' )
+					: esc_html__( 'Free', 'w3-total-cache' );
+			?>
+		</td>
 	</tr>
 	<tr>
 		<td><b><?php esc_html_e( 'Status:', 'w3-total-cache' ); ?></b></td>

--- a/Generic_WidgetAccount_View.php
+++ b/Generic_WidgetAccount_View.php
@@ -28,6 +28,7 @@ $license     = Licensing_Core::check_license( $license_key, W3TC_VERSION );
 			if ( ! empty( $license ) ) {
 				switch ( $license ) {
 					case 'active.by_rooturi' === $license->license_status:
+					case 'active.by_ip' === $license->license_status:
 						esc_html_e( 'Active', 'w3-total-cache' );
 						break;
 					case 'inactive.expired' === $license->license_status:


### PR DESCRIPTION
This PR simply adds another case for "active.by_ip" for the license status in the Account widget on the Dashboard