### PR TITLE
Refactor CDN strings to use constant

### DIFF
--- a/Cdn_TotalCdn_Auto_Configure.php
+++ b/Cdn_TotalCdn_Auto_Configure.php
@@ -185,7 +185,11 @@ class Cdn_TotalCdn_Auto_Configure {
 		if ( empty( $api_key ) ) {
 			return array(
 				'success' => false,
-				'message' => __( 'API key is not set. Please enter your Total CDN API key.', 'w3-total-cache' ),
+                               'message' => sprintf(
+                                       // translators: 1: CDN name.
+                                       __( 'API key is not set. Please enter your %1$s API key.', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 			);
 		}
 
@@ -446,11 +450,12 @@ class Cdn_TotalCdn_Auto_Configure {
 					// Print a message indication that the pull zone and url do not match, and ask if they want to update it. Provide a Yes button and a No button.
 					echo wp_kses_post(
 						sprintf(
-							// translators: 1: Pull zone URL, 2: Current site URL. 3: Update Pullzone button button (update action).
-							__( '<p>The Total CDN pull zone URL <strong>( %1$s )</strong> does not match your current Site URL <strong>( %2$s )</strong>.</p><p><a class="button button-secondary" href="%3$s">Click here to update pull zone URL</a></p>', 'w3-total-cache' ),
-							esc_html( $origin_url ),
-							esc_html( $current_site_url ),
-							\wp_nonce_url( 'admin.php?page=w3tc_cdn&w3tc_cdn_update_w3tc_cdn_pullzone', 'w3tc' )
+                                       // translators: 1: CDN name, 2: Pull zone URL, 3: Current site URL, 4: Update pull zone URL link.
+                                       __( '<p>The %1$s pull zone URL <strong>( %2$s )</strong> does not match your current Site URL <strong>( %3$s )</strong>.</p><p><a class="button button-secondary" href="%4$s">Click here to update pull zone URL</a></p>', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME ),
+                                       esc_html( $origin_url ),
+                                       esc_html( $current_site_url ),
+                                       \wp_nonce_url( 'admin.php?page=w3tc_cdn&w3tc_cdn_update_w3tc_cdn_pullzone', 'w3tc' )
 						)
 					);
 					?>
@@ -497,8 +502,16 @@ class Cdn_TotalCdn_Auto_Configure {
 			'admin_notices',
 			function () {
 				echo '<div class="notice notice-warning is-dismissible">';
-				echo '<p>' . esc_html__( 'You have an active Total CDN account. Click the button below to auto-configure it.', 'w3-total-cache' ) . '</p>';
-				echo '<p><button class="button button-primary button-auto-tcdn">' . esc_html__( 'Auto-Configure Total CDN', 'w3-total-cache' ) . '</button></p>';
+                               echo '<p>' . sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_html__( 'You have an active %1$s account. Click the button below to auto-configure it.', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               ) . '</p>';
+                               echo '<p><button class="button button-primary button-auto-tcdn">' . sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_html__( 'Auto-Configure %1$s', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               ) . '</button></p>';
 				echo '</div>';
 			}
 		);

--- a/Cdn_TotalCdn_Page.php
+++ b/Cdn_TotalCdn_Page.php
@@ -81,7 +81,11 @@ class Cdn_TotalCdn_Page {
 			$actions[] = sprintf(
 				'<input type="submit" class="dropdown-item" name="w3tc_%1$s_flush_all_except_%1$s" value="%2$s"%3$s>',
 				esc_attr( W3TC_CDN_SLUG ),
-				esc_attr__( 'Empty All Caches Except Total CDN', 'w3-total-cache' ),
+                               sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_attr__( 'Empty All Caches Except %1$s', 'w3-total-cache' ),
+                                       esc_attr( W3TC_CDN_NAME )
+                               ),
 				( ! $can_empty_memcache && ! $can_empty_opcode && ! $can_empty_file && ! $can_empty_varnish ) ? ' disabled="disabled"' : ''
 			);
 		}

--- a/Cdn_TotalCdn_Popup_View_Intro.php
+++ b/Cdn_TotalCdn_Popup_View_Intro.php
@@ -28,7 +28,11 @@ defined( 'W3TC' ) || die();
 		</div>
 	<?php endif; ?>
 	<div class="metabox-holder">
-		<?php Util_Ui::postbox_header( esc_html__( 'Total CDN API Configuration', 'w3-total-cache' ) ); ?>
+               <?php Util_Ui::postbox_header( sprintf(
+                       // translators: 1: CDN name.
+                       esc_html__( '%1$s API Configuration', 'w3-total-cache' ),
+                       esc_html( W3TC_CDN_NAME )
+               ) ); ?>
 		<table class="form-table">
 			<tr>
 				<td><?php esc_html_e( 'Account API Key', 'w3-total-cache' ); ?>:</td>

--- a/Cdn_TotalCdn_Widget_View_Unauthorized.php
+++ b/Cdn_TotalCdn_Widget_View_Unauthorized.php
@@ -57,12 +57,13 @@ defined( 'W3TC' ) || die();
 		<p class="notice notice-error">
 			<?php
 			echo wp_kses(
-				sprintf(
-					// translators: 1 opening HTML a tag to CDN settings page, 2 closing HTML a tag.
-					__( 'W3 Total Cache has detected that Total CDN is selected but not fully configured. Please use the "Authorize" button on the %1$sCDN%2$s settings page to connect a pull zone.', 'w3-total-cache' ),
-					'<a href="' . esc_url_raw( Util_Ui::admin_url( 'admin.php?page=w3tc_cdn' ) ) . '">',
-					'</a>'
-				),
+                               sprintf(
+                                       // translators: 1 opening HTML a tag to CDN settings page, 2 closing HTML a tag, 3: CDN name.
+                                       __( 'W3 Total Cache has detected that %3$s is selected but not fully configured. Please use the "Authorize" button on the %1$sCDN%2$s settings page to connect a pull zone.', 'w3-total-cache' ),
+                                       '<a href="' . esc_url_raw( Util_Ui::admin_url( 'admin.php?page=w3tc_cdn' ) ) . '">',
+                                       '</a>',
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 				array(
 					'a' => array(
 						'href' => array(),
@@ -107,11 +108,12 @@ defined( 'W3TC' ) || die();
 			}
 
 			echo wp_kses(
-				sprintf(
-					// translators: 1 configured CDN/CDN FSD label.
-					__( 'W3 Total Cache has detected that you are using the %1$s, which is fully supported and compatible. For optimal performance and value, we recommend considering our Total CDN service as an alternative.', 'w3-total-cache' ),
-					$cdn_label
-				),
+                               sprintf(
+                                       // translators: 1 configured CDN/CDN FSD label, 2: CDN name.
+                                       __( 'W3 Total Cache has detected that you are using the %1$s, which is fully supported and compatible. For optimal performance and value, we recommend considering our %2$s service as an alternative.', 'w3-total-cache' ),
+                                       $cdn_label,
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 				array(
 					'acronym' => array(
 						'title' => array(),
@@ -127,12 +129,13 @@ defined( 'W3TC' ) || die();
 		<p class="notice notice-error">
 			<?php
 			echo wp_kses(
-				sprintf(
-					// translators: 1 opening HTML a tag to CDN settings page, 2 closing HTML a tag.
-					__( 'W3 Total Cache has detected that Total CDN has been purchased and is available but has yet to be enabled. Please %1$sEnable%2$s the CDN feature on the General Settings page and select Total CDN for the CDN type.', 'w3-total-cache' ),
-					'<a class="button-primary" href="' . \esc_url( \wp_nonce_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' ), 'w3tc' ) ) . '">',
-					'</a>'
-				),
+                               sprintf(
+                                       // translators: 1 opening HTML a tag to CDN settings page, 2 closing HTML a tag, 3: CDN name.
+                                       __( 'W3 Total Cache has detected that %3$s has been purchased and is available but has yet to be enabled. Please %1$sEnable%2$s the CDN feature on the General Settings page and select %3$s for the CDN type.', 'w3-total-cache' ),
+                                       '<a class="button-primary" href="' . \esc_url( \wp_nonce_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' ), 'w3tc' ) ) . '">',
+                                       '</a>',
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 				array(
 					'a' => array(
 						'class' => array(),
@@ -149,11 +152,12 @@ defined( 'W3TC' ) || die();
 		<p class="notice notice-error">
 			<?php
 			echo wp_kses(
-				sprintf(
-					// translators: 1 HTML acronym for Content Delivery Network (CDN).
-					__( 'W3 Total Cache has detected that you do not have a %1$s configured. For optimal performance and value, we recommend considering our Total CDN service.', 'w3-total-cache' ),
-					'<acronym title="' . __( 'Content Delivery Network', 'w3-total-cache' ) . '">' . __( 'CDN', 'w3-total-cache' ) . '</acronym>'
-				),
+                               sprintf(
+                                       // translators: 1 HTML acronym for Content Delivery Network (CDN), 2: CDN name.
+                                       __( 'W3 Total Cache has detected that you do not have a %1$s configured. For optimal performance and value, we recommend considering our %2$s service.', 'w3-total-cache' ),
+                                       '<acronym title="' . __( 'Content Delivery Network', 'w3-total-cache' ) . '">' . __( 'CDN', 'w3-total-cache' ) . '</acronym>',
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 				array(
 					'acronym' => array(
 						'title' => array(),
@@ -187,14 +191,18 @@ defined( 'W3TC' ) || die();
 
 		<p>
 			<?php
-			w3tc_e(
-				'cdn.' . W3TC_CDN_SLUG . '.widget.v2.works_magically',
-				\__( 'Total CDN works magically with W3 Total Cache to speed up your site around the world for as little as $1 per month.', 'w3-total-cache' )
-			);
+                               w3tc_e(
+                                       'cdn.' . W3TC_CDN_SLUG . '.widget.v2.works_magically',
+                                       sprintf(
+                                               // translators: 1: CDN name.
+                                               \__( '%1$s works magically with W3 Total Cache to speed up your site around the world for as little as $1 per month.', 'w3-total-cache' ),
+                                               esc_html( W3TC_CDN_NAME )
+                                       )
+                               );
 			?>
 		</p>
 
-		<input type="button" class="button-primary btn button-buy-tcdn" data-renew-key="<?php echo esc_attr( $config->get_string( 'plugin.license_key' ) ); ?>" data-src="general_page_cdn_subscribe" value="<?php esc_attr_e( 'Subscribe To Total CDN', 'w3-total-cache' ); ?>">
+               <input type="button" class="button-primary btn button-buy-tcdn" data-renew-key="<?php echo esc_attr( $config->get_string( 'plugin.license_key' ) ); ?>" data-src="general_page_cdn_subscribe" value="<?php echo sprintf( esc_attr__( 'Subscribe To %1$s', 'w3-total-cache' ), esc_attr( W3TC_CDN_NAME ) ); ?>">
 		<?php
 	}
 	?>
@@ -204,14 +212,15 @@ defined( 'W3TC' ) || die();
 		<?php
 		w3tc_e(
 			'cdn.' . W3TC_CDN_SLUG . '.widget.v2.existing',
-			\sprintf(
-				// translators: 1 HTML acronym for Content Delivery Network (CDN).
-				\__(
-					'If you\'re an existing Total CDN customer, enable %1$s and authorize. If you need help configuring your %1$s, we also offer Premium Services to assist you.',
-					'w3-total-cache'
-				),
-				'<acronym title="' . \__( 'Content Delivery Network', 'w3-total-cache' ) . '">' . \__( 'CDN', 'w3-total-cache' ) . '</acronym>'
-			)
+                       \sprintf(
+                               // translators: 1 HTML acronym for Content Delivery Network (CDN), 2: CDN name.
+                               \__(
+                                       'If you\'re an existing %2$s customer, enable %1$s and authorize. If you need help configuring your %1$s, we also offer Premium Services to assist you.',
+                                       'w3-total-cache'
+                               ),
+                               '<acronym title="' . \__( 'Content Delivery Network', 'w3-total-cache' ) . '">' . \__( 'CDN', 'w3-total-cache' ) . '</acronym>',
+                               esc_html( W3TC_CDN_NAME )
+                       )
 		);
 		?>
 	</p>

--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -141,7 +141,11 @@ class Generic_AdminActions_Default {
 				echo wp_json_encode( array( 'result' => 'success' ) );
 				exit();
 			} else {
-				echo wp_json_encode( array( 'result' => 'failed', 'message' => __( 'Failed to auto apply Total CDN configuration.', 'w3-total-cache' ) ) );
+                               echo wp_json_encode( array( 'result' => 'failed', 'message' => sprintf(
+                                       // translators: 1: CDN name.
+                                       __( 'Failed to auto apply %1$s configuration.', 'w3-total-cache' ),
+                                       W3TC_CDN_NAME
+                               ) ) );
 				exit();
 			}
 		} catch ( \Exception $ex ) {

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -1318,34 +1318,40 @@ class Generic_Plugin_Admin {
 			$logo_url = plugins_url( 'pub/img/' . W3TC_CDN_SLUG . '-logo-2.png', WP_PLUGIN_DIR . '/w3-total-cache/w3-total-cache.php' );
 
 			$html = sprintf(
-				'<div id="w3tc-tcdn-success" class="notice inline">
-					<div class="w3tc-success-inner">
-						<div class="w3tc-success-text">
-							<h2><img class="w3tc-success-logo" src="%1$s" alt="Total CDN Logo">%2$s 🎉</h2>
-							<p>%3$s</p>
-							<p>%4$s</p>
-							<p>%5$s<a href="admin.php?page=w3tc_cdn">%6$s</a>.</p>
-							<p>%7$s<a href="https://www.boldgrid.com/support/w3-total-cache/total-cdn-setup/">%8$s</a></p>
+                               '<div id="w3tc-tcdn-success" class="notice inline">
+                                        <div class="w3tc-success-inner">
+                                                <div class="w3tc-success-text">
+                                                        <h2><img class="w3tc-success-logo" src="%1$s" alt="' . esc_attr( W3TC_CDN_NAME ) . ' Logo">%2$s 🎉</h2>
+                                                        <p>%3$s</p>
+                                                        <p>%4$s</p>
+                                                        <p>%5$s<a href="admin.php?page=w3tc_cdn">%6$s</a>.</p>
+                                                        <p>%7$s<a href="https://www.boldgrid.com/support/w3-total-cache/total-cdn-setup/">%8$s</a></p>
 						</div>
 					</div>
 				 </div>',
 				esc_url( $logo_url ),
 				esc_html__( 'CONGRATULATIONS!', 'w3-total-cache' ),
-				esc_html__(
-					'Total CDN has been automatically configured, and there are no further steps needed at this time.',
-					'w3-total-cache'
-				),
-				esc_html__(
-					'Your images, CSS, and JavaScript files, are now being served from the Total CDN network. This means faster load times and improved performance for your website.',
-					'w3-total-cache'
-				),
+                               sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_html__( '%1$s has been automatically configured, and there are no further steps needed at this time.', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
+                               sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_html__( 'Your images, CSS, and JavaScript files, are now being served from the %1$s network. This means faster load times and improved performance for your website.', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               ),
 				esc_html__(
 					'If you would like to configure additional settings, please visit the ',
 					'w3-total-cache'
 				),
 				esc_html__( 'CDN settings page', 'w3-total-cache' ),
 				esc_html__( 'To learn more about how everything works, you can check out our support article here: ', 'w3-total-cache' ),
-				esc_html__( 'Getting Started With Total CDN', 'w3-total-cache' )
+                               sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_html__( 'Getting Started With %1$s', 'w3-total-cache' ),
+                                       esc_html( W3TC_CDN_NAME )
+                               )
 			);
 
 			echo wp_kses(

--- a/Licensing_Plugin_Admin.php
+++ b/Licensing_Plugin_Admin.php
@@ -410,16 +410,17 @@ class Licensing_Plugin_Admin {
 		switch ( true ) {
 			case $this->_status_is( $cdn_status, 'inactive.expired' ):
 				$cdn_message = wp_kses(
-					sprintf(
-						// Translators: 1 HTML input button to renew license.
-						__(
-							'Your Total CDN subscription has expired. %1$s to continue using Total CDN',
-							'w3-total-cache'
-						),
-						'<input type="button" class="button button-buy-tcdn" data-nonce="' .
-							wp_create_nonce( 'w3tc' ) . '" data-renew-key="' . esc_attr( $this->get_license_key() ) .
-							'" data-src="cdn_expired" value="' . __( 'Renew Now', 'w3-total-cache' ) . '" />'
-					),
+                                       sprintf(
+                                               // Translators: 1 HTML input button to renew license, 2: CDN name.
+                                               __(
+                                                       'Your %2$s subscription has expired. %1$s to continue using %2$s',
+                                                       'w3-total-cache'
+                                               ),
+                                               '<input type="button" class="button button-buy-tcdn" data-nonce="' .
+                                                       wp_create_nonce( 'w3tc' ) . '" data-renew-key="' . esc_attr( $this->get_license_key() ) .
+                                                        '" data-src="cdn_expired" value="' . __( 'Renew Now', 'w3-total-cache' ) . '" />',
+                                               esc_html( W3TC_CDN_NAME )
+                                        ),
 					array(
 						'input' => array(
 							'type'           => array(),

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -25,18 +25,20 @@ if (
 	<div id="w3tc-tcdn-ad-cdn">
 		<?php
 		echo wp_kses(
-			sprintf(
-				// translators: 1 opening HTML strong tag, 2 closing HTML strong tag,
-				// translators: 3 HTML input for Total CDN sign up, 4 HTML img tag for Total CDN logo.
-				__(
-					'%1$sLooking for a top rated CDN Provider? Try Total CDN.%2$s%3$s%4$s',
-					'w3-total-cache'
-				),
-				'<strong>',
-				'</strong>',
-				'<input type="button" class="button-primary btn button-buy-tcdn" data-renew-key="' . $this->_config->get_string( 'plugin.license_key' ) . '" data-src="general_page_cdn_subscribe" value="' . esc_attr__( 'Subscribe To Total CDN', 'w3-total-cache' ) . '">',
-				'<img class="w3tc-tcdn-icon" src="' . esc_url( plugins_url( '/pub/img/w3tc_w3tc-logo.png', W3TC_FILE ) ) . '" alt="Total CDN Icon">'
-			),
+                       sprintf(
+                               // translators: 1 opening HTML strong tag, 2 CDN name, 3 closing HTML strong tag,
+                               // translators: 4 HTML input for CDN sign up, 5 HTML img tag for CDN logo.
+                               __( '%1$sLooking for a top rated CDN Provider? Try %2$s.%3$s%4$s%5$s', 'w3-total-cache' ),
+                               '<strong>',
+                               esc_html( W3TC_CDN_NAME ),
+                               '</strong>',
+                               '<input type="button" class="button-primary btn button-buy-tcdn" data-renew-key="' . $this->_config->get_string( 'plugin.license_key' ) . '" data-src="general_page_cdn_subscribe" value="' . sprintf(
+                                       // translators: 1: CDN name.
+                                       esc_attr__( 'Subscribe To %1$s', 'w3-total-cache' ),
+                                       esc_attr( W3TC_CDN_NAME )
+                               ) . '">',
+                               '<img class="w3tc-tcdn-icon" src="' . esc_url( plugins_url( '/pub/img/w3tc_w3tc-logo.png', W3TC_FILE ) ) . '" alt="' . esc_attr( W3TC_CDN_NAME ) . ' Icon">'
+                       ),
 			array(
 				'strong' => array(),
 				'img'    => array(


### PR DESCRIPTION
## Summary
- replace hardcoded "Total CDN" mentions with `W3TC_CDN_NAME`
- add translator comments and escaping

## Testing
- `npm run js-lint` *(fails: prettier-eslint not found)*

------
https://chatgpt.com/codex/tasks/task_b_68596d2918b08328a2e2676eebf32fd0