### PR TITLE
Statistics Widget Warning Fix

### DIFF
--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -348,11 +348,9 @@ class PgCache_Plugin_Admin {
 				}
 			}
 		} else {
-			// all request counts data available
-			$pagecache['requests'] = $summary['php']['php_requests_v'];
-			$pagecache['requests_hit'] =
-				isset( $summary['php']['php_requests_pagecache_hit'] ) ?
-				$summary['php']['php_requests_pagecache_hit'] : 0;
+			// all request counts data available.
+			$pagecache['requests']     = isset( $summary['php']['php_requests_v'] ) ? $summary['php']['php_requests_v'] : 0;
+			$pagecache['requests_hit'] = isset( $summary['php']['php_requests_pagecache_hit'] ) ? $summary['php']['php_requests_pagecache_hit'] : 0;
 
 			$requests_time_ms = Util_UsageStatistics::sum( $history,
 				'pagecache_requests_time_10ms' ) * 10;


### PR DESCRIPTION
This PR addresses a PHP warning that is thrown if the usage statistics data becomes stale