### PR TITLE
Add settings to enable objectcache and dbcache for WP-CLI

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -176,6 +176,10 @@ $keys = array(
 			'\bfound_rows\(\)'
 		)
 	),
+	'dbcache.wpcli_disk' => array(
+		'type' => 'boolean',
+		'default' => false,
+	),
 
 	'docroot_fix.enable' => array(
 		'type' => 'boolean',
@@ -356,6 +360,10 @@ $keys = array(
 	'objectcache.purge.all' => array(
 		'type' => 'boolean',
 		'default' => false
+	),
+	'objectcache.wpcli_disk' => array(
+		'type' => 'boolean',
+		'default' => false,
 	),
 
 	'pgcache.configuration_overloaded' => array(

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -167,13 +167,12 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 			$flush_after_query         = true;
 		}
 
-		// Reject if this is a WP-CLI call and dbcache engine is set to Disk.
+		// Reject if this is a WP-CLI call, dbcache engine is set to Disk, and is disabled for WP-CLI.
 		if ( $this->is_wpcli_disk() ) {
-			$this->cache_reject_reason = 'wp-cli and dbcache set to disk';
+			$this->cache_reject_reason = 'dbcache set to disk and disabled for wp-cli';
 			$reject_reason             = $this->cache_reject_reason;
 			$caching                   = false;
 		}
-
 
 		if ( $this->use_filters && function_exists( 'apply_filters' ) ) {
 			$reject_reason = apply_filters(
@@ -962,7 +961,8 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 	 * @return bool
 	 */
 	private function is_wpcli_disk(): bool {
-		$engine = $this->_config->get_string( 'dbcache.engine' );
-		return defined( 'WP_CLI' ) && WP_CLI && 'file' === $engine;
+		$is_engine_disk = 'file' === $this->_config->get_string( 'dbcache.engine' );
+		$is_wpcli_disk  = $this->_config->get_boolean( 'dbcache.wpcli_disk' );
+		return defined( 'WP_CLI' ) && \WP_CLI && $is_engine_disk && ! $is_wpcli_disk;
 	}
 }

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -178,7 +178,7 @@ class ObjectCache_WpObjectCache_Regular {
 	 * @return mixed
 	 */
 	public function get( $id, $group = 'default', $force = false, &$found = null ) {
-		// Abort if this is a WP-CLI call and objectcache engine is set to Disk.
+		// Abort if this is a WP-CLI call, objectcache engine is set to Disk, and is disabled for WP-CLI.
 		if ( $this->is_wpcli_disk() ) {
 			return false;
 		}
@@ -340,7 +340,7 @@ class ObjectCache_WpObjectCache_Regular {
 	 * @return boolean
 	 */
 	public function set( $id, $data, $group = 'default', $expire = 0 ) {
-		// Abort if this is a WP-CLI call and objectcache engine is set to Disk.
+		// Abort if this is a WP-CLI call, objectcache engine is set to Disk, and is disabled for WP-CLI.
 		if ( $this->is_wpcli_disk() ) {
 			return false;
 		}
@@ -1327,7 +1327,7 @@ class ObjectCache_WpObjectCache_Regular {
 	}
 
 	/**
-	 * Check if this is a WP-CLI call and objectcache.engine is using Disk.
+	 * Check if this is a WP-CLI call and objectcache.engine is using Disk and disabled for WP-CLI.
 	 *
 	 * @since  2.8.1
 	 * @access private
@@ -1335,7 +1335,8 @@ class ObjectCache_WpObjectCache_Regular {
 	 * @return bool
 	 */
 	private function is_wpcli_disk(): bool {
-		$engine = $this->_config->get_string( 'objectcache.engine' );
-		return defined( 'WP_CLI' ) && WP_CLI && 'file' === $engine;
+		$is_engine_disk = 'file' === $this->_config->get_string( 'objectcache.engine' );
+		$is_wpcli_disk  = $this->_config->get_boolean( 'objectcache.wpcli_disk' );
+		return defined( 'WP_CLI' ) && \WP_CLI && $is_engine_disk && ! $is_wpcli_disk;
 	}
 }

--- a/Util_File.php
+++ b/Util_File.php
@@ -130,7 +130,7 @@ class Util_File {
 	 * @return void
 	 */
 	static public function rmdir( $path, $exclude = array(), $remove = true ) {
-		$dir = @opendir( $path );
+		$dir = file_exists( $path ) ? opendir( $path ) : false;
 
 		if ( $dir ) {
 			while ( ( $entry = @readdir( $dir ) ) !== false ) {

--- a/inc/options/dbcache.php
+++ b/inc/options/dbcache.php
@@ -1,9 +1,8 @@
 <?php
 namespace W3TC;
 
-if ( ! defined( 'W3TC' ) ) {
-	die();
-}
+defined( 'W3TC' ) || die();
+
 ?>
 <?php require W3TC_INC_DIR . '/options/common/header.php'; ?>
 
@@ -128,6 +127,17 @@ if ( ! defined( 'W3TC' ) ) {
 					<p class="description"><?php esc_html_e( 'Disable caching once specified constants defined.', 'w3-total-cache' ); ?></p>
 				</td>
 			</tr>
+			<?php
+			Util_Ui::config_item(
+				array(
+					'key'            => 'dbcache.wpcli_disk',
+					'label'          => esc_html__( 'Enable for WP-CLI', 'w3-total-cache' ),
+					'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
+					'control'        => 'checkbox',
+					'disabled'       => ! $dbcache_enabled,
+				)
+			);
+			?>
 		</table>
 
 		<?php Util_Ui::postbox_footer(); ?>
@@ -156,11 +166,9 @@ if ( ! defined( 'W3TC' ) ) {
 				?>
 			</p>
 			<?php
-			$c           = Dispatcher::config();
-			$disabled    = ! $c->get_boolean( 'dbcache.enabled' );
-			$wp_disabled = ! $c->get_boolean( 'dbcache.wp_cron' );
+			$wp_disabled = ! $this->_config->get_boolean( 'dbcache.wp_cron' );
 
-			if ( $disabled ) {
+			if ( ! $dbcache_enabled ) {
 				echo wp_kses(
 					sprintf(
 						// Translators: 1 opening HTML div tag followed by opening HTML p tag, 2 opening HTML a tag,
@@ -189,7 +197,7 @@ if ( ! defined( 'W3TC' ) ) {
 					'label'          => esc_html__( 'Enable WP-Cron Event', 'w3-total-cache' ),
 					'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
 					'control'        => 'checkbox',
-					'disabled'       => $disabled,
+					'disabled'       => ! $dbcache_enabled,
 				)
 			);
 
@@ -210,7 +218,7 @@ if ( ! defined( 'W3TC' ) ) {
 					'control'          => 'selectbox',
 					'selectbox_values' => $time_options,
 					'description'      => esc_html__( 'This setting controls the initial start time of the cron job. If the selected time has already passed, it will schedule the job for the following day at the selected time.', 'w3-total-cache' ),
-					'disabled'         => $disabled || $wp_disabled,
+					'disabled'         => ! $dbcache_enabled || $wp_disabled,
 				)
 			);
 
@@ -226,7 +234,7 @@ if ( ! defined( 'W3TC' ) ) {
 						'weekly'     => esc_html__( 'Weekly', 'w3-total-cache' ),
 					),
 					'description'      => esc_html__( 'This setting controls the interval that the cron job should occur.', 'w3-total-cache' ),
-					'disabled'         => $disabled || $wp_disabled,
+					'disabled'         => ! $dbcache_enabled || $wp_disabled,
 				)
 			);
 			?>

--- a/inc/options/objectcache.php
+++ b/inc/options/objectcache.php
@@ -1,9 +1,8 @@
 <?php
 namespace W3TC;
 
-if ( ! defined( 'W3TC' ) ) {
-	die();
-}
+defined( 'W3TC' ) || die();
+
 ?>
 <?php require W3TC_INC_DIR . '/options/common/header.php'; ?>
 
@@ -85,7 +84,7 @@ if ( ! defined( 'W3TC' ) ) {
 			<tr>
 				<th colspan="2">
 					<?php $this->checkbox( 'objectcache.fallback_transients' ); ?><?php esc_html_e( 'Store transients in database', 'w3-total-cache' ); ?></label>
-					<p class="description"><?php esc_html_e( 'Use that to store transients in database even when external cache is used. That allows transient values to survive object cache cleaning / expiration', 'w3-total-cache' ); ?></p>
+					<p class="description"><?php esc_html_e( 'Store transients in database even when external cache is used, which allows transient values to survive object cache cleaning/expiration', 'w3-total-cache' ); ?></p>
 				</th>
 			</tr>
 			<?php if ( $this->_config->get_boolean( 'cluster.messagebus.enabled' ) ) : ?>
@@ -112,7 +111,18 @@ if ( ! defined( 'W3TC' ) ) {
 					</p>
 				</th>
 			</tr>
-			<?php endif ?>
+			<?php endif; ?>
+			<?php
+			Util_Ui::config_item(
+				array(
+					'key'            => 'objectcache.wpcli_disk',
+					'label'          => esc_html__( 'Enable for WP-CLI', 'w3-total-cache' ),
+					'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
+					'control'        => 'checkbox',
+					'disabled'       => ! $objectcache_enabled,
+				)
+			);
+			?>
 		</table>
 
 		<?php Util_Ui::postbox_footer(); ?>
@@ -141,11 +151,8 @@ if ( ! defined( 'W3TC' ) ) {
 				?>
 			</p>
 			<?php
-			$c           = Dispatcher::config();
-			$disabled    = ! $c->get_boolean( 'objectcache.enabled' );
-			$wp_disabled = ! $c->get_boolean( 'objectcache.wp_cron' );
 
-			if ( $disabled ) {
+			if ( ! $objectcache_enabled ) {
 				echo wp_kses(
 					sprintf(
 						// Translators: 1 opening HTML div tag followed by opening HTML p tag, 2 opening HTML a tag,
@@ -174,7 +181,7 @@ if ( ! defined( 'W3TC' ) ) {
 					'label'          => esc_html__( 'Enable WP-Cron Event', 'w3-total-cache' ),
 					'checkbox_label' => esc_html__( 'Enable', 'w3-total-cache' ),
 					'control'        => 'checkbox',
-					'disabled'       => $disabled,
+					'disabled'       => ! $objectcache_enabled,
 				)
 			);
 
@@ -188,6 +195,8 @@ if ( ! defined( 'W3TC' ) ) {
 				}
 			}
 
+			$wp_disabled = ! $this->_config->get_boolean( 'objectcache.wp_cron' );
+
 			Util_Ui::config_item(
 				array(
 					'key'              => 'objectcache.wp_cron_time',
@@ -195,7 +204,7 @@ if ( ! defined( 'W3TC' ) ) {
 					'control'          => 'selectbox',
 					'selectbox_values' => $time_options,
 					'description'      => esc_html__( 'This setting controls the initial start time of the cron job. If the selected time has already passed, it will schedule the job for the following day at the selected time.', 'w3-total-cache' ),
-					'disabled'         => $disabled || $wp_disabled,
+					'disabled'         => ! $objectcache_enabled || $wp_disabled,
 				)
 			);
 
@@ -211,7 +220,7 @@ if ( ! defined( 'W3TC' ) ) {
 						'weekly'     => esc_html__( 'Weekly', 'w3-total-cache' ),
 					),
 					'description'      => esc_html__( 'This setting controls the interval that the cron job should occur.', 'w3-total-cache' ),
-					'disabled'         => $disabled || $wp_disabled,
+					'disabled'         => ! $objectcache_enabled || $wp_disabled,
 				)
 			);
 			?>


### PR DESCRIPTION
To test:

1. Save the settings and review the `master.php` configuration file for the new setting values for `objectcache.wpcli_disk` and `objectcache.wpcli_disk` are set to a default value of `false`.
2. Go to the Object Cache settings page, check the box "Enable for WP-CLI", and save the settings.
3. Review the setting to ensure that it is enabled (and set to `true`).
4. Go to the Database Cache settings page, check the box "Enable for WP-CLI", and save the settings.
5. Review the setting to ensure that it is enabled (and set to `true`).

Notes:
If one of the cache engines is disabled, the associated setting for it is also disabled on the settings page.
There is also a fix for silent warnings showing in Query Monitor in reference to database cache directories.
