### PR TITLE
Update disk notice logic

### DIFF
--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -482,37 +482,47 @@ function cdn_cf_bucket_location() {
 		.text( id + '.s3.' + get_bucket_region( jQuery( '#cdn_cf_bucket_location' ).val() ) + 'amazonaws.com' );
 }
 
+/**
+ * Toggle the disk notice for dbcache.
+ *
+ * @since X.X.X
+ */
+function toggle_dbcache_notice() {
+	if ( jQuery('#dbcache__engine').val() === 'file' && jQuery('#dbcache__enabled').is(':checked') ) {
+		jQuery('.dbcache_disk_notice').show();
+	} else {
+		jQuery('.dbcache_disk_notice').hide();
+	}
+}
+
+/**
+ * Toggle the disk notice for objectcache.
+ *
+ * @since X.X.X
+ */
+function toggle_objectcache_notice() {
+	if ( jQuery('#objectcache__engine').val() === 'file' && jQuery('#objectcache__enabled').is(':checked') ) {
+		jQuery('.objectcache_disk_notice').show();
+	} else {
+		jQuery('.objectcache_disk_notice').hide();
+	}
+}
+
 // On document ready.
 jQuery(function() {
 	// Global vars.
 	var $cdn_enabled = jQuery('#cdn__enabled'),
 		$cdn_engine = jQuery('#cdn__engine');
 
-	// Object cache disk usage warning
-	if ( jQuery('#objectcache__engine').val() === 'file' ) {
-		jQuery('.objectcache_disk_notice').show();
-	}
+	// Database cache disk usage warning.
+	toggle_dbcache_notice();
+	jQuery('#dbcache__enabled').change(toggle_dbcache_notice);
+	jQuery('#dbcache__engine').change(toggle_dbcache_notice);
 
-	jQuery('#objectcache__engine').change( function() {
-        if ( jQuery(this).val() === 'file' ) {
-			jQuery('.objectcache_disk_notice').show();
-        } else {
-			jQuery('.objectcache_disk_notice').hide();
-		}
-    });
-
-  // Database cache disk usage warning
-	if ( jQuery('#dbcache__engine').val() === 'file' ) {
-		jQuery('.dbcache_disk_notice').show();
-	}
-
-	jQuery('#dbcache__engine').change( function() {
-		if ( jQuery(this).val() === 'file' ) {
-			jQuery('.dbcache_disk_notice').show();
-		} else {
-			jQuery('.dbcache_disk_notice').hide();
-		}
-	});
+	// Object cache disk usage warning.
+	toggle_objectcache_notice();
+	jQuery('#objectcache__enabled').change(toggle_objectcache_notice);
+	jQuery('#objectcache__engine').change(toggle_objectcache_notice);
 
 	// General page.
 	jQuery('.w3tc_read_technical_info').on('click', function() {


### PR DESCRIPTION
To test, go to the General Settings and toggle the Database Cache and Object Cache engines to see when the notices are shown or hidden.  A notice is only displayed when the engine is enabled and the type is "Disk".
