### PR TITLE
Avoid Redudant Cache Misses WP 6.4 - 6.7

### DIFF
--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -100,26 +100,25 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		 *
 		 * @return mixed
 		 */
-               function wp_cache_get( $id, $group = 'default', $force = false, &$found = null ) {
-                       global $wp_object_cache;
+		function wp_cache_get( $id, $group = 'default', $force = false, &$found = null ) {
+			global $wp_object_cache;
 
-                       if ( 'options' === $group && 'notoptions' !== $id ) {
-                               $notoptions = $wp_object_cache->get( 'notoptions', 'options', $force, $n_found );
+			if ( 'options' === $group && 'notoptions' !== $id ) {
+				// Mirror WP 6.8's early notoptions lookup to avoid repeated external cache checks.
+				$notoptions = $wp_object_cache->get( 'notoptions', 'options', $force, $found );
 
-                               // Mirror WP 6.8's early notoptions lookup to avoid repeated external cache checks.
-                               if ( ! is_array( $notoptions ) ) {
-                                       $notoptions = array();
-                                       $wp_object_cache->set( 'notoptions', $notoptions, 'options' );
-                               }
+				if ( ! is_array( $notoptions ) ) {
+					$notoptions = array();
+					$wp_object_cache->set( 'notoptions', $notoptions, 'options' );
+				}
 
-                               if ( isset( $notoptions[ $id ] ) ) {
-                                       $found = false;
-                                       return false;
-                               }
-                       }
+				if ( isset( $notoptions[ $id ] ) ) {
+					return false;
+				}
+			}
 
-                       return $wp_object_cache->get( $id, $group, $force, $found );
-               }
+			return $wp_object_cache->get( $id, $group, $force, $found );
+		}
 
 		/**
 		 * Retrieves multiple values from the cache in one call.

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -126,6 +126,7 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 				}
 
 				if ( isset( $notoptions[ $id ] ) ) {
+					$found = false;
 					return false;
 				}
 			}

--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -103,7 +103,20 @@ if ( ! @is_dir( W3TC_DIR ) || ! file_exists( W3TC_DIR . '/w3-total-cache-api.php
 		function wp_cache_get( $id, $group = 'default', $force = false, &$found = null ) {
 			global $wp_object_cache;
 
-			if ( 'options' === $group && 'notoptions' !== $id ) {
+			static $wp_version;
+
+			// Detect and cache WP version for conditional logic.
+			if ( null === $wp_version ) {
+				include ABSPATH . WPINC . '/version.php';
+			}
+
+			// Apply notoptions short-circuit for affected WP versions (6.4.0–6.7.x).
+			if (
+				version_compare( $wp_version, '6.4', '>=' ) &&
+				version_compare( $wp_version, '6.8', '<' ) &&
+				'options' === $group &&
+				'notoptions' !== $id
+			) {
 				// Mirror WP 6.8's early notoptions lookup to avoid repeated external cache checks.
 				$notoptions = $wp_object_cache->get( 'notoptions', 'options', $force, $found );
 


### PR DESCRIPTION
This PR addresses a bug that was introduced in WP 6.4-6.7 where non-existent options would result in repeated cache misses if called in a loop