### PR TITLE
Fix check for advanced-cache.php file.  Fixes #1025

### DIFF
--- a/Generic_Environment.php
+++ b/Generic_Environment.php
@@ -109,8 +109,7 @@ class Generic_Environment {
 
 		if ( $this->advanced_cache_installed() ) {
 			if ( $this->is_advanced_cache_add_in() ) {
-				$script_data = @wp_remote_get( $dst );
-				if ( @wp_remote_get( $src ) === $script_data ) {
+				if ( @hash_file( 'sha256', $src ) === @hash_file( 'sha256', $dst ) ) {
 					return;
 				}
 			} elseif ( 'yes' === get_transient( 'w3tc_remove_add_in_pgcache' ) ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif


### PR DESCRIPTION
This fixes the file check to compare the source and destination "advanced-cache.php" addin/dropin file.