### PR TITLE
Add CDN site health check

### DIFF
--- a/Cdn_SiteHealth.php
+++ b/Cdn_SiteHealth.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * File: Cdn_SiteHealth.php
+ *
+ * Adds a custom Site Health test for checking if the CDN is enabled.
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+/**
+ * Class Cdn_SiteHealth
+ */
+class Cdn_SiteHealth {
+		/**
+		 * Register hooks.
+		 *
+		 * @return void
+		 */
+	public function run() {
+		if ( is_admin() ) {
+			add_filter( 'site_status_tests', array( $this, 'add_tests' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		}
+	}
+
+		/**
+		 * Enqueue assets on the Site Health screen so the purchase button works.
+		 *
+		 * @param string $hook The current admin page hook.
+		 *
+		 * @return void
+		 */
+	public function enqueue_scripts( $hook ) {
+		if ( 'site-health.php' !== $hook ) {
+			return;
+		}
+
+		// Styles and scripts are registered in Generic_Plugin_Admin.
+		wp_enqueue_style( 'w3tc-lightbox' );
+		wp_enqueue_script( 'w3tc-lightbox' );
+
+		// Provide nonce to JS just like on plugin screens.
+		if ( ! wp_script_is( 'w3tc-lightbox', 'data' ) ) {
+			wp_localize_script( 'w3tc-lightbox', 'w3tc_nonce', array( wp_create_nonce( 'w3tc' ) ) );
+		}
+	}
+
+		/**
+		 * Register the CDN status test.
+		 *
+		 * @param array $tests Existing Site Health tests.
+		 *
+		 * @return array
+		 */
+	public function add_tests( $tests ) {
+		$tests['direct']['w3tc_cdn'] = array(
+			'label' => __( 'W3 Total Cache CDN', 'w3-total-cache' ),
+			'test'  => array( $this, 'test_cdn_enabled' ),
+		);
+		return $tests;
+	}
+
+		/**
+		 * Perform the CDN enabled test.
+		 *
+		 * @return array Test result.
+		 */
+	public function test_cdn_enabled() {
+		$config  = Dispatcher::config();
+		$enabled = $config->get_boolean( 'cdn.enabled' );
+
+		$result = array(
+			'label'       => '',
+			'status'      => '',
+			'badge'       => array(
+				'label' => __( 'Performance', 'w3-total-cache' ),
+				'color' => 'blue',
+			),
+			'description' => '',
+			'actions'     => '',
+			'test'        => 'w3tc_cdn',
+		);
+
+		if ( $enabled ) {
+			$result['status'] = 'good';
+			$result['label']  = __( 'CDN is enabled', 'w3-total-cache' );
+		} else {
+			$result['status']  = 'recommended';
+			$result['label']   = __( 'CDN is not enabled', 'w3-total-cache' );
+			$result['actions'] = $this->get_actions( $config );
+		}
+
+		return $result;
+	}
+
+		/**
+		 * Generates the action markup when CDN is disabled.
+		 *
+		 * @param Config $config Plugin configuration.
+		 *
+		 * @return string HTML actions.
+		 */
+	private function get_actions( $config ) {
+		$api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
+
+		if ( ! empty( $api_key ) ) {
+			$url = wp_nonce_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' ), 'w3tc' );
+			return '<p><a href="' . esc_url( $url ) . '" class="button button-primary">' . esc_html__( 'Enable', 'w3-total-cache' ) . '</a></p>';
+		}
+
+		$license_key = $config->get_string( 'plugin.license_key' );
+		$button      = '<input type="button" class="button-primary btn button-buy-tcdn"';
+		$button     .= ' data-renew-key="' . esc_attr( $license_key ) . '"';
+		$button     .= ' data-src="site_health"';
+		$button     .= ' value="' . esc_attr__( 'Purchase TotalCDN', 'w3-total-cache' ) . '" />';
+
+		return '<p>' . $button . '</p>';
+	}
+}

--- a/Root_Loader.php
+++ b/Root_Loader.php
@@ -113,6 +113,7 @@ class Root_Loader {
 			$plugins[] = new UsageStatistics_Plugin_Admin();
 			$plugins[] = new SetupGuide_Plugin_Admin();
 			$plugins[] = new FeatureShowcase_Plugin_Admin();
+			$plugins[] = new Cdn_SiteHealth();
 		} elseif ( $c->get_boolean( 'jquerymigrate.disabled' ) ) {
 			$plugins[] = new UserExperience_Plugin_Jquery();
 		}


### PR DESCRIPTION
## Summary
- add CDN_SiteHealth class for a Site Health test
- load CDN_SiteHealth in Root_Loader

## Testing
- `composer install`
- `vendor/bin/phpcs Cdn_SiteHealth.php`
- `vendor/bin/phpcs Root_Loader.php`
- `vendor/bin/phpunit` *(fails: WordPress test library missing)*

------
https://chatgpt.com/codex/tasks/task_b_68793079b46c83288f5f4aa7d30245dc