### PR TITLE
fix(Cdn_Plugin.php): improve srcset regex pattern to handle multiline attributes

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -923,7 +923,7 @@ class _Cdn_Plugin_ContentFilter { // phpcs:ignore Generic.Classes.OpeningBraceSa
 	public function replace_all_links( $buffer ) {
 		$this->fill_regexps();
 
-		$srcset_pattern = '~srcset\s*=\s*[\"\'](.*?)[\"\']~';
+		$srcset_pattern = '~srcset\s*=\s*[\"\'](.*?)[\"\']~s';
 		$buffer         = preg_replace_callback(
 			$srcset_pattern,
 			array( $this, '_srcset_replace_callback' ),


### PR DESCRIPTION
Add PCRE_DOTALL flag to srcset regex pattern to properly match multiline srcset attributes in HTML content. This ensures CDN replacement works correctly even when srcset values span multiple lines.