### PR TITLE
Add WP Cron error notice

### DIFF
--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -922,6 +922,22 @@ class Extension_ImageService_Plugin_Admin {
 					</p>
 				</div>
 				<?php
+			} elseif ( ! Util_Environment::is_wpcron_working() ) {
+				// WP Cron is now functioning correctly.
+				?>
+				<div class="notice notice-error is-dismissible">
+					<p>
+						<?php
+						printf(
+							// translators: 1: HTML anchor open tag, 2: HTML anchor close tag.
+							esc_html__( 'WP Cron is not working as expected, which is required for WebP conversions.  %1$sLearn more%2$s.', 'w3-total-cache' ),
+							'<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/enable-wp-cron/?utm_source=w3tc&utm_medium=wp_cron&utm_campaign=imageservice' ) . '">',
+							'</a>'
+						);
+						?>
+					</p>
+				</div>
+				<?php
 			}
 		}
 	}

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -1664,4 +1664,92 @@ class Util_Environment {
 
 		return false;
 	}
+
+	/**
+	 * Tests the WP Cron spawning system and reports back its status.
+	 *
+	 * This command tests the spawning system by performing the following steps:
+	 *
+	 * * Checks to see if the `DISABLE_WP_CRON` constant is set; errors if true
+	 * because WP-Cron is disabled.
+	 * * Checks to see if the `ALTERNATE_WP_CRON` constant is set; warns if true.
+	 * * Attempts to spawn WP-Cron over HTTP; warns if non 200 response code is
+	 * returned.
+	 *
+	 * @since X.X.X
+	 * @link  https://github.com/wp-cli/cron-command/blob/v2.3.1/src/Cron_Command.php#L14-L55
+	 *
+	 * @return boolean
+	 */
+	public static function is_wpcron_working() {
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			$errormsg = 'The DISABLE_WP_CRON constant is set to true. WP-Cron spawning is disabled.';
+			return false;
+		}
+
+		if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
+			$errormsg = 'The ALTERNATE_WP_CRON constant is set to true. WP-Cron spawning is not asynchronous.';
+			return false;
+		}
+
+		$spawn = self::get_cron_spawn();
+
+		if ( is_wp_error( $spawn ) ) {
+			$errormsg = sprintf( 'WP-Cron spawn failed with error: %s', $spawn->get_error_message() );
+			return false;
+		}
+
+		$code    = wp_remote_retrieve_response_code( $spawn );
+		$message = wp_remote_retrieve_response_message( $spawn );
+
+		if ( 200 === $code ) {
+			// WP-Cron spawning is working as expected.
+			return true;
+		} else {
+			$errormsg = sprintf( 'WP-Cron spawn returned HTTP status code: %1$s %2$s', $code, $message );
+			return false;
+		}
+	}
+
+	/**
+	 * Spawns a request to `wp-cron.php` and return the response.
+	 *
+	 * This function is designed to mimic the functionality in `spawn_cron()`
+	 * with the addition of returning the result of the `wp_remote_post()`
+	 * request.
+	 *
+	 * @since X.X.X
+	 * @link  https://github.com/wp-cli/cron-command/blob/v2.3.1/src/Cron_Command.php#L57-L91
+	 *
+	 * @global $wp_version WordPress version string.
+	 *
+	 * @return WP_Error|array The response or WP_Error on failure.
+	 */
+	protected static function get_cron_spawn() {
+		global $wp_version;
+
+		$sslverify     = version_compare( $wp_version, 4.0, '<' );
+		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
+
+		$cron_request_array = array(
+			'url'  => site_url( 'wp-cron.php?doing_wp_cron=' . $doing_wp_cron ),
+			'key'  => $doing_wp_cron,
+			'args' => array(
+				'timeout'   => 3,
+				'blocking'  => true,
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Calling native WordPress hook.
+				'sslverify' => apply_filters( 'https_local_ssl_verify', $sslverify ),
+			),
+		);
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Calling native WordPress hook.
+		$cron_request = apply_filters( 'cron_request', $cron_request_array );
+
+		// Enforce a blocking request in case something that's hooked onto the 'cron_request' filter sets it to false.
+		$cron_request['args']['blocking'] = true;
+
+		$result = wp_remote_post( $cron_request['url'], $cron_request['args'] );
+
+		return $result;
+	}
 }


### PR DESCRIPTION
To test, add a "Deny from <ip_address>" for the server IP address to `.htaccess` and go to the Media Library page in list mode (`wp-admin/upload.php?mode=list`) with the WebP Converter active.  There will be an admin notice at the top of the page with a support link.