### PR TITLE
Miscellaneous fixes

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1395,7 +1395,6 @@ class PgCache_ContentGrabber {
 					$cookie = trim( $cookie );
 					if ( ! empty( $cookie ) ) {
 						$cookie = str_replace( '+', ' ', $cookie );
-						$cookie = Util_Environment::preg_quote( $cookie );
 						if ( strpos( $cookie, '=' ) === false ) {
 							$cookie .= '=.*';
 						}

--- a/Root_Loader.php
+++ b/Root_Loader.php
@@ -239,7 +239,11 @@ class Root_Loader {
 			return;
 		}
 
-		$screen = get_current_screen();
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+		} else {
+			return;
+		}
 
 		if ( ! $screen || 'upload' !== $screen->id || 'attachment' !== $screen->post_type ) {
 			return;


### PR DESCRIPTION
There are two fixes:
 - Fix cookie cache group regex matching
 - Fix error in meta_query for Image Service media when run before admin_init

To test:
1. Go to the Cache Group settings page (`wp-admin/admin.php?page=w3tc_cachegroups#manage-cg`) and enable the default cookie group "loggedin" and set it to cache.
2.  Go to General Settings (`wp-admin/admin.php?page=w3tc_general`) to enable Page Cache (Disk: Enhanced).
3. Go to the Page Cache settings (`wp-admin/admin.php?page=w3tc_pgcache`) and uncheck "Don't cache pages for logged in users", "Don't cache pages for following user roles", and save the settings.
4. Open an Incognito or Private Browsing window, log in, and browse to some front-end pages.
5. View the page source to see that the W3TC footer comment contains "Page Caching using Disk: Enhanced loggedin".
6. Check the cache folder for `page_enhanced` and look for filenames including "loggedin".
```
find wp-content/cache/page_enhanced/ -type f ! -name '.htaccess' -ls
```