### PR TITLE
fixes #990

### DIFF
--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -551,7 +551,9 @@ class Minify_MinifiedFileRequestHandler {
 			Minify_Core::debug_error( sprintf( 'Unable to fetch custom files list: "%s.%s"', $hash, $type ), false, 404 );
 		}
 
-		Minify_Core::log( implode("\n", $files ) );
+		if ( $this->_config->get_boolean( 'minify.debug' ) ) {
+			Minify_Core::log( implode( "\n", $files ) );
+		}
 
 		return $result;
 	}


### PR DESCRIPTION
Fixes minify still logging when debug is not checked.

### Testing

1. Flush cache
2. Go to the site and monitor wp-content/cache/log/000000/minify.log
3. The log file should not have any new entries.