### PR TITLE
Browser Cache CSS/JS and Other/Media Cache Policy Immutable

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -805,20 +805,9 @@ class BrowserCache_Environment {
 					$headers_rules .= "        Header set Cache-Control \"public, max-age=" . $lifetime . ", immutable\"\n";
 					break;
 
-				case 'cache_immutable_noproxy':
-					$lifetime       = $config->get_integer( 'browsercache.' . $section . '.lifetime' );
-					$headers_rules .= "        Header set Pragma \"private\"\n";
-					$headers_rules .= "        Header set Cache-Control \"private, max-age=" . $lifetime . ", immutable\"\n";
-					break;
-
 				case 'cache_immutable_nomaxage':
 					$headers_rules .= "        Header set Pragma \"public\"\n";
 					$headers_rules .= "        Header set Cache-Control \"public, immutable\"\n";
-					break;
-
-				case 'cache_immutable_validation':
-					$headers_rules .= "        Header set Pragma \"public\"\n";
-					$headers_rules .= "        Header set Cache-Control \"public, immutable, must-revalidate, proxy-revalidate\"\n";
 					break;
 			}
 		}

--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -798,6 +798,28 @@ class BrowserCache_Environment {
 					$headers_rules .= "        Header set Pragma \"no-store\"\n";
 					$headers_rules .= "        Header set Cache-Control \"no-store\"\n";
 					break;
+
+				case 'cache_immutable':
+					$lifetime       = $config->get_integer( 'browsercache.' . $section . '.lifetime' );
+					$headers_rules .= "        Header set Pragma \"public\"\n";
+					$headers_rules .= "        Header set Cache-Control \"public, max-age=" . $lifetime . ", immutable\"\n";
+					break;
+
+				case 'cache_immutable_noproxy':
+					$lifetime       = $config->get_integer( 'browsercache.' . $section . '.lifetime' );
+					$headers_rules .= "        Header set Pragma \"private\"\n";
+					$headers_rules .= "        Header set Cache-Control \"private, max-age=" . $lifetime . ", immutable\"\n";
+					break;
+
+				case 'cache_immutable_nomaxage':
+					$headers_rules .= "        Header set Pragma \"public\"\n";
+					$headers_rules .= "        Header set Cache-Control \"public, immutable\"\n";
+					break;
+
+				case 'cache_immutable_validation':
+					$headers_rules .= "        Header set Pragma \"public\"\n";
+					$headers_rules .= "        Header set Cache-Control \"public, immutable, must-revalidate, proxy-revalidate\"\n";
+					break;
 			}
 		}
 

--- a/BrowserCache_Environment_LiteSpeed.php
+++ b/BrowserCache_Environment_LiteSpeed.php
@@ -251,25 +251,11 @@ class BrowserCache_Environment_LiteSpeed {
 					$add_header_rules[] = "set Cache-Control \"public, max-age=$lifetime, immutable\"";
 					break;
 
-				case 'cache_immutable_noproxy':
-					$add_header_rules[] = 'unset Pragma';
-					$add_header_rules[] = 'set Pragma private';
-					$add_header_rules[] = 'unset Cache-Control';
-					$add_header_rules[] = "set Cache-Control \"private, max-age=$lifetime, immutable\"";
-					break;
-
 				case 'cache_immutable_nomaxage':
 					$add_header_rules[] = 'unset Pragma';
 					$add_header_rules[] = 'set Pragma public';
 					$add_header_rules[] = 'unset Cache-Control';
 					$add_header_rules[] = 'set Cache-Control "public, immutable"';
-					break;
-
-				case 'cache_immutable_validation':
-					$add_header_rules[] = 'unset Pragma';
-					$add_header_rules[] = 'set Pragma public';
-					$add_header_rules[] = 'unset Cache-Control';
-					$add_header_rules[] = 'set Cache-Control "public, immutable, must-revalidate, proxy-revalidate"';
 					break;
 			}
 		}

--- a/BrowserCache_Environment_LiteSpeed.php
+++ b/BrowserCache_Environment_LiteSpeed.php
@@ -243,6 +243,34 @@ class BrowserCache_Environment_LiteSpeed {
 					$add_header_rules[] = 'unset Cache-Control';
 					$add_header_rules[] = 'set Cache-Control "no-store"';
 					break;
+
+				case 'cache_immutable':
+					$add_header_rules[] = 'unset Pragma';
+					$add_header_rules[] = 'set Pragma public';
+					$add_header_rules[] = 'unset Cache-Control';
+					$add_header_rules[] = "set Cache-Control \"public, max-age=$lifetime, immutable\"";
+					break;
+
+				case 'cache_immutable_noproxy':
+					$add_header_rules[] = 'unset Pragma';
+					$add_header_rules[] = 'set Pragma private';
+					$add_header_rules[] = 'unset Cache-Control';
+					$add_header_rules[] = "set Cache-Control \"private, max-age=$lifetime, immutable\"";
+					break;
+
+				case 'cache_immutable_nomaxage':
+					$add_header_rules[] = 'unset Pragma';
+					$add_header_rules[] = 'set Pragma public';
+					$add_header_rules[] = 'unset Cache-Control';
+					$add_header_rules[] = 'set Cache-Control "public, immutable"';
+					break;
+
+				case 'cache_immutable_validation':
+					$add_header_rules[] = 'unset Pragma';
+					$add_header_rules[] = 'set Pragma public';
+					$add_header_rules[] = 'unset Cache-Control';
+					$add_header_rules[] = 'set Cache-Control "public, immutable, must-revalidate, proxy-revalidate"';
+					break;
 			}
 		}
 

--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -521,6 +521,26 @@ class BrowserCache_Environment_Nginx {
 					$add_header_rules[] = 'add_header Pragma "no-store";';
 					$add_header_rules[] = 'add_header Cache-Control "no-store";';
 					break;
+
+				case 'cache_immutable':
+					$add_header_rules[] = 'add_header Pragma "public";';
+					$add_header_rules[] = "add_header Cache-Control \"public, max-age=$lifetime, immutable\";";
+					break;
+
+				case 'cache_immutable_noproxy':
+					$add_header_rules[] = 'add_header Pragma "private";';
+					$add_header_rules[] = "add_header Cache-Control \"private, max-age=$lifetime, immutable\";";
+					break;
+
+				case 'cache_immutable_nomaxage':
+					$add_header_rules[] = 'add_header Pragma "public";';
+					$add_header_rules[] = 'add_header Cache-Control "public, immutable";';
+					break;
+
+				case 'cache_immutable_validation':
+					$add_header_rules[] = 'add_header Pragma "public";';
+					$add_header_rules[] = 'add_header Cache-Control "public, immutable, must-revalidate, proxy-revalidate";';
+					break;
 			}
 		}
 

--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -527,19 +527,9 @@ class BrowserCache_Environment_Nginx {
 					$add_header_rules[] = "add_header Cache-Control \"public, max-age=$lifetime, immutable\";";
 					break;
 
-				case 'cache_immutable_noproxy':
-					$add_header_rules[] = 'add_header Pragma "private";';
-					$add_header_rules[] = "add_header Cache-Control \"private, max-age=$lifetime, immutable\";";
-					break;
-
 				case 'cache_immutable_nomaxage':
 					$add_header_rules[] = 'add_header Pragma "public";';
 					$add_header_rules[] = 'add_header Cache-Control "public, immutable";';
-					break;
-
-				case 'cache_immutable_validation':
-					$add_header_rules[] = 'add_header Pragma "public";';
-					$add_header_rules[] = 'add_header Cache-Control "public, immutable, must-revalidate, proxy-revalidate";';
 					break;
 			}
 		}

--- a/BrowserCache_Plugin.php
+++ b/BrowserCache_Plugin.php
@@ -546,19 +546,9 @@ class BrowserCache_Plugin {
 					$headers['Cache-Control'] = "max-age=$lifetime, public, immutable";
 					break;
 
-				case 'cache_immutable_noproxy':
-					$headers['Pragma']        = 'private';
-					$headers['Cache-Control'] = "max-age=$lifetime, private, immutable";
-					break;
-
 				case 'cache_immutable_nomaxage':
 					$headers['Pragma']        = 'public';
 					$headers['Cache-Control'] = 'public, immutable';
-					break;
-
-				case 'cache_immutable_validation':
-					$headers['Pragma']        = 'public';
-					$headers['Cache-Control'] = 'public, immutable, must-revalidate, proxy-revalidate';
 					break;
 			}
 		}

--- a/BrowserCache_Plugin.php
+++ b/BrowserCache_Plugin.php
@@ -540,6 +540,26 @@ class BrowserCache_Plugin {
 					$headers['Pragma']        = 'no-store';
 					$headers['Cache-Control'] = 'no-store';
 					break;
+
+				case 'cache_immutable':
+					$headers['Pragma']        = 'public';
+					$headers['Cache-Control'] = "max-age=$lifetime, public, immutable";
+					break;
+
+				case 'cache_immutable_noproxy':
+					$headers['Pragma']        = 'private';
+					$headers['Cache-Control'] = "max-age=$lifetime, private, immutable";
+					break;
+
+				case 'cache_immutable_nomaxage':
+					$headers['Pragma']        = 'public';
+					$headers['Cache-Control'] = 'public, immutable';
+					break;
+
+				case 'cache_immutable_validation':
+					$headers['Pragma']        = 'public';
+					$headers['Cache-Control'] = 'public, immutable, must-revalidate, proxy-revalidate';
+					break;
 			}
 		}
 

--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -674,50 +674,70 @@ class Minify_Environment {
 				$cache_policy = $config->get_string( 'browsercache.cssjs.cache.policy' );
 
 				switch ( $cache_policy ) {
-				case 'cache':
-					$rules .= "    Header set Pragma \"public\"\n";
-					$rules .= "    Header set Cache-Control \"public\"\n";
-					break;
+					case 'cache':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"public\"\n";
+						break;
 
-				case 'cache_public_maxage':
-					$rules .= "    Header set Pragma \"public\"\n";
+					case 'cache_public_maxage':
+						$rules .= "    Header set Pragma \"public\"\n";
 
-					if ( $expires ) {
-						$rules .= "    Header append Cache-Control \"public\"\n";
-					} else {
-						$rules .= "    Header set Cache-Control \"max-age=" . $lifetime . ", public\"\n";
-					}
-					break;
+						if ( $expires ) {
+							$rules .= "    Header append Cache-Control \"public\"\n";
+						} else {
+							$rules .= "    Header set Cache-Control \"max-age=" . $lifetime . ", public\"\n";
+						}
+						break;
 
-				case 'cache_validation':
-					$rules .= "    Header set Pragma \"public\"\n";
-					$rules .= "    Header set Cache-Control \"public, must-revalidate, proxy-revalidate\"\n";
-					break;
+					case 'cache_validation':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"public, must-revalidate, proxy-revalidate\"\n";
+						break;
 
-				case 'cache_noproxy':
-					$rules .= "    Header set Pragma \"public\"\n";
-					$rules .= "    Header set Cache-Control \"private, must-revalidate\"\n";
-					break;
+					case 'cache_noproxy':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"private, must-revalidate\"\n";
+						break;
 
-				case 'cache_maxage':
-					$rules .= "    Header set Pragma \"public\"\n";
+					case 'cache_maxage':
+						$rules .= "    Header set Pragma \"public\"\n";
 
-					if ( $expires ) {
-						$rules .= "    Header append Cache-Control \"public, must-revalidate, proxy-revalidate\"\n";
-					} else {
-						$rules .= "    Header set Cache-Control \"max-age=" . $lifetime . ", public, must-revalidate, proxy-revalidate\"\n";
-					}
-					break;
+						if ( $expires ) {
+							$rules .= "    Header append Cache-Control \"public, must-revalidate, proxy-revalidate\"\n";
+						} else {
+							$rules .= "    Header set Cache-Control \"max-age=" . $lifetime . ", public, must-revalidate, proxy-revalidate\"\n";
+						}
+						break;
 
-				case 'no_cache':
-					$rules .= "    Header set Pragma \"no-cache\"\n";
-					$rules .= "    Header set Cache-Control \"max-age=0, private, no-store, no-cache, must-revalidate\"\n";
-					break;
+					case 'no_cache':
+						$rules .= "    Header set Pragma \"no-cache\"\n";
+						$rules .= "    Header set Cache-Control \"max-age=0, private, no-store, no-cache, must-revalidate\"\n";
+						break;
 
-				case 'no_store':
-					$rules .= "    Header set Pragma \"no-store\"\n";
-					$rules .= "    Header set Cache-Control \"no-store\"\n";
-					break;
+					case 'no_store':
+						$rules .= "    Header set Pragma \"no-store\"\n";
+						$rules .= "    Header set Cache-Control \"no-store\"\n";
+						break;
+
+					case 'cache_immutable':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"public, max-age=" . $lifetime . ", immutable\"\n";
+						break;
+
+					case 'cache_immutable_noproxy':
+						$rules .= "    Header set Pragma \"private\"\n";
+						$rules .= "    Header set Cache-Control \"private, max-age=" . $lifetime . ", immutable\"\n";
+						break;
+
+					case 'cache_immutable_nomaxage':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"public, immutable\"\n";
+						break;
+
+					case 'cache_immutable_validation':
+						$rules .= "    Header set Pragma \"public\"\n";
+						$rules .= "    Header set Cache-Control \"public, immutable, must-revalidate, proxy-revalidate\"\n";
+						break;
 				}
 			}
 

--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -724,19 +724,9 @@ class Minify_Environment {
 						$rules .= "    Header set Cache-Control \"public, max-age=" . $lifetime . ", immutable\"\n";
 						break;
 
-					case 'cache_immutable_noproxy':
-						$rules .= "    Header set Pragma \"private\"\n";
-						$rules .= "    Header set Cache-Control \"private, max-age=" . $lifetime . ", immutable\"\n";
-						break;
-
 					case 'cache_immutable_nomaxage':
 						$rules .= "    Header set Pragma \"public\"\n";
 						$rules .= "    Header set Cache-Control \"public, immutable\"\n";
-						break;
-
-					case 'cache_immutable_validation':
-						$rules .= "    Header set Pragma \"public\"\n";
-						$rules .= "    Header set Cache-Control \"public, immutable, must-revalidate, proxy-revalidate\"\n";
 						break;
 				}
 			}

--- a/inc/options/browsercache.php
+++ b/inc/options/browsercache.php
@@ -458,6 +458,10 @@ $security_session_values = array(
 						<option value="cache_noproxy"<?php selected( $value, 'cache_noproxy' ); ?>><?php esc_html_e( 'cache without proxy ("private, must-revalidate")', 'w3-total-cache' ); ?></option>
 						<option value="no_cache"<?php selected( $value, 'no_cache' ); ?>><?php esc_html_e( 'don\'t cache ("private, no-cache")', 'w3-total-cache' ); ?></option>
 						<option value="no_store"<?php selected( $value, 'no_store' ); ?>><?php esc_html_e( 'don\'t store ("no-store")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable"<?php selected( $value, 'cache_immutable' ); ?>><?php esc_html_e( 'cache immutable ("public, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_noproxy"<?php selected( $value, 'cache_immutable_noproxy' ); ?>><?php esc_html_e( 'cache immutable without proxy ("private, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_nomaxage"<?php selected( $value, 'cache_immutable_nomaxage' ); ?>><?php esc_html_e( 'cache immutable no max-age ("public, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_validation"<?php selected( $value, 'cache_immutable_validation' ); ?>><?php esc_html_e( 'cache immutable with validation ("public, immutable, must-revalidate, proxy-revalidate")', 'w3-total-cache' ); ?></option>
 					</select>
 					<?php if ( $is_nginx && $cssjs_expires ) : ?>
 						<p class="description"><?php esc_html_e( 'The Expires header already sets the max-age.', 'w3-total-cache' ); ?></p>
@@ -723,6 +727,10 @@ $security_session_values = array(
 						<option value="cache_noproxy"<?php selected( $value, 'cache_noproxy' ); ?>><?php esc_html_e( 'cache without proxy ("private, must-revalidate")', 'w3-total-cache' ); ?></option>
 						<option value="no_cache"<?php selected( $value, 'no_cache' ); ?>><?php esc_html_e( 'don\'t cache ("private, no-cache")', 'w3-total-cache' ); ?></option>
 						<option value="no_store"<?php selected( $value, 'no_store' ); ?>><?php esc_html_e( 'don\'t store ("no-store")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable"<?php selected( $value, 'cache_immutable' ); ?>><?php esc_html_e( 'cache immutable ("public, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_noproxy"<?php selected( $value, 'cache_immutable_noproxy' ); ?>><?php esc_html_e( 'cache immutable without proxy ("private, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_nomaxage"<?php selected( $value, 'cache_immutable_nomaxage' ); ?>><?php esc_html_e( 'cache immutable no max-age ("public, immutable")', 'w3-total-cache' ); ?></option>
+						<option value="cache_immutable_validation"<?php selected( $value, 'cache_immutable_validation' ); ?>><?php esc_html_e( 'cache immutable with validation ("public, immutable, must-revalidate, proxy-revalidate")', 'w3-total-cache' ); ?></option>
 					</select>
 					<?php if ( $is_nginx && $other_expires ) : ?>
 						<p class="description"><?php esc_html_e( 'The Expires header already sets the max-age.', 'w3-total-cache' ); ?></p>

--- a/inc/options/browsercache.php
+++ b/inc/options/browsercache.php
@@ -459,9 +459,7 @@ $security_session_values = array(
 						<option value="no_cache"<?php selected( $value, 'no_cache' ); ?>><?php esc_html_e( 'don\'t cache ("private, no-cache")', 'w3-total-cache' ); ?></option>
 						<option value="no_store"<?php selected( $value, 'no_store' ); ?>><?php esc_html_e( 'don\'t store ("no-store")', 'w3-total-cache' ); ?></option>
 						<option value="cache_immutable"<?php selected( $value, 'cache_immutable' ); ?>><?php esc_html_e( 'cache immutable ("public, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
-						<option value="cache_immutable_noproxy"<?php selected( $value, 'cache_immutable_noproxy' ); ?>><?php esc_html_e( 'cache immutable without proxy ("private, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
 						<option value="cache_immutable_nomaxage"<?php selected( $value, 'cache_immutable_nomaxage' ); ?>><?php esc_html_e( 'cache immutable no max-age ("public, immutable")', 'w3-total-cache' ); ?></option>
-						<option value="cache_immutable_validation"<?php selected( $value, 'cache_immutable_validation' ); ?>><?php esc_html_e( 'cache immutable with validation ("public, immutable, must-revalidate, proxy-revalidate")', 'w3-total-cache' ); ?></option>
 					</select>
 					<?php if ( $is_nginx && $cssjs_expires ) : ?>
 						<p class="description"><?php esc_html_e( 'The Expires header already sets the max-age.', 'w3-total-cache' ); ?></p>
@@ -728,9 +726,7 @@ $security_session_values = array(
 						<option value="no_cache"<?php selected( $value, 'no_cache' ); ?>><?php esc_html_e( 'don\'t cache ("private, no-cache")', 'w3-total-cache' ); ?></option>
 						<option value="no_store"<?php selected( $value, 'no_store' ); ?>><?php esc_html_e( 'don\'t store ("no-store")', 'w3-total-cache' ); ?></option>
 						<option value="cache_immutable"<?php selected( $value, 'cache_immutable' ); ?>><?php esc_html_e( 'cache immutable ("public, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
-						<option value="cache_immutable_noproxy"<?php selected( $value, 'cache_immutable_noproxy' ); ?>><?php esc_html_e( 'cache immutable without proxy ("private, max-age=EXPIRES_SECONDS, immutable")', 'w3-total-cache' ); ?></option>
 						<option value="cache_immutable_nomaxage"<?php selected( $value, 'cache_immutable_nomaxage' ); ?>><?php esc_html_e( 'cache immutable no max-age ("public, immutable")', 'w3-total-cache' ); ?></option>
-						<option value="cache_immutable_validation"<?php selected( $value, 'cache_immutable_validation' ); ?>><?php esc_html_e( 'cache immutable with validation ("public, immutable, must-revalidate, proxy-revalidate")', 'w3-total-cache' ); ?></option>
 					</select>
 					<?php if ( $is_nginx && $other_expires ) : ?>
 						<p class="description"><?php esc_html_e( 'The Expires header already sets the max-age.', 'w3-total-cache' ); ?></p>


### PR DESCRIPTION
This PR adds new immutable options in the dropdowns for the cache policy select for the CSS/JS and Other/Media sections located on the Browser Cache settings page