### PR TITLE
Exit Survey data delete on skip

### DIFF
--- a/Generic_Plugin_Survey.php
+++ b/Generic_Plugin_Survey.php
@@ -200,7 +200,7 @@ class Generic_Plugin_Survey {
 		}
 
 		// Collect remove data flag.
-		$remove_data = sanitize_text_field( Util_Request::get_string( 'remove' ) );
+		$remove_data = Util_Request::get_string( 'remove' );
 
 		if ( 'yes' === $remove_data ) {
 			update_option( 'w3tc_remove_data', true );

--- a/Generic_Plugin_Survey.php
+++ b/Generic_Plugin_Survey.php
@@ -81,6 +81,7 @@ class Generic_Plugin_Survey {
 	public function run() {
 		add_action( 'w3tc_ajax_exit_survey_render', array( $this, 'w3tc_ajax_exit_survey_render' ) );
 		add_action( 'w3tc_ajax_exit_survey_submit', array( $this, 'w3tc_ajax_exit_survey_submit' ) );
+		add_action( 'w3tc_ajax_exit_survey_skip', array( $this, 'w3tc_ajax_exit_survey_skip' ) );
 	}
 
 	/**
@@ -178,6 +179,32 @@ class Generic_Plugin_Survey {
 			wp_send_json_success( array( 'message' => 'Thank you for your feedback!' ) );
 		} else {
 			wp_send_json_error( array( 'message' => 'API error: ' . $api_response->message ) );
+		}
+	}
+
+	/**
+	 * Skips the exit survey and processes removing plugin data.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function w3tc_ajax_exit_survey_skip() {
+		if ( ! \user_can( \get_current_user_id(), 'manage_options' ) ) {
+			return;
+		}
+
+		// Verify nonce.
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( Util_Request::get_string( '_wpnonce' ), 'w3tc' ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid nonce.' ) );
+		}
+
+		// Collect remove data flag.
+		$remove_data = sanitize_text_field( Util_Request::get_string( 'remove' ) );
+
+		if ( 'yes' === $remove_data ) {
+			update_option( 'w3tc_remove_data', true );
+			wp_send_json_success( array( 'message' => 'Plugin data will be removed!' ) );
 		}
 	}
 }

--- a/inc/lightbox/exit_survey.php
+++ b/inc/lightbox/exit_survey.php
@@ -49,7 +49,7 @@
 			<p><?php esc_html_e( 'We\'re serious about making W3 Total Cache better, and sometimes that means reaching out to users like you to get a few more details about your experience. Would you be open to us contacting you for further feedback? If so, please enter your email address below.', 'w3-total-cache' ); ?></p>
 
 			<div class="w3tc-exit-survey-email">
-				<input id="email" type="email" id="w3tc_exit_survey_uninstall_reason_other" name="email" placeholder="<?php esc_attr_e( 'Email address...', 'w3-total-cache' ); ?>" />
+				<input id="email" type="email" id="w3tc_exit_survey_uninstall_reason_other" name="email" placeholder="<?php esc_attr_e( 'Email address...', 'w3-total-cache' ); ?>" disabled/>
 			</div>
 
 			<h2><?php esc_html_e( 'Remove all plugin data?', 'w3-total-cache' ); ?></h2>

--- a/pub/js/exit-survey.js
+++ b/pub/js/exit-survey.js
@@ -41,7 +41,7 @@ function w3tc_exit_survey_render() {
 
 				var remove = jQuery('input[name="remove"]:checked', lightbox.container).val();
 
-				if ( 'Yes' === remove ) {
+				if ( 'yes' === remove ) {
 					// Build the params object.
 					var params = {
 						action: 'w3tc_ajax',
@@ -50,7 +50,7 @@ function w3tc_exit_survey_render() {
 						remove: remove
 					};
 
-					// Send the survey data to the API server.
+					// Send the remove data flag via AJAX.
 					jQuery.post( ajaxurl, params, function(response) {
 						if(response.error && window.w3tc_ga) {
 							w3tc_ga(
@@ -62,11 +62,11 @@ function w3tc_exit_survey_render() {
 								}
 							);
 						}
-
-						lightbox.close();
-						window.location.href = deactivateUrl;
 					});
 				}
+
+				lightbox.close();
+				window.location.href = deactivateUrl;
 			});
 
 			// Handle form submission.

--- a/pub/js/exit-survey.js
+++ b/pub/js/exit-survey.js
@@ -154,6 +154,7 @@ jQuery(function() {
 	jQuery(document).on('change', 'input[name="reason"]', function() {
 		// Enable Submit & Deactivate button once an option is selected.
 		if (jQuery('input[name="reason"]:checked').length > 0) {
+			jQuery('.w3tc-exit-survey-email #email').prop('disabled', false);
 			jQuery('#w3tc-exit-survey-submit').prop('disabled', false);
 		}
 

--- a/pub/js/exit-survey.js
+++ b/pub/js/exit-survey.js
@@ -39,10 +39,34 @@ function w3tc_exit_survey_render() {
 					);
 				}
 
-				// Close the lightbox.
-				lightbox.close();
-				// Proceed with plugin deactivation.
-				window.location.href = deactivateUrl;
+				var remove = jQuery('input[name="remove"]:checked', lightbox.container).val();
+
+				if ( 'Yes' === remove ) {
+					// Build the params object.
+					var params = {
+						action: 'w3tc_ajax',
+						_wpnonce: w3tcData.nonce,
+						w3tc_action: 'exit_survey_skip',
+						remove: remove
+					};
+
+					// Send the survey data to the API server.
+					jQuery.post( ajaxurl, params, function(response) {
+						if(response.error && window.w3tc_ga) {
+							w3tc_ga(
+								'event',
+								'w3tc_error',
+								{
+									eventCategory: 'exit_survey',
+									eventLabel: 'skip_error'
+								}
+							);
+						}
+
+						lightbox.close();
+						window.location.href = deactivateUrl;
+					});
+				}
 			});
 
 			// Handle form submission.
@@ -80,23 +104,19 @@ function w3tc_exit_survey_render() {
 
 				// Send the survey data to the API server.
 				jQuery.post( ajaxurl, params, function(response) {
-					if(response.success) {
-						lightbox.close();
-						window.location.href = deactivateUrl;
-					} else {
-						if (window.w3tc_ga) {
-							w3tc_ga(
-								'event',
-								'w3tc_error',
-								{
-									eventCategory: 'exit_survey',
-									eventLabel: 'api_error'
-								}
-							);
-						}
-						lightbox.close();
-						window.location.href = deactivateUrl;
+					if(response.error && window.w3tc_ga) {
+						w3tc_ga(
+							'event',
+							'w3tc_error',
+							{
+								eventCategory: 'exit_survey',
+								eventLabel: 'api_error'
+							}
+						);
 					}
+
+					lightbox.close();
+					window.location.href = deactivateUrl;
 				});
 			});
 


### PR DESCRIPTION
This PR makes it so if the user selects yes for data removal in the exit survey and then clicks on the "Skip & Deactivate" link it will remove plugin data