### PR TITLE
Object Cache Drop In Feature Enable Check

### DIFF
--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -28,9 +28,15 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		echo sprintf( '<strong>W3 Total Cache Error:</strong> some files appear to be missing or out of place. Please re-install plugin or remove <strong>%s</strong>. <br />', __FILE__ );
 	}
 } else {
-	$w3tc_config = \W3TC\Dispatcher::config();
-	if ( ! $w3tc_config->get_boolean( 'objectcache.enabled' ) ) {
-		// Fallback to default WordPress caching.
+	if ( class_exists( '\W3TC\Dispatcher' ) ) {
+		$w3tc_config = \W3TC\Dispatcher::config();
+		if ( ! $w3tc_config->get_boolean( 'objectcache.enabled' ) ) {
+			// Fallback to default WordPress caching.
+			require_once ABSPATH . WPINC . '/cache.php';
+			return;
+		}
+	} else {
+		// Fallback to default WordPress caching if Dispatcher isn't available.
 		require_once ABSPATH . WPINC . '/cache.php';
 		return;
 	}

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -36,6 +36,11 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 	 * @return void
 	 */
 	function wp_cache_init() {
+		$config = \W3TC\Dispatcher::config();
+		if ( ! $config->get_boolean( 'objectcache.enabled' ) ) {
+			return;
+		}
+
 		$GLOBALS['wp_object_cache'] = \W3TC\Dispatcher::component( 'ObjectCache_WpObjectCache' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -22,23 +22,19 @@ if ( ! defined( 'W3TC_DIR' ) ) {
 }
 
 if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php' ) ) {
-	if ( ! defined( 'WP_ADMIN' ) ) { // lets don't show error on front end.
-		require_once ABSPATH . WPINC . '/cache.php';
+	if ( ! defined( 'WP_ADMIN' ) ) { // Don't show error on front end.
+			require_once ABSPATH . WPINC . '/cache.php';
 	} else {
-		echo sprintf( '<strong>W3 Total Cache Error:</strong> some files appear to be missing or out of place. Please re-install plugin or remove <strong>%s</strong>. <br />', __FILE__ );
+		printf(
+			'<strong>W3 Total Cache Error:</strong> some files appear to be missing or out of place. Please re-install plugin or remove <strong>%s</strong>. <br />',
+			__FILE__
+		);
 	}
 } else {
-	if ( class_exists( '\W3TC\Dispatcher' ) ) {
-		$w3tc_config = \W3TC\Dispatcher::config();
-		if ( ! $w3tc_config->get_boolean( 'objectcache.enabled' ) ) {
+	if ( ! ( class_exists( 'W3TC\Dispatcher' ) && ( new \W3TC\Dispatcher() )->config()->get_boolean( 'objectcache.enabled' ) ) ) {
 			// Fallback to default WordPress caching.
 			require_once ABSPATH . WPINC . '/cache.php';
 			return;
-		}
-	} else {
-		// Fallback to default WordPress caching if Dispatcher isn't available.
-		require_once ABSPATH . WPINC . '/cache.php';
-		return;
 	}
 
 	require_once W3TC_DIR . '/w3-total-cache-api.php';

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -28,6 +28,13 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		echo sprintf( '<strong>W3 Total Cache Error:</strong> some files appear to be missing or out of place. Please re-install plugin or remove <strong>%s</strong>. <br />', __FILE__ );
 	}
 } else {
+	$w3tc_config = \W3TC\Dispatcher::config();
+	if ( ! $w3tc_config->get_boolean( 'objectcache.enabled' ) ) {
+		// Fallback to default WordPress caching.
+		require_once ABSPATH . WPINC . '/cache.php';
+		return;
+	}
+
 	require_once W3TC_DIR . '/w3-total-cache-api.php';
 
 	/**
@@ -36,11 +43,6 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 	 * @return void
 	 */
 	function wp_cache_init() {
-		$config = \W3TC\Dispatcher::config();
-		if ( ! $config->get_boolean( 'objectcache.enabled' ) ) {
-			return;
-		}
-
 		$GLOBALS['wp_object_cache'] = \W3TC\Dispatcher::component( 'ObjectCache_WpObjectCache' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 


### PR DESCRIPTION
Added check to drop in file to prevent object cache from initializing if it is disabled but the drop in remains in place (should be removed if it is in the default location).