### PR TITLE
Added tracking for Google PageSpeed scores

### DIFF
--- a/PageSpeed_Page.php
+++ b/PageSpeed_Page.php
@@ -163,11 +163,75 @@ class PageSpeed_Page {
 		include __DIR__ . '/PageSpeed_Page_View_FromAPI.php';
 		$content = ob_get_contents();
 		ob_end_clean();
-
 		echo wp_json_encode(
 			array(
-				'w3tcps_content'   => $content,
-				'w3tcps_timestamp' => ! empty( $api_response['display_time'] ) ? $api_response['display_time'] : '',
+				'w3tcps_domain'                   => $url,
+				'w3tcps_score'                    => array(
+					'mobile'  => $api_response['mobile']['score'],
+					'desktop' => $api_response['desktop']['score'],
+				),
+				'w3tcps_first_contentful_paint'   => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['first-contentful-paint']['score'],
+						'displayValue' => $api_response['mobile']['first-contentful-paint']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['first-contentful-paint']['score'],
+						'displayValue' => $api_response['desktop']['first-contentful-paint']['displayValue'],
+					),
+				),
+				'w3tcps_largest_contentful_paint' => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['largest-contentful-paint']['score'],
+						'displayValue' => $api_response['mobile']['largest-contentful-paint']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['largest-contentful-paint']['score'],
+						'displayValue' => $api_response['desktop']['largest-contentful-paint']['displayValue'],
+					),
+				),
+				'w3tcps_interactive'              => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['interactive']['score'],
+						'displayValue' => $api_response['mobile']['interactive']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['interactive']['score'],
+						'displayValue' => $api_response['desktop']['interactive']['displayValue'],
+					),
+				),
+				'w3tcps_cumulative_layout_shift'  => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['cumulative-layout-shift']['score'],
+						'displayValue' => $api_response['mobile']['cumulative-layout-shift']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['cumulative-layout-shift']['score'],
+						'displayValue' => $api_response['desktop']['cumulative-layout-shift']['displayValue'],
+					),
+				),
+				'w3tcps_total_blocking_time'      => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['total-blocking-time']['score'],
+						'displayValue' => $api_response['mobile']['total-blocking-time']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['total-blocking-time']['score'],
+						'displayValue' => $api_response['desktop']['total-blocking-time']['displayValue'],
+					),
+				),
+				'w3tcps_speed_index'              => array(
+					'mobile'  => array(
+						'score'        => $api_response['mobile']['speed-index']['score'],
+						'displayValue' => $api_response['mobile']['speed-index']['displayValue'],
+					),
+					'desktop' => array(
+						'score'        => $api_response['desktop']['speed-index']['score'],
+						'displayValue' => $api_response['desktop']['speed-index']['displayValue'],
+					),
+				),
+				'w3tcps_content'                  => $content,
+				'w3tcps_timestamp'                => ! empty( $api_response['display_time'] ) ? $api_response['display_time'] : '',
 			)
 		);
 	}

--- a/PageSpeed_Page_View.js
+++ b/PageSpeed_Page_View.js
@@ -48,6 +48,43 @@ jQuery(document).ready(function ($) {
 				$('.w3tcps_buttons').removeClass('w3tc_none');
 				$('#' + page_post_id).html(data.w3tcps_content).fadeIn('slow');
 				$('.w3tcps_item_desciption a').attr('target', '_blank');
+
+				if (window.w3tc_ga) {
+					w3tc_ga(
+						'event',
+						'pagespeed',
+						{
+							'event_category': 'Performance Metrics',
+							'event_action': data.w3tcps_domain,
+							'mobile_score': data.w3tcps_score.mobile,
+							'desktop_score': data.w3tcps_score.desktop,
+							'mobile_first_contentful_paint_score': data.w3tcps_first_contentful_paint.mobile.score,
+							'mobile_first_contentful_paint_display_value': data.w3tcps_first_contentful_paint.mobile.displayValue,
+							'mobile_largest_contentful_paint_score': data.w3tcps_largest_contentful_paint.mobile.score,
+							'mobile_largest_contentful_paint_display_value': data.w3tcps_largest_contentful_paint.mobile.displayValue,
+							'mobile_interactive_score': data.w3tcps_interactive.mobile.score,
+							'mobile_interactive_display_value': data.w3tcps_interactive.mobile.displayValue,
+							'mobile_cumulative_layout_shift_score': data.w3tcps_cumulative_layout_shift.mobile.score,
+							'mobile_cumulative_layout_shift_display_value': data.w3tcps_cumulative_layout_shift.mobile.displayValue,
+							'mobile_total_blocking_time_score': data.w3tcps_total_blocking_time.mobile.score,
+							'mobile_total_blocking_time_display_value': data.w3tcps_total_blocking_time.mobile.displayValue,
+							'mobile_speed_index_score': data.w3tcps_speed_index.mobile.score,
+							'mobile_speed_index_display_value': data.w3tcps_speed_index.mobile.displayValue,
+							'desktop_first_contentful_paint_score': data.w3tcps_first_contentful_paint.desktop.score,
+							'desktop_first_contentful_paint_display_value': data.w3tcps_first_contentful_paint.desktop.displayValue,
+							'desktop_largest_contentful_paint_score': data.w3tcps_largest_contentful_paint.desktop.score,
+							'desktop_largest_contentful_paint_display_value': data.w3tcps_largest_contentful_paint.desktop.displayValue,
+							'desktop_interactive_score': data.w3tcps_interactive.desktop.score,
+							'desktop_interactive_display_value': data.w3tcps_interactive.desktop.displayValue,
+							'desktop_cumulative_layout_shift_score': data.w3tcps_cumulative_layout_shift.desktop.score,
+							'desktop_cumulative_layout_shift_display_value': data.w3tcps_cumulative_layout_shift.desktop.displayValue,
+							'desktop_total_blocking_time_score': data.w3tcps_total_blocking_time.desktop.score,
+							'desktop_total_blocking_time_display_value': data.w3tcps_total_blocking_time.desktop.displayValue,
+							'desktop_speed_index_score': data.w3tcps_speed_index.desktop.score,
+							'desktop_speed_index_display_value': data.w3tcps_speed_index.desktop.displayValue,
+						}
+					);
+				}
 			},
 			error: function (jqXHR, textStatus, errorThrown) {
 				$('.w3tcps_analyze').prop('disabled', false);


### PR DESCRIPTION
This PR adds Google Tag tracking for analytics that will report data on

'mobile_score'
'desktop_score'
'mobile_first_contentful_paint_score'
'mobile_first_contentful_paint_display_value'
'mobile_largest_contentful_paint_score'
'mobile_largest_contentful_paint_display_value'
'mobile_interactive_score'
'mobile_interactive_display_value'
'mobile_cumulative_layout_shift_score'
'mobile_cumulative_layout_shift_display_value'
'mobile_total_blocking_time_score'
'mobile_total_blocking_time_display_value'
'mobile_speed_index_score'
'mobile_speed_index_display_value'
'desktop_first_contentful_paint_score'
'desktop_first_contentful_paint_display_value'
'desktop_largest_contentful_paint_score'
'desktop_largest_contentful_paint_display_value'
'desktop_interactive_score'
'desktop_interactive_display_value'
'desktop_cumulative_layout_shift_score'
'desktop_cumulative_layout_shift_display_value'
'desktop_total_blocking_time_score'
'desktop_total_blocking_time_display_value'
'desktop_speed_index_score'
'desktop_speed_index_display_value'