### PR TITLE
Browser Cache Security Header Fix

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -563,7 +563,7 @@ class BrowserCache_Environment {
 				$scriptelem      = trim( $config->get_string( 'browsercache.security.csp.scriptelem' ) );
 				$scriptattr      = trim( $config->get_string( 'browsercache.security.csp.scriptattr' ) );
 				$styleelem       = trim( $config->get_string( 'browsercache.security.csp.styleelem' ) );
-				$scriptelem      = trim( $config->get_string( 'browsercache.security.csp.styleattr' ) );
+				$styleattr       = trim( $config->get_string( 'browsercache.security.csp.styleattr' ) );
 				$worker          = trim( $config->get_string( 'browsercache.security.csp.worker' ) );
 				$default         = trim( $config->get_string( 'browsercache.security.csp.default' ) );
 

--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -257,7 +257,7 @@ class BrowserCache_Environment_Nginx {
 				$scriptelem      = trim( $this->c->get_string( 'browsercache.security.csp.scriptelem' ) );
 				$scriptattr      = trim( $this->c->get_string( 'browsercache.security.csp.scriptattr' ) );
 				$styleelem       = trim( $this->c->get_string( 'browsercache.security.csp.styleelem' ) );
-				$scriptelem      = trim( $this->c->get_string( 'browsercache.security.csp.styleattr' ) );
+				$styleattr       = trim( $this->c->get_string( 'browsercache.security.csp.styleattr' ) );
 				$worker          = trim( $this->c->get_string( 'browsercache.security.csp.worker' ) );
 				$default         = trim( $this->c->get_string( 'browsercache.security.csp.default' ) );
 
@@ -312,7 +312,7 @@ class BrowserCache_Environment_Nginx {
 				$scriptelem      = trim( $this->c->get_string( 'browsercache.security.csp.scriptelem' ) );
 				$scriptattr      = trim( $this->c->get_string( 'browsercache.security.csp.scriptattr' ) );
 				$styleelem       = trim( $this->c->get_string( 'browsercache.security.csp.styleelem' ) );
-				$scriptelem      = trim( $this->c->get_string( 'browsercache.security.csp.styleattr' ) );
+				$styleattr       = trim( $this->c->get_string( 'browsercache.security.csp.styleattr' ) );
 				$worker          = trim( $this->c->get_string( 'browsercache.security.csp.worker' ) );
 				$default         = trim( $this->c->get_string( 'browsercache.security.cspro.default' ) );
 


### PR DESCRIPTION
This PR fixes 2 bugs in the Browser Cache Security section
- The script-src-elem setting was being overridden by the value in style-src-attr setting
- The style-src-attr setting wasn't applying