### PR TITLE
Always Cached UI Update

### DIFF
--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -17,6 +17,7 @@ if ( ! defined( 'W3TC' ) ) {
 
 $config = Dispatcher::config();
 
+<<<<<<< HEAD
 if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	echo wp_kses(
 		sprintf(
@@ -40,6 +41,8 @@ if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	);
 }
 
+=======
+>>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 ?>
 <p>
 	<?php esc_html_e( 'Page Cache is currently ', 'w3-total-cache' ); ?>

--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -17,6 +17,29 @@ if ( ! defined( 'W3TC' ) ) {
 
 $config = Dispatcher::config();
 
+if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
+	echo wp_kses(
+		sprintf(
+			// Translators: 1 opening HTML div tag followed by opening HTML p tag, 2 opening HTML a tag to general settings page,
+			// Translators: 3 closing HTML a tag, 4 closing HTML p tag followed by closing HTML div tag.
+			__( '%1$sPage Cache is required for the Always Cached extension. Please enable it %2$shere.%3$s%4$s', 'w3-total-cache' ),
+			'<div class="notice notice-error inline"><p>',
+			'<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '">',
+			'</a>',
+			'</p></div>'
+		),
+		array(
+			'div' => array(
+				'class' => array(),
+			),
+			'p'   => array(),
+			'a'   => array(
+				'href' => array(),
+			),
+		)
+	);
+}
+
 ?>
 <p>
 	<?php esc_html_e( 'Page Cache is currently ', 'w3-total-cache' ); ?>

--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -19,6 +19,7 @@ $config = Dispatcher::config();
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	echo wp_kses(
 		sprintf(
@@ -42,6 +43,8 @@ if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	);
 }
 
+=======
+>>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 =======
 >>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 =======

--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -17,9 +17,6 @@ if ( ! defined( 'W3TC' ) ) {
 
 $config = Dispatcher::config();
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	echo wp_kses(
 		sprintf(
@@ -43,12 +40,6 @@ if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	);
 }
 
-=======
->>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
-=======
->>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
-=======
->>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 ?>
 <p>
 	<?php esc_html_e( 'Page Cache is currently ', 'w3-total-cache' ); ?>

--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -18,6 +18,7 @@ if ( ! defined( 'W3TC' ) ) {
 $config = Dispatcher::config();
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	echo wp_kses(
 		sprintf(
@@ -41,6 +42,8 @@ if ( ! $config->get_boolean( 'pgcache.enabled' ) ) {
 	);
 }
 
+=======
+>>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 =======
 >>>>>>> 33b25193 (Updated descriptions of many of the settings for more clarity on function and purpose. Several other tweaks.)
 ?>

--- a/Extension_AlwaysCached_Page_View.php
+++ b/Extension_AlwaysCached_Page_View.php
@@ -15,7 +15,19 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
+$config = Dispatcher::config();
+
 ?>
+<p>
+	<?php esc_html_e( 'Page Cache is currently ', 'w3-total-cache' ); ?>
+	<?php
+	if ( $config->get_boolean( 'pgcache.enabled' ) ) {
+		echo '<span class="w3tc-enabled">' . esc_html__( 'enabled.', 'w3-total-cache' ) . '</span>';
+	} else {
+		echo '<span class="w3tc-disabled">' . esc_html__( 'disabled.', 'w3-total-cache' ) . '</span>';
+	}
+	?>
+<p>
 <p>
 	<?php esc_html_e( 'AlwaysCached extension is currently ', 'w3-total-cache' ); ?>
 	<?php
@@ -28,12 +40,6 @@ if ( ! defined( 'W3TC' ) ) {
 <p>
 <p>
 	<?php esc_html_e( 'The Always Cached extension prevents page/post updates from clearing corresponding cache entries and instead adds them to a queue that can be manually cleared or scheduled to clear via cron.', 'w3-total-cache' ); ?>
-</p>
-<p>
-	<?php esc_html_e( 'The "Pending in queue" represent pages/posts that have been updated but are still serving the pre-update cache entry.', 'w3-total-cache' ); ?>
-</p>
-<p>
-	<?php esc_html_e( 'The "Postponed in queue" represent pages/posts that failed to process either due to an error or due to the queue processor exceeding its allocated time slot. These entries will be processed on the next scheduled queue processor execution.', 'w3-total-cache' ); ?>
 </p>
 <form action="admin.php?page=w3tc_extensions&amp;extension=alwayscached&amp;action=view" method="post">
 	<?php

--- a/Extension_AlwaysCached_Page_View_BoxCron.php
+++ b/Extension_AlwaysCached_Page_View_BoxCron.php
@@ -15,8 +15,10 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
-$c           = Dispatcher::config();
-$wp_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
+$c                = Dispatcher::config();
+$pgcache_disabled = ! $c->get_boolean( 'pgcache.enabled' );
+$wp_cron_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
+
 ?>
 <div class="metabox-holder">
 	<?php Util_Ui::postbox_header( esc_html__( 'Cron', 'w3-total-cache' ), '', 'cron' ); ?>
@@ -33,6 +35,7 @@ $wp_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
 				'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
 				'control'        => 'checkbox',
 				'description'    => esc_html__( 'Enabling this will schedule a WP-Cron event that will process the queue and regenerate cache files. If you prefer to use a system cron job instead of WP-Cron, you can schedule the following command to run at your desired interval: "wp w3tc alwayscached_process".', 'w3-total-cache' ),
+				'disabled'       => $pgcache_disabled,
 			)
 		);
 
@@ -54,7 +57,8 @@ $wp_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
 				'label'            => esc_html__( 'Start Time', 'w3-total-cache' ),
 				'control'          => 'selectbox',
 				'selectbox_values' => $time_options,
-				'disabled'         => $wp_disabled,
+				'description'      => esc_html__( 'This setting controls the initial start time of the Cron Job based on the configured WordPress timezone. It will automatically adjust the timestamp used to accommodate differences between the configured WordPress and server timezones. If the selected time has already passed, it will add a day so that it begins the next day.', 'w3-total-cache' ),
+				'disabled'         => $pgcache_disabled || $wp_cron_disabled,
 			)
 		);
 
@@ -72,7 +76,8 @@ $wp_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
 					'daily'      => esc_html__( 'Daily', 'w3-total-cache' ),
 					'weekly'     => esc_html__( 'Weekly', 'w3-total-cache' ),
 				),
-				'disabled'         => $wp_disabled,
+				'description'      => esc_html__( 'This setting controls the interval that the Cron Job should occur.', 'w3-total-cache' ),
+				'disabled'         => $pgcache_disabled || $wp_cron_disabled,
 			)
 		);
 		?>

--- a/Extension_AlwaysCached_Page_View_BoxCron.php
+++ b/Extension_AlwaysCached_Page_View_BoxCron.php
@@ -57,7 +57,7 @@ $wp_cron_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
 				'label'            => esc_html__( 'Start Time', 'w3-total-cache' ),
 				'control'          => 'selectbox',
 				'selectbox_values' => $time_options,
-				'description'      => esc_html__( 'This setting controls the initial start time of the Cron Job based on the configured WordPress timezone. It will automatically adjust the timestamp used to accommodate differences between the configured WordPress and server timezones. If the selected time has already passed, it will add a day so that it begins the next day.', 'w3-total-cache' ),
+				'description'      => esc_html__( 'This setting controls the initial start time of the cron job based on the configured WordPress timezone. It will automatically adjust the timestamp to accommodate differences between the configured WordPress and server timezones. If the selected time has already passed, it will add a day so that it begins the next day.', 'w3-total-cache' ),
 				'disabled'         => $pgcache_disabled || $wp_cron_disabled,
 			)
 		);
@@ -76,7 +76,7 @@ $wp_cron_disabled = ! $c->get_boolean( array( 'alwayscached', 'wp_cron' ) );
 					'daily'      => esc_html__( 'Daily', 'w3-total-cache' ),
 					'weekly'     => esc_html__( 'Weekly', 'w3-total-cache' ),
 				),
-				'description'      => esc_html__( 'This setting controls the interval that the Cron Job should occur.', 'w3-total-cache' ),
+				'description'      => esc_html__( 'This setting controls the interval that the cron job should occur.', 'w3-total-cache' ),
 				'disabled'         => $pgcache_disabled || $wp_cron_disabled,
 			)
 		);

--- a/Extension_AlwaysCached_Page_View_BoxFlushAll.php
+++ b/Extension_AlwaysCached_Page_View_BoxFlushAll.php
@@ -15,8 +15,9 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
-$c        = Dispatcher::config();
-$disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
+$c                 = Dispatcher::config();
+$pgcache_disabled  = ! $c->get_boolean( 'pgcache.enabled' );
+$flushall_disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
 
 ?>
 <div class="metabox-holder">
@@ -34,6 +35,7 @@ $disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
 				'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
 				'control'        => 'checkbox',
 				'description'    => esc_html__( 'With this enabled, the "Purge All Caches" action will instead queue items based on the below settings. If this is NOT enabled, the "Flush All" action will purge all caches and clear all queue entries as pending changes will be applied. Note that enabling this can cause the "Flush All" action to take longer, especially if the "Number of Latests Pages/Posts" are set at a high value.', 'w3-total-cache' ),
+				'disabled'       => $pgcache_disabled,
 			)
 		);
 
@@ -51,9 +53,10 @@ $disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
 					'flush_all_home',
 				),
 				'label'          => esc_html__( 'Homepage', 'w3-total-cache' ),
+				'description'    => esc_html__( 'This setting controls whether the homepage should be added to the queue when a flush all operation occurs.', 'w3-total-cache' ),
 				'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
 				'control'        => 'checkbox',
-				'disabled'       => $disabled,
+				'disabled'       => $pgcache_disabled || $flushall_disabled,
 			)
 		);
 
@@ -64,11 +67,11 @@ $disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
 					'flush_all_posts_count',
 				),
 				'label'        => esc_html__( 'Number of Latest Posts:', 'w3-total-cache' ),
-				'description'  => esc_html__( 'Number of latest posts to regenerate', 'w3-total-cache' ),
+				'description'  => esc_html__( 'This setting controls the number of latest posts that will be added to the queue when a flush all operation occurs. If this field is left blank it will default to the latest 15 posts.', 'w3-total-cache' ),
 				'control'      => 'textbox',
 				'textbox_type' => 'number',
 				'default'      => '10',
-				'disabled'     => $disabled,
+				'disabled'     => $pgcache_disabled || $flushall_disabled,
 			)
 		);
 
@@ -79,11 +82,11 @@ $disabled = ! $c->get_boolean( array( 'alwayscached', 'flush_all' ) );
 					'flush_all_pages_count',
 				),
 				'label'        => esc_html__( 'Number of Latest Pages:', 'w3-total-cache' ),
-				'description'  => esc_html__( 'Number of latest pages to regenerate', 'w3-total-cache' ),
+				'description'  => esc_html__( 'This setting controls the number of latest pages that will be added to the queue when a flush all operation occurs. If this field is left blank it will default to the latest 15 pages.', 'w3-total-cache' ),
 				'control'      => 'textbox',
 				'textbox_type' => 'number',
 				'default'      => '10',
-				'disabled'     => $disabled,
+				'disabled'     => $pgcache_disabled || $flushall_disabled,
 			)
 		);
 

--- a/Extension_AlwaysCached_Page_View_BoxQueue.php
+++ b/Extension_AlwaysCached_Page_View_BoxQueue.php
@@ -15,6 +15,9 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
+$c                = Dispatcher::config();
+$pgcache_disabled = ! $c->get_boolean( 'pgcache.enabled' );
+
 $count_pending   = Extension_AlwaysCached_Queue::row_count_pending();
 $count_postponed = Extension_AlwaysCached_Queue::row_count_postponed();
 
@@ -22,6 +25,18 @@ $time_lastrun = get_option( 'w3tc_alwayscached_worker_timestamp' );
 ?>
 <div class="metabox-holder">
 	<?php Util_Ui::postbox_header( esc_html__( 'Queue', 'w3-total-cache' ), '', 'queue' ); ?>
+	<p>
+		<?php esc_html_e( 'The "Pending in queue" represent pages/posts that have been updated but are still serving the pre-update cache entry.', 'w3-total-cache' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'The "Postponed in queue" represent pages/posts that failed to process either due to an error or due to the queue processor exceeding its allocated time slot. These entries will be processed on the next scheduled queue processor execution.', 'w3-total-cache' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'The "Last processed" represents the last time the queue processor was executed.', 'w3-total-cache' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'When viewing the queue, each entry will have a circular arrow icon that can be clicked to manually regenerate the corresponding cache entry. Once this completes, the queue entry will be removed from the queue.', 'w3-total-cache' ); ?>
+	</p>
 	<table class="form-table">
 		<tr>
 			<th style="width: 300px;">
@@ -93,9 +108,20 @@ $time_lastrun = get_option( 'w3tc_alwayscached_worker_timestamp' );
 			<th></th>
 			<td>
 				<input id="w3tc-alwayscached-process" type="submit" name="w3tc_alwayscached_process"
-					value="<?php esc_html_e( 'Regenerate All', 'w3-total-cache' ); ?>" class="button" />
+					value="<?php esc_html_e( 'Regenerate All', 'w3-total-cache' ); ?>" class="button" <?php echo $pgcache_disabled ? 'disabled="disabled"' : ''; ?>/>
+				<p>
+					<?php esc_html_e( 'This button will manually trigger the queue processor to begin regenerating the cache entry for each item in the queue, thereby publishing all pending changes.', 'w3-total-cache' ); ?>
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<th></th>
+			<td>
 				<input id="w3tc-alwayscached-empty" type="submit" name="w3tc_alwayscached_empty"
-					value="<?php esc_html_e( 'Clear Queue', 'w3-total-cache' ); ?>" class="button" />
+					value="<?php esc_html_e( 'Clear Queue', 'w3-total-cache' ); ?>" class="button" <?php echo $pgcache_disabled ? 'disabled="disabled"' : ''; ?>/>
+				<p>
+					<?php esc_html_e( 'This button removes all items in the queue. The pending changes for each removed item will not be published until the corresponding existing cache entry expires. Removed items can be re-added to the queue via further modifications to the item or a flush all caches operation with the "Queue Purge All Requests" option enabled.', 'w3-total-cache' ); ?>
+				</p>
 			</td>
 		</tr>
 	</table>

--- a/Extension_AlwaysCached_Page_View_Exclusions.php
+++ b/Extension_AlwaysCached_Page_View_Exclusions.php
@@ -15,7 +15,8 @@ if ( ! defined( 'W3TC' ) ) {
 	die();
 }
 
-$c           = Dispatcher::config();
+$c                = Dispatcher::config();
+$pgcache_disabled = ! $c->get_boolean( 'pgcache.enabled' )
 ?>
 <div class="metabox-holder">
 	<?php Util_Ui::postbox_header( esc_html__( 'Exclusions', 'w3-total-cache' ), '', 'exclusions' ); ?>
@@ -30,6 +31,7 @@ $c           = Dispatcher::config();
 				'control'     => 'textarea',
 				'label'       => esc_html__( 'Exclusions:', 'w3-total-cache' ),
 				'description' => esc_html__( 'URLs defined here will be excluded from the Always Cached process and will behave normally in that updates will invalidate relevent cache entries rather than be added to the queue. Specify one URL per line. These can be absolute or releative, and can include wildcards.', 'w3-total-cache' ),
+				'disabled'    => $pgcache_disabled,
 			)
 		);
 		?>

--- a/Extension_AlwaysCached_Plugin.php
+++ b/Extension_AlwaysCached_Plugin.php
@@ -293,7 +293,7 @@ class Extension_AlwaysCached_Plugin {
 				}
 			}
 
-			$posts_count = $c->get_integer( array( 'alwayscached', 'flush_all_posts_count' ) );
+			$posts_count = $c->get_integer( array( 'alwayscached', 'flush_all_posts_count' ) ) ?? 15;
 			if ( $posts_count > 0 ) {
 				$posts = get_posts(
 					array(
@@ -325,7 +325,7 @@ class Extension_AlwaysCached_Plugin {
 				}
 			}
 
-			$pages_count = $c->get_integer( array( 'alwayscached', 'flush_all_pages_count' ) );
+			$pages_count = $c->get_integer( array( 'alwayscached', 'flush_all_pages_count' ) ) ?? 15;
 			if ( $pages_count > 0 ) {
 				$posts = get_posts(
 					array(


### PR DESCRIPTION
This PR simply updates the UI for many of the settings to better clarify what each does. It also adds a check for if Page Cache is enabled and displays an admin notice if it's not, indicating to enable it with a link to the General Settings page