### PR TITLE
Add phpunit tests

### DIFF
--- a/Root_Environment.php
+++ b/Root_Environment.php
@@ -235,12 +235,12 @@ class Root_Environment {
 
 		// Delete options and transients with defined prefixes.
 		foreach ( $prefixes as $prefix ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-					$prefix . '%'
-				)
-			);
+			$query        = 'SELECT `option_name` FROM ' . $wpdb->options . ' WHERE `option_name` LIKE "' . $prefix . '%";';
+			$option_names = $wpdb->get_col( $query ); // phpcs:ignore WordPress.DB.PreparedSQL
+
+			foreach ( $option_names as $option_name ) {
+				delete_option( $option_name );
+			}
 		}
 
 		// Remove plugin-created directories.

--- a/tests/admin/class-w3tc-admin-root-environment.php
+++ b/tests/admin/class-w3tc-admin-root-environment.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File: class-w3tc-admin-root-environment.php
+ *
+ * @package    W3TC
+ * @subpackage W3TC/tests/admin
+ * @author     BoldGrid <development@boldgrid.com>
+ * @since      X.X.X
+ * @link       https://www.boldgrid.com/w3-total-cache/
+ */
+
+declare( strict_types = 1 );
+
+use W3TC\Root_Environment;
+
+/**
+ * Class: W3tc_Admin_Root_Environment_Test
+ *
+ * @since X.X.X
+ */
+class W3tc_Admin_Root_Environment_Test extends WP_UnitTestCase {
+	/**
+	 * Test delete_plugin_data().
+	 *
+	 * @since X.X.X
+	 *
+	 * @see w3tc_config()
+	 *
+	 * @return void
+	 */
+	public function test_delete_plugin_data() {
+		// Setup: Add dummy plugin data.
+		$option_name = 'w3tc_plugin_data' . wp_rand();
+		add_option( $option_name, 'Test value', '', false );
+
+		// Verify that the option exists.
+		$this->assertNotFalse( get_option( $option_name ), 'Pre-condition failed: Plugin option should exist.' );
+
+		// Call the method to delete plugin data.
+		Root_Environment::delete_plugin_data( w3tc_config() );
+
+		// Verify that the plugin option is deleted.
+		$this->assertFalse( get_option( $option_name ), 'The plugin option should have been deleted.' );
+	}
+}

--- a/tests/admin/class-w3tc-admin-util-environment.php
+++ b/tests/admin/class-w3tc-admin-util-environment.php
@@ -14,11 +14,11 @@ declare( strict_types = 1 );
 use W3TC\Util_Environment;
 
 /**
- * Class: W3tc_Admin_Util_File_Test
+ * Class: W3tc_Admin_Util_Environment_Test
  *
  * @since 2.7.4
  */
-class W3tc_Admin_Util_Environment extends WP_UnitTestCase {
+class W3tc_Admin_Util_Environment_Test extends WP_UnitTestCase {
 	/**
 	 * Test array_intersect_partial().
 	 *


### PR DESCRIPTION
This pull request fixes the issue of deleting the W3TC WP Options when the user selects to delete data on deactivation in the exit survey.

Test:
1) Run PHPUnit to see if it passes the new test.
2) Check the database for 'w3%' options exist.
3) Deactivate the plugin with the delete checkbox checked.
4) Check the database to ensure the options were deleted.
