### PR TITLE
Fix AWS S3 test

### DIFF
--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -558,7 +558,7 @@ class CdnEngine_S3 extends CdnEngine_Base {
 			)
 		);
 
-		if ( $object['Body'] !== $key ) {
+		if ( (string) $object['Body'] !== $key ) {
 			$error = 'Objects are not equal.';
 
 			$this->api->deleteObject(

--- a/CdnEngine_S3_Compatible.php
+++ b/CdnEngine_S3_Compatible.php
@@ -396,7 +396,7 @@ class CdnEngine_S3_Compatible extends CdnEngine_Base {
 			return false;
 		}
 
-		if ( $object->body !== $string ) {
+		if ( (string) $object->body !== $string ) {
 			$error = 'Objects are not equal.';
 
 			@$this->_s3->deleteObject( $this->_config['bucket'], $string );


### PR DESCRIPTION
When testing Amazon S3 on Cloudfront, an error "Objects are not equal" is shown.  This fix allows it to pass.