### PR TITLE
Fix repeated cache misses for nonexistent options

### DIFF
--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -105,7 +105,14 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 
                        if ( 'options' === $group && 'notoptions' !== $id ) {
                                $notoptions = $wp_object_cache->get( 'notoptions', 'options', $force, $n_found );
-                               if ( is_array( $notoptions ) && isset( $notoptions[ $id ] ) ) {
+
+                               // Mirror WP 6.8's early notoptions lookup to avoid repeated external cache checks.
+                               if ( ! is_array( $notoptions ) ) {
+                                       $notoptions = array();
+                                       $wp_object_cache->set( 'notoptions', $notoptions, 'options' );
+                               }
+
+                               if ( isset( $notoptions[ $id ] ) ) {
                                        $found = false;
                                        return false;
                                }

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -100,11 +100,19 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		 *
 		 * @return mixed
 		 */
-		function wp_cache_get( $id, $group = 'default', $force = false, &$found = null ) {
-			global $wp_object_cache;
+               function wp_cache_get( $id, $group = 'default', $force = false, &$found = null ) {
+                       global $wp_object_cache;
 
-			return $wp_object_cache->get( $id, $group, $force, $found );
-		}
+                       if ( 'options' === $group && 'notoptions' !== $id ) {
+                               $notoptions = $wp_object_cache->get( 'notoptions', 'options', $force, $n_found );
+                               if ( is_array( $notoptions ) && isset( $notoptions[ $id ] ) ) {
+                                       $found = false;
+                                       return false;
+                               }
+                       }
+
+                       return $wp_object_cache->get( $id, $group, $force, $found );
+               }
 
 		/**
 		 * Retrieves multiple values from the cache in one call.


### PR DESCRIPTION
## Summary
- prevent redundant remote lookups when `get_option()` queries missing options by checking `notoptions` first

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_687fd6a72e188328986f67952dce65fe