### PR TITLE
Adjust Total CDN setup flow

### DIFF
--- a/Cdn_TotalCdn_Page.php
+++ b/Cdn_TotalCdn_Page.php
@@ -104,11 +104,11 @@ class Cdn_TotalCdn_Page {
 	 * @return void
 	 */
 	public static function admin_print_scripts_w3tc_cdn() {
-        $config        = Dispatcher::config();
-        $is_authorized = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) &&
-                        ( $config->get_string( 'cdn.totalcdn.pull_zone_id' ) || $config->get_string( 'cdnfsd.totalcdn.pull_zone_id' ) );
-        $has_api_key   = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) );
-        $license_key   = $config->get_string( 'plugin.license_key' );
+		$config        = Dispatcher::config();
+		$is_authorized = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) &&
+			( $config->get_string( 'cdn.totalcdn.pull_zone_id' ) || $config->get_string( 'cdnfsd.totalcdn.pull_zone_id' ) );
+		$has_api_key   = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) );
+		$license_key   = $config->get_string( 'plugin.license_key' );
 
 		\wp_register_script(
 			'w3tc_cdn_totalcdn',
@@ -118,21 +118,21 @@ class Cdn_TotalCdn_Page {
 			false
 		);
 
-                \wp_localize_script(
-                        'w3tc_cdn_totalcdn',
-                        'W3TC_TotalCdn',
-                        array(
-                                'is_authorized' => $is_authorized,
-                                'has_api_key'   => $has_api_key,
-                                'license_key'   => $license_key,
-                                'lang'          => array(
-                                        'empty_url'       => \esc_html__( 'No URL specified', 'w3-total-cache' ),
-                                        'success_purging' => \esc_html__( 'Successfully purged URL', 'w3-total-cache' ),
-                                        'error_purging'   => \esc_html__( 'Error purging URL', 'w3-total-cache' ),
-                                        'error_ajax'      => \esc_html__( 'Error with AJAX', 'w3-total-cache' ),
-                                ),
-                        )
-                );
+		\wp_localize_script(
+			'w3tc_cdn_totalcdn',
+			'W3TC_TotalCdn',
+			array(
+				'is_authorized' => $is_authorized,
+				'has_api_key'   => $has_api_key,
+				'license_key'   => $license_key,
+				'lang'          => array(
+					'empty_url'       => \esc_html__( 'No URL specified', 'w3-total-cache' ),
+					'success_purging' => \esc_html__( 'Successfully purged URL', 'w3-total-cache' ),
+					'error_purging'   => \esc_html__( 'Error purging URL', 'w3-total-cache' ),
+					'error_ajax'      => \esc_html__( 'Error with AJAX', 'w3-total-cache' ),
+				),
+			)
+		);
 
 		\wp_enqueue_script( 'w3tc_cdn_totalcdn' );
 	}

--- a/Cdn_TotalCdn_Page.php
+++ b/Cdn_TotalCdn_Page.php
@@ -104,9 +104,11 @@ class Cdn_TotalCdn_Page {
 	 * @return void
 	 */
 	public static function admin_print_scripts_w3tc_cdn() {
-		$config        = Dispatcher::config();
-		$is_authorized = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) &&
-			( $config->get_string( 'cdn.totalcdn.pull_zone_id' ) || $config->get_string( 'cdnfsd.totalcdn.pull_zone_id' ) );
+        $config        = Dispatcher::config();
+        $is_authorized = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) &&
+                        ( $config->get_string( 'cdn.totalcdn.pull_zone_id' ) || $config->get_string( 'cdnfsd.totalcdn.pull_zone_id' ) );
+        $has_api_key   = ! empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) );
+        $license_key   = $config->get_string( 'plugin.license_key' );
 
 		\wp_register_script(
 			'w3tc_cdn_totalcdn',
@@ -116,19 +118,21 @@ class Cdn_TotalCdn_Page {
 			false
 		);
 
-		\wp_localize_script(
-			'w3tc_cdn_totalcdn',
-			'W3TC_TotalCdn',
-			array(
-				'is_authorized' => $is_authorized,
-				'lang'          => array(
-					'empty_url'       => \esc_html__( 'No URL specified', 'w3-total-cache' ),
-					'success_purging' => \esc_html__( 'Successfully purged URL', 'w3-total-cache' ),
-					'error_purging'   => \esc_html__( 'Error purging URL', 'w3-total-cache' ),
-					'error_ajax'      => \esc_html__( 'Error with AJAX', 'w3-total-cache' ),
-				),
-			)
-		);
+                \wp_localize_script(
+                        'w3tc_cdn_totalcdn',
+                        'W3TC_TotalCdn',
+                        array(
+                                'is_authorized' => $is_authorized,
+                                'has_api_key'   => $has_api_key,
+                                'license_key'   => $license_key,
+                                'lang'          => array(
+                                        'empty_url'       => \esc_html__( 'No URL specified', 'w3-total-cache' ),
+                                        'success_purging' => \esc_html__( 'Successfully purged URL', 'w3-total-cache' ),
+                                        'error_purging'   => \esc_html__( 'Error purging URL', 'w3-total-cache' ),
+                                        'error_ajax'      => \esc_html__( 'Error with AJAX', 'w3-total-cache' ),
+                                ),
+                        )
+                );
 
 		\wp_enqueue_script( 'w3tc_cdn_totalcdn' );
 	}

--- a/Cdn_TotalCdn_Page_View.js
+++ b/Cdn_TotalCdn_Page_View.js
@@ -22,7 +22,6 @@ jQuery(function($) {
 		// Load the authorization or subscription form.
 		.on('click', '.w3tc_cdn_totalcdn_authorize', function() {
 			if ( W3TC_TotalCdn.has_api_key ) {
-				console.log('Loading pull zone selection form...');
 				W3tc_Lightbox.open({
 					id:'w3tc-overlay',
 					close: '',
@@ -35,7 +34,6 @@ jQuery(function($) {
 					callback: w3tc_totalcdn_resize
 				});
 			} else {
-				console.log('Loading subscription form...');
 				w3tc_lightbox_buy_tcdn( w3tc_nonce, 'cdn_authorize', W3TC_TotalCdn.license_key );
 			}
 		})

--- a/Cdn_TotalCdn_Page_View.js
+++ b/Cdn_TotalCdn_Page_View.js
@@ -19,26 +19,26 @@ jQuery(function($) {
 
 	// Add event handlers.
 	$('body')
-                // Load the authorization or subscription form.
-                .on('click', '.w3tc_cdn_totalcdn_authorize', function() {
-                        if ( W3TC_TotalCdn.has_api_key ) {
-                                console.log('Loading pull zone selection form...');
-                                W3tc_Lightbox.open({
-                                        id:'w3tc-overlay',
-                                        close: '',
-                                        width: 800,
-                                        height: 300,
-                                        url: ajaxurl +
-                                                '?action=w3tc_ajax&_wpnonce=' +
-                                                w3tc_nonce +
-                                                '&w3tc_action=cdn_totalcdn_list_pull_zones',
-                                        callback: w3tc_totalcdn_resize
-                                });
-                        } else {
-                                console.log('Loading subscription form...');
-                                w3tc_lightbox_buy_tcdn( w3tc_nonce, 'cdn_authorize', W3TC_TotalCdn.license_key );
-                        }
-                })
+		// Load the authorization or subscription form.
+		.on('click', '.w3tc_cdn_totalcdn_authorize', function() {
+			if ( W3TC_TotalCdn.has_api_key ) {
+				console.log('Loading pull zone selection form...');
+				W3tc_Lightbox.open({
+					id:'w3tc-overlay',
+					close: '',
+					width: 800,
+					height: 300,
+					url: ajaxurl +
+							'?action=w3tc_ajax&_wpnonce=' +
+							w3tc_nonce +
+							'&w3tc_action=cdn_totalcdn_list_pull_zones',
+					callback: w3tc_totalcdn_resize
+				});
+			} else {
+				console.log('Loading subscription form...');
+				w3tc_lightbox_buy_tcdn( w3tc_nonce, 'cdn_authorize', W3TC_TotalCdn.license_key );
+			}
+		})
 
 		// Sanitize the account API key input value.
 		.on('change', '#w3tc-account-api-key', function() {

--- a/Cdn_TotalCdn_Page_View.js
+++ b/Cdn_TotalCdn_Page_View.js
@@ -19,21 +19,26 @@ jQuery(function($) {
 
 	// Add event handlers.
 	$('body')
-		// Load the authorization form.
-		.on('click', '.w3tc_cdn_totalcdn_authorize', function() {
-			console.log('Loading authorization form...');
-			W3tc_Lightbox.open({
-				id:'w3tc-overlay',
-				close: '',
-				width: 800,
-				height: 300,
-				url: ajaxurl +
-					'?action=w3tc_ajax&_wpnonce=' +
-					w3tc_nonce +
-					'&w3tc_action=cdn_totalcdn_intro',
-				callback: w3tc_totalcdn_resize
-			});
-		})
+                // Load the authorization or subscription form.
+                .on('click', '.w3tc_cdn_totalcdn_authorize', function() {
+                        if ( W3TC_TotalCdn.has_api_key ) {
+                                console.log('Loading pull zone selection form...');
+                                W3tc_Lightbox.open({
+                                        id:'w3tc-overlay',
+                                        close: '',
+                                        width: 800,
+                                        height: 300,
+                                        url: ajaxurl +
+                                                '?action=w3tc_ajax&_wpnonce=' +
+                                                w3tc_nonce +
+                                                '&w3tc_action=cdn_totalcdn_list_pull_zones',
+                                        callback: w3tc_totalcdn_resize
+                                });
+                        } else {
+                                console.log('Loading subscription form...');
+                                w3tc_lightbox_buy_tcdn( w3tc_nonce, 'cdn_authorize', W3TC_TotalCdn.license_key );
+                        }
+                })
 
 		// Sanitize the account API key input value.
 		.on('change', '#w3tc-account-api-key', function() {

--- a/Cdn_TotalCdn_Page_View.php
+++ b/Cdn_TotalCdn_Page_View.php
@@ -26,15 +26,22 @@ $ssl_cert_loaded = $config->get_string( 'cdn.totalcdn.custom_hostname_ssl_loaded
 	<tr>
 		<th style="width: 300px;">
 			<label>
-				<?php esc_html_e( 'Account API key authorization', 'w3-total-cache' ); ?>:
+				<?php esc_html_e( 'Initial Configuration', 'w3-total-cache' ); ?>:
 			</label>
 		</th>
 		<td>
 			<?php if ( $is_authorized ) : ?>
 				<input class="w3tc_cdn_totalcdn_deauthorization button-primary" type="button" value="<?php esc_attr_e( 'Deauthorize', 'w3-total-cache' ); ?>" />
 			<?php else : ?>
-				<input class="w3tc_cdn_totalcdn_authorize button-primary" type="button" value="<?php esc_attr_e( 'Authorize', 'w3-total-cache' ); ?>"
-				<?php echo ( $is_unavailable ? 'disabled' : '' ); ?> />
+				<input class="w3tc_cdn_totalcdn_authorize button-primary" type="button"
+					value="
+					<?php
+						$account_api_key ? esc_attr_e( 'Authorize', 'w3-total-cache' ) :
+						// translators: %s: CDN name.
+						printf( esc_attr__( 'Subscribe to %s', 'w3-total-cache' ), esc_html( W3TC_CDN_NAME ) );
+					?>
+					"
+					<?php echo ( $is_unavailable ? 'disabled' : '' ); ?> />
 				<?php if ( $is_unavailable ) : ?>
 					<div class="notice notice-info">
 						<p>

--- a/Cdn_TotalCdn_Popup.php
+++ b/Cdn_TotalCdn_Popup.php
@@ -260,7 +260,8 @@ class Cdn_TotalCdn_Popup {
 	 * @return void
 	 */
 	public function w3tc_ajax_cdn_totalcdn_list_pull_zones() {
-		$account_api_key = Util_Request::get_string( 'account_api_key' );
+		$config          = Dispatcher::config();
+		$account_api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
 		$api             = new Cdn_TotalCdn_Api( array( 'account_api_key' => $account_api_key ) );
 
 		// Try to retrieve pull zones.

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -18,8 +18,8 @@ $can_purge = Cdn_Util::can_purge( $cdn_engine );
 require W3TC_INC_DIR . '/options/common/header.php';
 
 if (
-        ( empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) ) ||
-        in_array( $state->get_string( 'cdn.totalcdn.status' ), array( 'canceled', 'inactive.expired' ), true )
+	( ! $cdn_enabled && empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) ) ||
+	in_array( $state->get_string( 'cdn.totalcdn.status' ), array( 'canceled', 'inactive.expired' ), true )
 ) {
 	?>
 	<div id="w3tc-tcdn-ad-cdn">

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -18,8 +18,8 @@ $can_purge = Cdn_Util::can_purge( $cdn_engine );
 require W3TC_INC_DIR . '/options/common/header.php';
 
 if (
-	( ! $cdn_enabled && empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) ) ||
-	in_array( $state->get_string( 'cdn.totalcdn.status' ), array( 'canceled', 'inactive.expired' ), true )
+        ( empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) ) ||
+        in_array( $state->get_string( 'cdn.totalcdn.status' ), array( 'canceled', 'inactive.expired' ), true )
 ) {
 	?>
 	<div id="w3tc-tcdn-ad-cdn">


### PR DESCRIPTION
## Summary
- show Total CDN subscribe banner whenever no API key is configured
- pass account subscription status to the Total CDN script
- skip API key step when a subscription exists and load pull zones directly
- open subscription overlay when no API key is found

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm run js-lint` *(fails: prettier-eslint not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a46850e9c8328b4be6173ef087812