### PR TITLE
Fix exception handing on activation (#1074)

### DIFF
--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -1236,7 +1236,7 @@ class Generic_Plugin_Admin {
 					'</tr>' .
 					'<tr>' .
 						'<td>' . esc_html__( 'or use FTP form to allow ', 'w3-total-cache' ) .
-							'<strong>' . esc_html__( 'W3 Total Cache', 'w3-total-cache' ) . '</strong>' .
+							'<strong>' . esc_html__( 'W3 Total Cache', 'w3-total-cache' ) . '</strong> ' .
 							esc_html__( 'make it automatically.', 'w3-total-cache' ) .
 						'</td>' .
 						'<td>' . Util_Ui::button( 'Update via FTP', '', 'w3tc-show-ftp-form button' ) . '</td>' .

--- a/Root_AdminActivation.php
+++ b/Root_AdminActivation.php
@@ -61,35 +61,80 @@ class Root_AdminActivation {
 			}
 		}
 
+		$e      = Dispatcher::component( 'Root_Environment' );
+		$config = Dispatcher::config();
+
 		try {
-			$e      = Dispatcher::component( 'Root_Environment' );
-			$config = Dispatcher::config();
 			$e->fix_in_wpadmin( $config, true );
-			$e->fix_on_event( $config, 'activate' );
+		} catch ( Util_Environment_Exceptions $exs ) {
+			$r = Util_Activation::parse_environment_exceptions( $exs );
 
-			// try to save config file if needed, optional thing so exceptions hidden.
-			if ( ! ConfigUtil::is_item_exists( 0, false ) ) {
-				try {
-					// create folders.
-					$e->fix_in_wpadmin( $config );
-				} catch ( \Exception $ex ) {
-					// missing exception handle?
-				}
-
-				try {
-					Util_Admin::config_save( Dispatcher::config(), $config );
-				} catch ( \Exception $ex ) {
-					// missing exception handle?
+			if ( \strlen( $r['required_changes'] ) > 0 ) {
+				// Log the error for debugging purposes.
+				if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					\error_log( 'W3 Total Cache environment exception: ' . $r['required_changes'] ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				}
 			}
-
-			if ( ! get_option( 'w3tc_install_date' ) ) {
-				update_option( 'w3tc_install_date', current_time( 'mysql' ) );
-			}
-		} catch ( Util_Environment_Exceptions $e ) {
-			// missing exception handle?
 		} catch ( \Exception $e ) {
+			// Log the exception for debugging purposes.
+			if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				\error_log( 'W3 Total Cache exception: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+
+			// Handle the exception gracefully.
 			Util_Activation::error_on_exception( $e );
+		}
+
+		try {
+			$e->fix_on_event( $config, 'activate' );
+		} catch ( Util_Environment_Exceptions $exs ) {
+			$r = Util_Activation::parse_environment_exceptions( $exs );
+
+			if ( \strlen( $r['required_changes'] ) > 0 ) {
+				// Log the error for debugging purposes.
+				if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					\error_log( 'W3 Total Cache environment exception: ' . $r['required_changes'] ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				}
+			}
+		} catch ( \Exception $e ) {
+			// Log the exception for debugging purposes.
+			if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				\error_log( 'W3 Total Cache exception: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+
+			// Handle the exception gracefully.
+			Util_Activation::error_on_exception( $e );
+		}
+
+		// try to save config file if needed, optional thing so exceptions hidden.
+		if ( ! ConfigUtil::is_item_exists( 0, false ) ) {
+			try {
+				// create folders.
+				$e->fix_in_wpadmin( $config );
+			} catch ( Util_Environment_Exceptions $exs ) {
+				$r = Util_Activation::parse_environment_exceptions( $exs );
+
+				if ( \strlen( $r['required_changes'] ) > 0 ) {
+					// Log the error for debugging purposes.
+					if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						\error_log( 'W3 Total Cache environment exception: ' . $r['required_changes'] ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					}
+				}
+			}
+
+			try {
+				Util_Admin::config_save( Dispatcher::config(), $config );
+			} catch ( \Exception $ex ) {
+				// Log the exception for debugging purposes.
+				if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					\error_log( 'W3 Total Cache exception: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				}
+			}
+		}
+
+		// Set the installation date if it is not already set.
+		if ( ! get_option( 'w3tc_install_date' ) ) {
+			update_option( 'w3tc_install_date', current_time( 'mysql' ) );
 		}
 	}
 

--- a/Root_AdminActivation.php
+++ b/Root_AdminActivation.php
@@ -127,7 +127,7 @@ class Root_AdminActivation {
 			} catch ( \Exception $ex ) {
 				// Log the exception for debugging purposes.
 				if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					\error_log( 'W3 Total Cache exception: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					\error_log( 'W3 Total Cache exception: ' . $ex->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1074

To test:
Replication steps are in the GitHub issue.  In order to stage the scenario, first remove the W3TC rules from your main `.htaccess` file and `chown root:root` so that WordPress cannot write to the file.

The WP_DEBUG error logging is to help debug.
