### PR TITLE
Add AI Crawler information report metabox

### DIFF
--- a/Extension_AiCrawler_Page_View.css
+++ b/Extension_AiCrawler_Page_View.css
@@ -10,10 +10,16 @@
 .w3tc-aicrawler-report {
         display: flex;
         gap: 20px;
+        justify-content: center;
 }
 
 .w3tc-aicrawler-report-item {
         text-align: center;
+}
+
+.w3tc-aicrawler-report-heading {
+        text-align: center;
+        margin: 0 0 12px;
 }
 
 .w3tc-aicrawler-report-label {
@@ -27,6 +33,12 @@
         border-radius: 50%;
         margin: 0 auto;
         background-color: #ccc;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 48px;
+        font-weight: 700;
 }
 
 .w3tc-aicrawler-report-circle-green {

--- a/Extension_AiCrawler_Page_View.css
+++ b/Extension_AiCrawler_Page_View.css
@@ -1,0 +1,46 @@
+/**
+ * File: Extension_AiCrawler_Page_View.css
+ *
+ * Styles for the AI Crawler settings page.
+ *
+ * @package W3TC
+ * @since X.X.X
+ */
+
+.w3tc-aicrawler-report {
+        display: flex;
+        gap: 20px;
+}
+
+.w3tc-aicrawler-report-item {
+        text-align: center;
+}
+
+.w3tc-aicrawler-report-label {
+        margin-bottom: 8px;
+        font-weight: 600;
+}
+
+.w3tc-aicrawler-report-circle {
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+        margin: 0 auto;
+        background-color: #ccc;
+}
+
+.w3tc-aicrawler-report-circle-green {
+        background-color: #46b450;
+}
+
+.w3tc-aicrawler-report-circle-yellow {
+        background-color: #ffb900;
+}
+
+.w3tc-aicrawler-report-circle-red {
+        background-color: #dc3232;
+}
+
+.w3tc-aicrawler-report-eval {
+        margin-top: 8px;
+}

--- a/Extension_AiCrawler_Page_View.css
+++ b/Extension_AiCrawler_Page_View.css
@@ -56,3 +56,8 @@
 .w3tc-aicrawler-report-eval {
         margin-top: 8px;
 }
+
+.w3tc-aicrawler-report-error {
+        text-align: center;
+        margin-bottom: 12px;
+}

--- a/Extension_AiCrawler_Page_View.php
+++ b/Extension_AiCrawler_Page_View.php
@@ -41,8 +41,9 @@ $config = Dispatcher::config();
 		)
 	);
 
-	require __DIR__ . '/Extension_AiCrawler_Page_View_Settings.php';
-	require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
-	?>
+        require __DIR__ . '/Extension_AiCrawler_Page_View_Settings.php';
+        require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
+        require __DIR__ . '/Extension_AiCrawler_Page_View_Information.php';
+        ?>
 </form>
 <?php require W3TC_INC_DIR . '/options/common/footer.php'; ?>

--- a/Extension_AiCrawler_Page_View_Information.php
+++ b/Extension_AiCrawler_Page_View_Information.php
@@ -83,24 +83,54 @@ $report = array();
 if ( $response['success'] && isset( $response['data']['report'] ) ) {
         $report = $response['data']['report'];
 }
-?>
-<div class="metabox-holder">
-        <?php Util_Ui::postbox_header( esc_html__( 'Information', 'w3-total-cache' ), '', 'information' ); ?>
+
+/**
+ * Render a report block.
+ *
+ * @param string $title  Report heading.
+ * @param array  $report Report data keyed by URL.
+ *
+ * @return void
+ */
+function w3tc_aicrawler_render_report( $title, $report ) {
+        if ( empty( $report ) ) {
+                return;
+        }
+        ?>
+        <h4 class="w3tc-aicrawler-report-heading"><?php echo esc_html( $title ); ?></h4>
         <div class="w3tc-aicrawler-report">
                 <?php foreach ( $report as $url => $data ) :
                         $file       = basename( parse_url( $url, PHP_URL_PATH ) );
                         $present    = ! empty( $data['present'] );
                         $sufficient = ! empty( $data['sufficient'] );
                         $color      = $present && $sufficient ? 'green' : ( $present ? 'yellow' : 'red' );
+                        $icon       = $present && $sufficient ? '&#10003;' : ( $present ? '!' : '&#10005;' );
                         ?>
                         <div class="w3tc-aicrawler-report-item">
                                 <div class="w3tc-aicrawler-report-label"><?php echo esc_html( $file ); ?></div>
-                                <div class="w3tc-aicrawler-report-circle w3tc-aicrawler-report-circle-<?php echo esc_attr( $color ); ?>"></div>
+                                <div class="w3tc-aicrawler-report-circle w3tc-aicrawler-report-circle-<?php echo esc_attr( $color ); ?>"><?php echo $icon; ?></div>
                                 <?php if ( 'green' !== $color && ! empty( $data['evaluation'] ) ) : ?>
                                         <div class="w3tc-aicrawler-report-eval"><?php echo esc_html( $data['evaluation'] ); ?></div>
                                 <?php endif; ?>
                         </div>
                 <?php endforeach; ?>
         </div>
+        <?php
+}
+?>
+<div class="metabox-holder">
+        <?php Util_Ui::postbox_header( esc_html__( 'Information', 'w3-total-cache' ), '', 'information' ); ?>
+        <?php
+        $reports = array(
+                array(
+                        'title' => __( 'AI Crawlability Summary', 'w3-total-cache' ),
+                        'data'  => $report,
+                ),
+        );
+
+        foreach ( $reports as $r ) {
+                w3tc_aicrawler_render_report( $r['title'], $r['data'] );
+        }
+        ?>
         <?php Util_Ui::postbox_footer(); ?>
 </div>

--- a/Extension_AiCrawler_Page_View_Information.php
+++ b/Extension_AiCrawler_Page_View_Information.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * File: Extension_AiCrawler_Page_View_Information.php
+ *
+ * Render the AI Crawler settings page - Information box.
+ *
+ * @package W3TC
+ * @since X.X.X
+ */
+
+namespace W3TC;
+
+if ( ! defined( 'W3TC' ) ) {
+        die();
+}
+
+// Dummy responses for testing the UI when the API is unavailable.
+// To use a dummy response, append "&aicrawler_dummy=mixed" or
+// "&aicrawler_dummy=all_good" to the settings page URL.
+$dummy_reports = array(
+        'all_good' => array(
+                'success' => true,
+                'url'     => home_url(),
+                'report'  => array(
+                        home_url( '/robots.txt' )  => array(
+                                'present'    => true,
+                                'sufficient' => true,
+                                'evaluation' => __( 'The robots.txt file is present and well-formed.', 'w3-total-cache' ),
+                        ),
+                        home_url( '/llms.txt' )    => array(
+                                'present'    => true,
+                                'sufficient' => true,
+                                'evaluation' => __( 'The llms.txt file is present and well-formed.', 'w3-total-cache' ),
+                        ),
+                        home_url( '/sitemap.xml' ) => array(
+                                'present'    => true,
+                                'sufficient' => true,
+                                'evaluation' => __( 'The sitemap.xml file is present and well-formed.', 'w3-total-cache' ),
+                        ),
+                ),
+                'metadata' => array(),
+        ),
+        'mixed'    => array(
+                'success' => true,
+                'url'     => home_url(),
+                'report'  => array(
+                        home_url( '/robots.txt' )  => array(
+                                'present'    => true,
+                                'sufficient' => true,
+                                'evaluation' => __( 'The robots.txt file is present and well-formed.', 'w3-total-cache' ),
+                        ),
+                        home_url( '/llms.txt' )    => array(
+                                'present'    => false,
+                                'sufficient' => false,
+                                'evaluation' => __( 'The file was not found', 'w3-total-cache' ),
+                        ),
+                        home_url( '/sitemap.xml' ) => array(
+                                'present'    => false,
+                                'sufficient' => false,
+                                'evaluation' => __( 'The file was not found', 'w3-total-cache' ),
+                        ),
+                ),
+                'metadata' => array(),
+        ),
+);
+
+if ( isset( $_GET['aicrawler_dummy'] ) && isset( $dummy_reports[ $_GET['aicrawler_dummy'] ] ) ) {
+        $response = array(
+                'success' => true,
+                'data'    => $dummy_reports[ $_GET['aicrawler_dummy'] ],
+        );
+} else {
+        $response = Extension_AiCrawler_Central_Api::call(
+                'report',
+                'POST',
+                array(
+                        'url' => home_url(),
+                )
+        );
+}
+
+$report = array();
+if ( $response['success'] && isset( $response['data']['report'] ) ) {
+        $report = $response['data']['report'];
+}
+?>
+<div class="metabox-holder">
+        <?php Util_Ui::postbox_header( esc_html__( 'Information', 'w3-total-cache' ), '', 'information' ); ?>
+        <div class="w3tc-aicrawler-report">
+                <?php foreach ( $report as $url => $data ) :
+                        $file       = basename( parse_url( $url, PHP_URL_PATH ) );
+                        $present    = ! empty( $data['present'] );
+                        $sufficient = ! empty( $data['sufficient'] );
+                        $color      = $present && $sufficient ? 'green' : ( $present ? 'yellow' : 'red' );
+                        ?>
+                        <div class="w3tc-aicrawler-report-item">
+                                <div class="w3tc-aicrawler-report-label"><?php echo esc_html( $file ); ?></div>
+                                <div class="w3tc-aicrawler-report-circle w3tc-aicrawler-report-circle-<?php echo esc_attr( $color ); ?>"></div>
+                                <?php if ( 'green' !== $color && ! empty( $data['evaluation'] ) ) : ?>
+                                        <div class="w3tc-aicrawler-report-eval"><?php echo esc_html( $data['evaluation'] ); ?></div>
+                                <?php endif; ?>
+                        </div>
+                <?php endforeach; ?>
+        </div>
+        <?php Util_Ui::postbox_footer(); ?>
+</div>

--- a/Extension_AiCrawler_Plugin_Admin.php
+++ b/Extension_AiCrawler_Plugin_Admin.php
@@ -35,14 +35,21 @@ class Extension_AiCrawler_Plugin_Admin {
 		$current_screen = get_current_screen();
 
 		// Enqueue scripts only if the current page is the settings page (wp-admin/admin.php?page=w3tc_aicrawler).
-		if ( isset( $current_screen->id ) && 'performance_page_w3tc_aicrawler' === $current_screen->id ) {
-			wp_register_script(
-				'w3tc-aicrawler-page',
-				esc_url( plugin_dir_url( __FILE__ ) . 'Extension_AiCrawler_Page.js' ),
-				array( 'jquery' ),
-				W3TC_VERSION,
-				true
-			);
+                if ( isset( $current_screen->id ) && 'performance_page_w3tc_aicrawler' === $current_screen->id ) {
+                        wp_register_script(
+                                'w3tc-aicrawler-page',
+                                esc_url( plugin_dir_url( __FILE__ ) . 'Extension_AiCrawler_Page.js' ),
+                                array( 'jquery' ),
+                                W3TC_VERSION,
+                                true
+                        );
+
+                        wp_register_style(
+                                'w3tc-aicrawler-page',
+                                esc_url( plugin_dir_url( __FILE__ ) . 'Extension_AiCrawler_Page_View.css' ),
+                                array(),
+                                W3TC_VERSION
+                        );
 
 			wp_localize_script(
 				'w3tc-aicrawler-page',
@@ -73,9 +80,10 @@ class Extension_AiCrawler_Plugin_Admin {
 				)
 			);
 
-			wp_enqueue_script( 'w3tc-aicrawler-page' );
-		}
-	}
+                        wp_enqueue_script( 'w3tc-aicrawler-page' );
+                        wp_enqueue_style( 'w3tc-aicrawler-page' );
+                }
+        }
 
 	/**
 	 * Adds AI Crawler to the extension list.


### PR DESCRIPTION
## Summary
- Add Information metabox to AI Crawler settings page displaying report for robots.txt, llms.txt, and sitemap.xml with color-coded status circles
- Support dummy API responses via `aicrawler_dummy` query arg for easy testing
- Enqueue new stylesheet for AI Crawler admin page

## Testing
- `npm test` (fails: Missing script)
- `composer test` (fails: Command "test" is not defined)
- `composer install`
- `vendor/bin/phpunit` (fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')

------
https://chatgpt.com/codex/tasks/task_b_689637eff3648328ae9a88aaa76fbac6