### PR TITLE
Nginx Page Cache - Disk Enhanced Fix

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1246,7 +1246,7 @@ class PgCache_Environment {
 		$rules .= "}\n";
 
 		$rules .= 'location / {' . "\n";
-		$rules .= '  try_files $uri $uri/ /index.php?$args;' . "\n";
+		$rules .= '    try_files $uri $uri/ /index.php$is_args$args;' . "\n";
 		$rules .= "}\n";
 
 		return $rules;

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1236,7 +1236,7 @@ class PgCache_Environment {
 			$rules .= "}\n";
 
 			$rules .= 'if ($w3tc_ext = "") {' . "\n";
-			$rules .= '  set $w3tc_rewrite 0;' . "\n";
+			$rules .= '    set $w3tc_rewrite 0;' . "\n";
 			$rules .= "}\n";
 		}
 

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1227,7 +1227,7 @@ class PgCache_Environment {
 			$rules .= 'set $w3tc_ext "";' . "\n";
 			$rules .= 'if (-f "$document_root' . $uri_prefix . '.html' .
 				$env_w3tc_enc . '") {' . "\n";
-			$rules .= '  set $w3tc_ext .html;' . "\n";
+			$rules .= '    set $w3tc_ext .html;' . "\n";
 			$rules .= "}\n";
 
 			$rules .= 'if (-f "$document_root' . $uri_prefix . '.xml' .

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1245,6 +1245,10 @@ class PgCache_Environment {
 			'" last;' . "\n";
 		$rules .= "}\n";
 
+		$rules .= 'location / {' . "\n";
+		$rules .= '  try_files $uri $uri/ /index.php?$args;' . "\n";
+		$rules .= "}\n";
+
 		return $rules;
 	}
 


### PR DESCRIPTION
This PR addresses an issue with Page Cache when using the Disk Enhanced engine under nginx where page/posts would result in an nginx 404 instead of hitting PHP when no cache entry is found