### PR TITLE
Add help tabs and content

### DIFF
--- a/Cdnfsd_GeneralPage_View.php
+++ b/Cdnfsd_GeneralPage_View.php
@@ -121,4 +121,7 @@ defined( 'W3TC' ) || die;
 	);
 	?>
 </table>
-<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'cdn' ) ); ?>
+<?php
+	echo wp_kses_post( Util_Ui::get_tab( 'cdn', 'tutorials' ) );
+	echo wp_kses_post( Util_Ui::get_tab( 'cdn', 'premium-services' ) );
+?>

--- a/Cdnfsd_GeneralPage_View.php
+++ b/Cdnfsd_GeneralPage_View.php
@@ -122,6 +122,6 @@ defined( 'W3TC' ) || die;
 	?>
 </table>
 <?php
-	echo wp_kses_post( Util_Ui::get_tab( 'cdn', 'tutorials' ) );
+	echo wp_kses_post( Util_Ui::get_tab( 'cdn', 'help' ) );
 	echo wp_kses_post( Util_Ui::get_tab( 'cdn', 'premium-services' ) );
 ?>

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -24,15 +24,15 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.youtube.com/watch?v=vdp0OrJ8hAg' ) . '" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/page-cache/' ) . '" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'minify'         => array(
@@ -51,13 +51,13 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/minify/' ) . '" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'database_cache' => array(
@@ -76,15 +76,15 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/database-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/database-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.youtube.com/watch?v=OWJckWamEvA' ) . '" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/database-cache/' ) . '" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'object_cache'   => array(
@@ -103,13 +103,13 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/object-cache/' ) . '" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'browser_cache'  => array(
@@ -128,13 +128,13 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/browser-cache/' ) . '" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'cdn'            => array(
@@ -151,17 +151,17 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Cloudflare with W3 Total Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'How to configure Cloudflare with W3 Total Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/bunny-cdn-setup/#configure-w3-total-cache?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Full Site Delivery with Bunny CDN', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/bunny-cdn-setup/#configure-w3-total-cache?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'Full Site Delivery with Bunny CDN', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab' ) . '" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn">
 				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><p>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="' . esc_url( 'https://www.boldgrid.com/support/topic-tag/cdn/' ) . '" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><p>
+				<p><a class="button button-secondary" href="' . esc_url( 'https://www.boldgrid.com/support/ask-a-question/' ) . '" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -22,10 +22,13 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a><p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>',
+				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache"></div>',
 		),
 	),
 	'minify'         => array(
@@ -42,8 +45,11 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>',
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>',
 		),
 	),
 	'database_cache' => array(
@@ -60,10 +66,13 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>',
+				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache"></div>',
 		),
 	),
 	'object_cache'   => array(
@@ -80,8 +89,11 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>',
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>',
 		),
 	),
 	'browser_cache'  => array(
@@ -98,8 +110,11 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>',
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>',
 		),
 	),
 	'cdn'            => array(
@@ -115,10 +130,13 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
+				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>',
+				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -24,13 +24,15 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a><p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '</a><br>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Form Topics... </p>
+				</div>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><br>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( '   in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'minify'         => array(
@@ -49,11 +51,11 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '</a>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'database_cache' => array(
@@ -72,13 +74,13 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/database-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
-				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '</a>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'object_cache'   => array(
@@ -97,11 +99,11 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '</a>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'browser_cache'  => array(
@@ -120,11 +122,11 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '</a>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'cdn'            => array(
@@ -142,13 +144,13 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>
-				<a href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '</a>
-				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -24,15 +24,15 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache">
-				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Form Topics... </p>
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
 				</div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><br>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( '   in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'minify'         => array(
@@ -53,9 +53,11 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
+				</div>
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'database_cache' => array(
@@ -78,9 +80,11 @@ return array(
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a class="w3tc-control-after" href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache"></div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
+				</div>
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'object_cache'   => array(
@@ -101,9 +105,11 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
+				</div>
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'browser_cache'  => array(
@@ -124,9 +130,11 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
+				</div>
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 	'cdn'            => array(
@@ -148,9 +156,11 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>
-				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn">
+				<p style="width:fit-content"><span class="spinner is-active" style="margin: 0 0 0 5px"></span> Loading Forum Topics... </p>
+				</div>
+				<p><a class="w3tc-control-after" href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a><p>
+				<p><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a> ' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -24,7 +24,7 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a><p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a><p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
@@ -49,7 +49,7 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>
 				<a href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '</a>
@@ -72,7 +72,7 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a></p>
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
@@ -97,7 +97,7 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>
 				<a href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '</a>
@@ -120,7 +120,7 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>
 				<a href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '</a>
@@ -142,10 +142,10 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>
 				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>
 				<a href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '</a>
 				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -151,7 +151,9 @@ return array(
 				</div>',
 			'help'            => '<h3>' . esc_html__( 'Documentation', 'w3-total-cache' ) . '</h3>
 				<p><span class="dashicons dashicons-text-page"></span>
-				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'How to configure Cloudflare with W3 Total Cache', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
+				<p><span class="dashicons dashicons-text-page"></span>
+				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/bunny-cdn-setup/#configure-w3-total-cache?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Full Site Delivery with Bunny CDN', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a class="w3tc-control-after" href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/?utm_source=w3tc&utm_medium=documentation&utm_campaign=helptab" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -146,7 +146,6 @@ return array(
 				<p><span class="dashicons dashicons-yes-alt"></span>' . esc_html__( 'Optimized for full page delivery, not just static files, enhancing overall site performance.', 'w3-total-cache' ) . '</p>
 				<p><span class="dashicons dashicons-yes-alt"></span>' . esc_html__( 'Setup includes integration with W3 Total Cache FSD CDN Pro for seamless performance.', 'w3-total-cache' ) . '</p>
 				<p><span class="dashicons dashicons-yes-alt"></span>' . esc_html__( 'Compatible with top CDN providers like Bunny CDN, Transparent CDN, Amazon, and Cloudflare.', 'w3-total-cache' ) . '</p>
-
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -22,12 +22,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Page Cache?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a>
-				<h3>' . esc_html__( 'Videos: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a><p>
+				<p><span class="dashicons dashicons-video-alt3"></span>
+				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 	'minify'         => array(
@@ -44,10 +42,8 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Page Cache?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 	'database_cache' => array(
@@ -64,12 +60,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Database Cache?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a>
-				<h3>' . esc_html__( 'Videos: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a></p>
+				<p><span class="dashicons dashicons-video-alt3"></span>
+				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 	'object_cache'   => array(
@@ -86,10 +80,8 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Object Cache?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 	'browser_cache'  => array(
@@ -106,10 +98,8 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Browser Cache?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 	'cdn'            => array(
@@ -125,11 +115,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
-			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up your CDN?', 'w3-total-cache' ) . '</h3>
-				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
-				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a><br>
-				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a>',
+			'tutorials'       => '<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a></p>
+				<p><span class="dashicons dashicons-text-page"></span>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -28,7 +28,9 @@ return array(
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_page_cache"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/page-cache/" target="_blank">' . esc_html__( 'View all questions in Page Cache forum', 'w3-total-cache' ) . '</a><br>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 	'minify'         => array(
@@ -49,7 +51,9 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_minify_cache"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/minify/" target="_blank">' . esc_html__( 'View all questions in Minify Cache forum', 'w3-total-cache' ) . '</a>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 	'database_cache' => array(
@@ -72,7 +76,9 @@ return array(
 				<p><span class="dashicons dashicons-video-alt3"></span>
 				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_database_cache"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/database-cache/" target="_blank">' . esc_html__( 'View all questions in Database Cache forum', 'w3-total-cache' ) . '</a>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 	'object_cache'   => array(
@@ -93,7 +99,9 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_object_cache"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/object-cache/" target="_blank">' . esc_html__( 'View all questions in Object Cache forum', 'w3-total-cache' ) . '</a>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 	'browser_cache'  => array(
@@ -114,7 +122,9 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a></p>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_browser_cache"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/browser-cache/" target="_blank">' . esc_html__( 'View all questions in Browser Cache forum', 'w3-total-cache' ) . '</a>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 	'cdn'            => array(
@@ -136,7 +146,9 @@ return array(
 				<p><span class="dashicons dashicons-text-page"></span>
 				<h3>' . esc_html__( 'Popular questions from the forums', 'w3-total-cache' ) . '</h3>
 				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a></p>
-				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>',
+				<div class="help-forum-topics" data-loaded="0" data-tab-id="tab_cdn"></div>
+				<a href="https://www.boldgrid.com/support/topic-tag/cdn/" target="_blank">' . esc_html__( 'View all questions in the CDN forum', 'w3-total-cache' ) . '</a>
+				<div class="ask-help-forums"><a class="button button-secondary" href="https://www.boldgrid.com/support/ask-a-question/" target="_blank">' . esc_html__( 'Ask a question', 'w3-total-cache' ) . '</a><p>' . esc_html__( 'in the forums. It may show up here!', 'w3-total-cache' ) . '</p></div>',
 		),
 	),
 );

--- a/ConfigSettingsTabsKeys.php
+++ b/ConfigSettingsTabsKeys.php
@@ -10,7 +10,7 @@ namespace W3TC;
 return array(
 	'page_cache'     => array(
 		'tabs' => array(
-			'premium_support' =>'<h3>' . esc_html__( 'Did you know that W3 Total Cache has premium services available, and can set up page cache for you?', 'w3-total-cache' ) . '</h3>
+			'premium_support' => '<h3>' . esc_html__( 'Did you know that W3 Total Cache has premium services available, and can set up page cache for you?', 'w3-total-cache' ) . '</h3>
 				<h4>' . esc_html__( 'Our more popular package is the Plugin Configuration package. Not only will we configure page caching for you, we will configure the object cache, database cache, and most other items too.', 'w3-total-cache' ) . '</h4>
 				<p><span class="dashicons dashicons-yes-alt"></span>' . esc_html__( 'Tailored W3 Total Cache setup, customized for your theme, plugins, and server.', 'w3-total-cache' ) . '</p>
 				<p><span class="dashicons dashicons-yes-alt"></span>' . esc_html__( 'Expert optimization based on WordPress-specific performance needs (WPO).', 'w3-total-cache' ) . '</p>
@@ -22,6 +22,12 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Page Cache?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/page-caching/" target="_blank">' . esc_html__( 'How to set up Page Cache', 'w3-total-cache' ) . '</a>
+				<h3>' . esc_html__( 'Videos: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.youtube.com/watch?v=vdp0OrJ8hAg" target="_blank">' . esc_html__( 'What is Page Cache', 'w3-total-cache' ) . '</a>',
 		),
 	),
 	'minify'         => array(
@@ -38,6 +44,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Page Cache?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/minify-cache/" target="_blank">' . esc_html__( 'Minify Cache Settings Guide', 'w3-total-cache' ) . '</a>',
 		),
 	),
 	'database_cache' => array(
@@ -54,6 +64,12 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Database Cache?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/database-caching/" target="_blank">' . esc_html__( 'How to set up Database Cache', 'w3-total-cache' ) . '</a>
+				<h3>' . esc_html__( 'Videos: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.youtube.com/watch?v=OWJckWamEvA" target="_blank">' . esc_html__( 'What is Database Cache', 'w3-total-cache' ) . '</a>',
 		),
 	),
 	'object_cache'   => array(
@@ -70,6 +86,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Object Cache?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/object-cache-settings-guide/" target="_blank">' . esc_html__( 'Object Cache Settings Guide', 'w3-total-cache' ) . '</a>',
 		),
 	),
 	'browser_cache'  => array(
@@ -86,6 +106,10 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up Browser Cache?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a tutorial that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure Browser Cache', 'w3-total-cache' ) . '</a>',
 		),
 	),
 	'cdn'            => array(
@@ -101,6 +125,11 @@ return array(
 				<div class="cta-button">
 					<a href="' . esc_url( Util_UI::admin_url( 'admin.php?page=w3tc_support' ) ) . '"> ' . esc_html__( 'Click here to purchase this premium service', 'w3-total-cache' ) . ' </a>
 				</div>',
+			'tutorials'       => '<h3>' . esc_html__( 'Need help setting up your CDN?', 'w3-total-cache' ) . '</h3>
+				<h4>' . esc_html__( 'We have a couple tutorials that can help!', 'w3-total-cache' ) . '</h4>
+				<h3>' . esc_html__( 'Documentation: ', 'w3-total-cache' ) . '</h4>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/how-to-configure-cloudflare-in-wordpress-with-w3-total-cache/" target="_blank">' . esc_html__( 'How to configure CloudFlare with W3 Total Cache', 'w3-total-cache' ) . '</a><br>
+				<a href="https://www.boldgrid.com/support/w3-total-cache/full-site-delivery-fds/" target="_blank">' . esc_html__( 'Enhancing WordPress Performance with Full Site Delivery (FSD)', 'w3-total-cache' ) . '</a>',
 		),
 	),
 );

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -212,7 +212,7 @@ class Util_Ui {
 		$basic_settings_tab = ( ! empty( $adv_link ) ) ? '<a class="w3tc-basic-settings nav-tab nav-tab-active no-link">' . esc_html__( 'Basic Settings', 'w3-total-cache' ) . '</a>' : '';
 		$adv_settings_tab   = ( ! empty( $adv_link ) ) ? '<a class="nav-tab link-tab" href="' . esc_url( $adv_link ) . '" gatitle="' . esc_attr( $id ) . '">' . esc_html__( 'Advanced Settings', 'w3-total-cache' ) . '<span class="dashicons dashicons-arrow-right-alt2"></span></a>' : '';
 		$premium_link_tab   = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . '" data-tab-type="premium-services">' . esc_html__( 'Premium Services', 'w3-total-cache' ) . '</a>' : '';
-		$tutorials_tab      = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . '" data-tab-type="tutorials">' . esc_html__( 'Tutorials', 'w3-total-cache' ) . '</a>' : '';
+		$tutorials_tab      = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . '" data-tab-type="help">' . esc_html__( 'Help', 'w3-total-cache' ) . '</a>' : '';
 
 		$extra_link_tabs = '';
 		foreach ( $extra_links as $extra_link_text => $extra_link ) {
@@ -237,6 +237,8 @@ class Util_Ui {
 
 	/**
 	 * Retrieves a specific tab's content based on the provided key and tab type.
+	 *
+	 * @since X.X.X
 	 *
 	 * This function dynamically loads content for a specified tab type (e.g., tutorials, premium services)
 	 * based on a given configuration key. It uses a mapping to fetch the correct tab content, which is then
@@ -264,7 +266,7 @@ class Util_Ui {
 
 		// Define a mapping of tab types to the corresponding config keys.
 		$tab_mapping = array(
-			'tutorials'        => 'tutorials',
+			'help'             => 'help',
 			'premium-services' => 'premium_support',
 		);
 

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -206,12 +206,13 @@ class Util_Ui {
 	 * @param array  $extra_links
 	 * @return void
 	 */
-	public static function postbox_header_tabs( $title, $description = '', $class = '', $id = '', $adv_link = '', $premium_link = '', $extra_links = array() ) {
+	public static function postbox_header_tabs( $title, $description = '', $class = '', $id = '', $adv_link = '', $premium_link = '', $tutorials_tab = '', $extra_links = array() ) {
 		$display_id         = ( ! empty( $id ) ) ? ' id="' . esc_attr( $id ) . '"' : '';
 		$description        = ( ! empty( $description ) ) ? '<div class="postbox-description">' . wp_kses( $description, self::get_allowed_html_for_wp_kses_from_content( $description ) ) . '</div>' : '';
 		$basic_settings_tab = ( ! empty( $adv_link ) ) ? '<a class="w3tc-basic-settings nav-tab nav-tab-active no-link">' . esc_html__( 'Basic Settings', 'w3-total-cache' ) . '</a>' : '';
 		$adv_settings_tab   = ( ! empty( $adv_link ) ) ? '<a class="nav-tab link-tab" href="' . esc_url( $adv_link ) . '" gatitle="' . esc_attr( $id ) . '">' . esc_html__( 'Advanced Settings', 'w3-total-cache' ) . '<span class="dashicons dashicons-arrow-right-alt2"></span></a>' : '';
-		$premium_link_tab   = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . ' w3tc-pro-services" data-tab-type="premium-services">' . esc_html__( 'Premium Services', 'w3-total-cache' ) . '</a>' : '';
+		$premium_link_tab   = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . '" data-tab-type="premium-services">' . esc_html__( 'Premium Services', 'w3-total-cache' ) . '</a>' : '';
+		$tutorials_tab      = ( ! empty( $premium_link ) ) ? '<a class="nav-tab link-tab ' . esc_attr( $id ) . '" data-tab-type="tutorials">' . esc_html__( 'Tutorials', 'w3-total-cache' ) . '</a>' : '';
 
 		$extra_link_tabs = '';
 		foreach ( $extra_links as $extra_link_text => $extra_link ) {
@@ -221,7 +222,7 @@ class Util_Ui {
 		echo '<div' . $display_id . ' class="postbox-tabs ' . esc_attr( $class ) . '">
 			<h3 class="postbox-title"><span>' . wp_kses( $title, self::get_allowed_html_for_wp_kses_from_content( $title ) ) . '</span></h3>
 			' . $description . '
-			<h2 class="nav-tab-wrapper">' . $basic_settings_tab . $adv_settings_tab . $premium_link_tab . $extra_link_tabs . '</h2>
+			<h2 class="nav-tab-wrapper">' . $basic_settings_tab . $adv_settings_tab . $premium_link_tab . $tutorials_tab . $extra_link_tabs . '</h2>
 			<div class="inside">';
 	}
 
@@ -235,25 +236,44 @@ class Util_Ui {
 	}
 
 	/**
-	 * Retrieves the premium services tab HTML from the general settings page configuration.
+	 * Retrieves a specific tab's content based on the provided key and tab type.
 	 *
-	 * @since x.x.x
+	 * This function dynamically loads content for a specified tab type (e.g., tutorials, premium services)
+	 * based on a given configuration key. It uses a mapping to fetch the correct tab content, which is then
+	 * wrapped in a `<div>` element with a `data-tab-type` attribute for identification.
 	 *
-	 * @param string $key The type of cache key to get from config.
+	 * @param string $key      The configuration key used to retrieve tab settings.
+	 * @param string $tab_type The type of tab to retrieve (e.g., 'tutorials', 'premium-services').
 	 *
-	 * @return string The HTML for the premium services tab.
+	 * @return string|null     The HTML content for the specified tab, or null if the tab or key is not found.
+	 *
+	 * Usage:
+	 * ```
+	 * echo wp_kses_post( Util_Ui::get_tab('example_key', 'tutorials');  // Retrieves the tutorials tab for 'example_key'
+	 * ```
 	 */
-	public static function get_premium_service_tab( string $key ) : string {
+	public static function get_tab( string $key, string $tab_type ) : ?string {
 
-		// If for any reason the key is empty, return an empty string.
-		if ( empty( $key ) ) {
+		// If for any reason the key or tab type is empty, return an empty string.
+		if ( empty( $key ) || empty( $tab_type ) ) {
 			return '';
 		}
 
 		require_once 'ConfigSettingsTabs.php';
 		$configs = Config_Tab_Settings::get_config( $key );
 
-		return isset( $configs['tabs']['premium_support'] ) ? '<div data-tab-type="premium-services">' . $configs['tabs']['premium_support'] . '</div>' : null;
+		// Define a mapping of tab types to the corresponding config keys.
+		$tab_mapping = array(
+			'tutorials'        => 'tutorials',
+			'premium-services' => 'premium_support',
+		);
+
+		// Check if the provided tab type exists in the mapping and in the configs.
+		if ( isset( $tab_mapping[ $tab_type ] ) && isset( $configs['tabs'][ $tab_mapping[ $tab_type ] ] ) ) {
+			return '<div data-tab-type="' . esc_attr( $tab_type ) . '">' . $configs['tabs'][ $tab_mapping[ $tab_type ] ] . '</div>';
+		}
+
+		return null;
 	}
 
 	public static function button_config_save( $id = '', $extra = '' ) {

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -178,7 +178,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		</table>
 
 		<?php
-			echo wp_kses_post( Util_Ui::get_tab( 'page_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'page_cache', 'help' ) );
 			echo wp_kses_post( Util_Ui::get_tab( 'page_cache', 'premium-services' ) );
 		?>
 
@@ -312,7 +312,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		</table>
 
 		<?php
-			echo wp_kses_post( Util_Ui::get_tab( 'minify', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'minify', 'help' ) );
 			echo wp_kses_post( Util_Ui::get_tab( 'minify', 'premium-services' ) );
 		?>
 
@@ -365,7 +365,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		</table>
 
 		<?php
-			echo wp_kses_post( Util_Ui::get_tab( 'database_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'database_cache', 'help' ) );
 			echo wp_kses_post( Util_Ui::get_tab( 'database_cache', 'premium-services' ) );
 		?>
 
@@ -434,7 +434,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		</table>
 
 		<?php
-			echo wp_kses_post( Util_Ui::get_tab( 'object_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'object_cache', 'help' ) );
 			echo wp_kses_post( Util_Ui::get_tab( 'object_cache', 'premium-services' ) );
 		?>
 
@@ -485,7 +485,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 		</table>
 
 		<?php
-			echo wp_kses_post( Util_Ui::get_tab( 'browser_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'browser_cache', 'help' ) );
 			echo wp_kses_post( Util_Ui::get_tab( 'browser_cache', 'premium-services' ) );
 		?>
 

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -102,7 +102,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			'',
 			'page_cache',
 			Util_UI::admin_url( 'admin.php?page=w3tc_pgcache' ),
-			'w3tc_premium_services'
+			'w3tc_premium_services',
+			'w3tc_tutorial'
 		);
 		Util_Ui::config_overloading_button( array( 'key' => 'pgcache.configuration_overloaded' ) );
 		?>
@@ -176,7 +177,10 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			?>
 		</table>
 
-		<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'page_cache' ) ); ?>
+		<?php
+			echo wp_kses_post( Util_Ui::get_tab( 'page_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'page_cache', 'premium-services' ) );
+		?>
 
 		<?php Util_Ui::postbox_footer(); ?>
 
@@ -190,7 +194,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			'',
 			'minify',
 			Util_UI::admin_url( 'admin.php?page=w3tc_minify' ),
-			'w3tc_premium_services'
+			'w3tc_premium_services',
+			'w3tc_tutorial'
 		);
 		Util_Ui::config_overloading_button( array( 'key' => 'minify.configuration_overloaded' ) );
 		?>
@@ -306,7 +311,10 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			?>
 		</table>
 
-		<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'minify' ) ); ?>
+		<?php
+			echo wp_kses_post( Util_Ui::get_tab( 'minify', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'minify', 'premium-services' ) );
+		?>
 
 		<?php Util_Ui::postbox_footer(); ?>
 
@@ -323,7 +331,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			'',
 			'database_cache',
 			Util_UI::admin_url( 'admin.php?page=w3tc_dbcache' ),
-			'w3tc_premium_services'
+			'w3tc_premium_services',
+			'w3tc_tutorial'
 		);
 		Util_Ui::config_overloading_button( array( 'key' => 'dbcache.configuration_overloaded' ) );
 		?>
@@ -355,7 +364,10 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			<?php endif; ?>
 		</table>
 
-		<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'database_cache' ) ); ?>
+		<?php
+			echo wp_kses_post( Util_Ui::get_tab( 'database_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'database_cache', 'premium-services' ) );
+		?>
 
 		<?php Util_Ui::postbox_footer(); ?>
 
@@ -369,7 +381,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			'',
 			'object_cache',
 			Util_UI::admin_url( 'admin.php?page=w3tc_objectcache' ),
-			'w3tc_premium_services'
+			'w3tc_premium_services',
+			'w3tc_tutorial'
 		);
 		Util_Ui::config_overloading_button( array( 'key' => 'objectcache.configuration_overloaded' ) );
 		echo ( ! $this->_config->getf_boolean( 'objectcache.enabled' ) && has_filter( 'w3tc_config_item_objectcache.enabled' ) ? '<p class="notice notice-warning inline w3tc-postbox-notice" style="margin-top:10px !important;">' . esc_html__( 'Object Cache is disabled via filter.', 'w3-total-cache' ) . '</p>' : '' );
@@ -420,7 +433,10 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			?>
 		</table>
 
-		<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'object_cache' ) ); ?>
+		<?php
+			echo wp_kses_post( Util_Ui::get_tab( 'object_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'object_cache', 'premium-services' ) );
+		?>
 
 		<?php Util_Ui::postbox_footer(); ?>
 
@@ -434,7 +450,8 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			'',
 			'browser_cache',
 			Util_UI::admin_url( 'admin.php?page=w3tc_browsercache' ),
-			'w3tc_premium_services'
+			'w3tc_premium_services',
+			'w3tc_tutorial'
 		);
 		Util_Ui::config_overloading_button( array( 'key' => 'browsercache.configuration_overloaded' ) );
 		?>
@@ -467,7 +484,10 @@ require W3TC_INC_DIR . '/options/common/header.php';
 			?>
 		</table>
 
-		<?php echo wp_kses_post( Util_Ui::get_premium_service_tab( 'browser_cache' ) ); ?>
+		<?php
+			echo wp_kses_post( Util_Ui::get_tab( 'browser_cache', 'tutorials' ) );
+			echo wp_kses_post( Util_Ui::get_tab( 'browser_cache', 'premium-services' ) );
+		?>
 
 		<?php Util_Ui::postbox_footer(); ?>
 

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -628,6 +628,10 @@ textarea.w3tc-error {
 	/* WP 5.5 */
 }
 
+#w3tc div.inside div[data-tab-type] {
+	display: none;
+}
+
 #pgcache_reject_roles label,
 #newrelic_accept_roles label,
 #cdn_reject_roles label {

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -628,6 +628,19 @@ textarea.w3tc-error {
 	/* WP 5.5 */
 }
 
+#w3tc .ask-help-forums {
+	margin: 5px 0;
+	display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+#w3tc .ask-help-forums p {
+	padding-left: 10px;
+}
+
 #pgcache_reject_roles label,
 #newrelic_accept_roles label,
 #cdn_reject_roles label {

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -628,19 +628,6 @@ textarea.w3tc-error {
 	/* WP 5.5 */
 }
 
-#w3tc .ask-help-forums {
-	margin: 5px 0;
-	display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: center;
-    justify-content: flex-start;
-}
-
-#w3tc .ask-help-forums p {
-	padding-left: 10px;
-}
-
 #pgcache_reject_roles label,
 #newrelic_accept_roles label,
 #cdn_reject_roles label {

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -625,7 +625,7 @@ jQuery(function() {
 						$li.append( $link );
 						$ul.append( $li );
 					});
-					$forumTopicsContainer.append( $ul );
+					$forumTopicsContainer.html( $ul );
 				}
 				// Mark topics as loaded to prevent duplicate requests
 				$forumTopicsContainer.attr( 'data-loaded', "1" );

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -561,12 +561,11 @@ jQuery(function() {
 	});
 
 	// General Settings Tab actions.
-
 	jQuery( document ).on( 'click', '.performance_page_w3tc_general .nav-tab', function(){
-   		var $tab = jQuery( this ),
+   		const $tab         = jQuery( this ),
 		$nav_tab_wrapper = $tab.closest( ".nav-tab-wrapper" )
-    	tab_type = $tab.attr( "data-tab-type" ),
-    	$inside = $tab.closest( ".postbox-tabs" ).find( ".inside" );
+    	tab_type         = $tab.attr( "data-tab-type" ),
+    	$inside          = $tab.closest( ".postbox-tabs" ).find( ".inside" );
 
 		// Highlight the selected tab.
 		$nav_tab_wrapper.find( "a" ).removeClass( "nav-tab-active" );
@@ -593,7 +592,7 @@ jQuery(function() {
 	// Tutorial page forum links via API.
 	jQuery(document).on( 'click', '[data-tab-type="help"]', function() {
 
-		var $helpTab          = jQuery( this ),
+		const $helpTab          = jQuery( this ),
 		$inside               = $helpTab.closest( ".postbox-tabs" ).find( ".inside" );
 		$forumTopicsContainer = $inside.find( '.help-forum-topics' );
 		isLoaded              = $forumTopicsContainer.attr( 'data-loaded' ) === "1";

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -592,43 +592,48 @@ jQuery(function() {
 	} );
 
 	// Tutorial page forum links via API.
-	jQuery(document).on('click', '[data-tab-type="help"]', function() {
+	jQuery(document).on( 'click', '[data-tab-type="help"]', function() {
 
 		var $helpTab          = jQuery( this ),
 		$inside               = $helpTab.closest( ".postbox-tabs" ).find( ".inside" );
-		$forumTopicsContainer = $inside.find('.help-forum-topics');
-		isLoaded              = $forumTopicsContainer.attr('data-loaded') === "1";
-		tabId                 = $forumTopicsContainer.attr('data-tab-id');
+		$forumTopicsContainer = $inside.find( '.help-forum-topics' );
+		isLoaded              = $forumTopicsContainer.attr( 'data-loaded' ) === "1";
+		tabId                 = $forumTopicsContainer.attr( 'data-tab-id' );
 
 		// Check if topics are already loaded
-		if (isLoaded) return;
+		if ( isLoaded ) return;
 		// Construct the API URL with the tab ID
 		const apiUrl = `https://boldgrid.com/support/wp-json/w3tc/v1/help_topics?tag=${tabId}`;
+
+		console.log( 'Fetching forum topics from API...' );
+
 		// Fetch topics from the API
 		jQuery.ajax({
 			url: apiUrl,
 			method: 'GET',
 			dataType: 'json',
-			success: function(data) {
+			success: function( data ) {
 				// Check for errors or empty results
-				if (data.code === 'no_topics' || !data.length) {
-					$forumTopicsContainer.html("<p>No forum topics found.</p>");
+				if ( Array.isArray( data ) && data.length === 0 ) {
+					$forumTopicsContainer.html( "<p>No forum topics found.</p>" );
 				} else {
 					// Create a list of topics
-					const $ul = jQuery('<ul></ul>');
-					jQuery.each(data, function(index, topic) {
-						const $li = jQuery('<li></li>');
-						const $link = jQuery('<a></a>').attr('href', topic.link).text(topic.title).attr('target', '_blank'); // Open in new tab
-						$li.append($link);
-						$ul.append($li);
+					const $ul = jQuery( '<ul></ul>' );
+					jQuery.each( data, function( index, topic ) {
+						const $li = jQuery( '<li></li>' );
+						const $link = jQuery( '<a></a>' ).addClass('w3tc-control-after').attr( 'href', topic.link ).text( topic.title ).attr( 'target', '_blank' ); // Open in new tab
+						const $icon = jQuery( '<span></span>' ).addClass( 'dashicons dashicons-external' );
+						$link.append( $icon );
+						$li.append( $link );
+						$ul.append( $li );
 					});
-					$forumTopicsContainer.append($ul);
+					$forumTopicsContainer.append( $ul );
 				}
 				// Mark topics as loaded to prevent duplicate requests
-				$forumTopicsContainer.attr('data-loaded', "1");
+				$forumTopicsContainer.attr( 'data-loaded', "1" );
 			},
 			error: function() {
-				$forumTopicsContainer.html("<p>Error loading topics. Please try again later.</p>");
+				$forumTopicsContainer.html( "<p>Error loading topics. Please try again later.</p>" );
 			}
 		});
 	});

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -591,6 +591,48 @@ jQuery(function() {
     	}
 	} );
 
+	// Tutorial page forum links via API.
+	jQuery(document).on('click', '[data-tab-type="help"]', function() {
+
+		var $helpTab          = jQuery( this ),
+		$inside               = $helpTab.closest( ".postbox-tabs" ).find( ".inside" );
+		$forumTopicsContainer = $inside.find('.help-forum-topics');
+		isLoaded              = $forumTopicsContainer.attr('data-loaded') === "1";
+		tabId                 = $forumTopicsContainer.attr('data-tab-id');
+
+		// Check if topics are already loaded
+		if (isLoaded) return;
+		// Construct the API URL with the tab ID
+		const apiUrl = `https://boldgrid.com/support/wp-json/w3tc/v1/help_topics?tag=${tabId}`;
+		// Fetch topics from the API
+		jQuery.ajax({
+			url: apiUrl,
+			method: 'GET',
+			dataType: 'json',
+			success: function(data) {
+				// Check for errors or empty results
+				if (data.code === 'no_topics' || !data.length) {
+					$forumTopicsContainer.html("<p>No forum topics found.</p>");
+				} else {
+					// Create a list of topics
+					const $ul = jQuery('<ul></ul>');
+					jQuery.each(data, function(index, topic) {
+						const $li = jQuery('<li></li>');
+						const $link = jQuery('<a></a>').attr('href', topic.link).text(topic.title).attr('target', '_blank'); // Open in new tab
+						$li.append($link);
+						$ul.append($li);
+					});
+					$forumTopicsContainer.append($ul);
+				}
+				// Mark topics as loaded to prevent duplicate requests
+				$forumTopicsContainer.attr('data-loaded', "1");
+			},
+			error: function() {
+				$forumTopicsContainer.html("<p>Error loading topics. Please try again later.</p>");
+			}
+		});
+	});
+
 	// Prevent enabling Bunny CDN for both CDN and CDNFSD.
 	$cdn_enabled.on('click', cdn_bunnycdn_check);
 	$cdn_engine.on('change', cdn_bunnycdn_check);

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -605,8 +605,6 @@ jQuery(function() {
 		// Construct the API URL with the tab ID
 		const apiUrl = `https://boldgrid.com/support/wp-json/w3tc/v1/help_topics?tag=${tabId}`;
 
-		console.log( 'Fetching forum topics from API...' );
-
 		// Fetch topics from the API
 		jQuery.ajax({
 			url: apiUrl,

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -561,7 +561,6 @@ jQuery(function() {
 	});
 
 	// General Settings Tab actions.
-	jQuery( '.postbox-tabs .inside' ).children( "[data-tab-type]" ).hide();
 
 	jQuery( document ).on( 'click', '.performance_page_w3tc_general .nav-tab', function(){
    		var $tab = jQuery( this ),


### PR DESCRIPTION
Adds tutorial content for main caching types

# Testing

1. Go to each of the main caching types.
2. Click on the tutorials tab
3. Review the content there 
4. Click back to general settings or premium services
5. Make sure the tabs are working correctly with hiding and showing the correct information.