### PR TITLE
Fix wp_resource_hints hook issue in UserExperience_Emoji_Extension.php

### DIFF
--- a/UserExperience_Emoji_Extension.php
+++ b/UserExperience_Emoji_Extension.php
@@ -74,6 +74,7 @@ class UserExperience_Emoji_Extension {
 			return $urls;
 		}
 
+		// remove s.w.org dns-prefetch used by emojis.
 		return array_filter(
 			$urls,
 			function ( $hint ) {

--- a/UserExperience_Emoji_Extension.php
+++ b/UserExperience_Emoji_Extension.php
@@ -74,11 +74,21 @@ class UserExperience_Emoji_Extension {
 			return $urls;
 		}
 
-		// remove s.w.org dns-prefetch used by emojis.
 		return array_filter(
 			$urls,
-			function ( $v ) {
-				return ( 'https://s.w.org/' !== substr( $v, 0, 16 ) );
+			function ( $hint ) {
+				// Handle the case where each hint is an array with 'href' key.
+				if ( is_array( $hint ) && isset( $hint['href'] ) ) {
+					return strpos( $hint['href'], '//s.w.org' ) === false;
+				}
+
+				// Handle the case where hint is a simple string URL.
+				if ( is_string( $hint ) ) {
+					return strpos( $hint, '//s.w.org' ) === false;
+				}
+
+				// In any other case, keep the item.
+				return true;
 			}
 		);
 	}


### PR DESCRIPTION
Hints passed through the wp-resource_hints hook can be either a flat or associative array. Our implementation handled these values as a flat array only which caused issues when associative values were present. This PR updates our implementation to properly handle both formats