### PR TITLE
Fix WP-CLI Object Cache

### DIFF
--- a/ObjectCache_Environment.php
+++ b/ObjectCache_Environment.php
@@ -222,6 +222,6 @@ class ObjectCache_Environment {
 			return false;
 
 		return ( ( $script_data = @file_get_contents( W3TC_ADDIN_FILE_OBJECT_CACHE ) )
-			&& strstr( $script_data, 'ObjectCache Version: 1.4' ) !== false );
+			&& strstr( $script_data, 'ObjectCache Version: 1.5' ) !== false );
 	}
 }

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -40,8 +40,19 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		if ( class_exists( 'W3TC\Dispatcher' ) ) {
 			$config = ( new \W3TC\Dispatcher() )->config();
 
+			// Don't use dropin if running in WP-CLI, object cache is enabled, set to disk, and not allows in settings.
 			if (
-				$config->get_boolean( 'objectcache.enabled' ) ||
+				defined( 'WP_CLI' ) && \WP_CLI &&
+				$config->getf_boolean( 'objectcache.enabled' ) &&
+				'file' === $config->get_string( 'objectcache.engine' ) &&
+				! $config->get_boolean( 'objectcache.wpcli_disk' )
+			) {
+				return false;
+			}
+
+			// Use dropin if obect cache is enabled or fragment cache is enabled.
+			if (
+				$config->getf_boolean( 'objectcache.enabled' ) ||
 				(
 					$config->is_extension_active( 'fragmentcache' ) &&
 					! empty( $config->get_string( array( 'fragmentcache', 'engine' ) ) ) &&

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -8,7 +8,7 @@
  *
  * W3 Total Cache Object Cache
  *
- * ObjectCache Version: 1.4 // This line is used in ObjectCache_Environment::is_objectcache_add_in(), which looks for "ObjectCache Version: 1.4".
+ * ObjectCache Version: 1.5 // This line is used in ObjectCache_Environment::is_objectcache_add_in(), which looks for "ObjectCache Version: 1.5".
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Transients are not being retrieved when using WP-CLI.  For example, when `wp core check-update` is executed when there is an actual WordPress update pending, the resulting output is "Success: WordPress is at the latest version." when it should be something like:
```
+---------+-------------+-----------------------------------------------------------------------+
| version | update_type | package_url                                                           |
+---------+-------------+-----------------------------------------------------------------------+
| 6.7.2   | minor       | https://downloads.wordpress.org/release/wordpress-6.7.2-partial-1.zip |
+---------+-------------+-----------------------------------------------------------------------+
```

To test:
1) Visit a W3TC plugin page or run `wp w3tc fix_environment` after applying the fix -- the Object Cache dropin was updated to version 1.5.
2) Enable Object Cache using Disk.
3) Ensure that "Enable for WP-CLI" (on "wp-admin/admin.php?page=w3tc_objectcache") is not checked.  Note: The option was added in another pull request that was included in this branch.
4) Ensure you have a previous version of WordPress -- `wp core update --version=6.7.1 --force`
5) Run `wp core check-update`
6) See the expected result -- a pending update when having the fix or no update before the fix.
