### PR TITLE
Add markdown generation queue for AI Crawler extension

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * File: Extension_AiCrawler_Markdown.php
+ *
+ * Handles generation of markdown content for posts and pages using the
+ * AI Crawler API.
+ *
+ * @package W3TC
+ * @since   X.X.X
+ */
+
+namespace W3TC;
+
+/**
+ * Class Extension_AiCrawler_Markdown
+ *
+ * Queues URLs for markdown generation and processes the queue in the
+ * background using a cron event.
+ *
+ * @since X.X.X
+ */
+class Extension_AiCrawler_Markdown {
+		/**
+		 * Cron hook name.
+		 *
+		 * @since X.X.X
+		 * @var string
+		 */
+		const CRON_HOOK = 'w3tc_aicrawler_markdown_cron';
+
+		/**
+		 * Post meta key for original URL.
+		 *
+		 * @since X.X.X
+		 * @var string
+		 */
+		const META_SOURCE_URL = 'w3tc_aicrawler_source_url';
+
+		/**
+		 * Post meta key for processing status.
+		 *
+		 * @since X.X.X
+		 * @var string
+		 */
+		const META_STATUS = 'w3tc_aicrawler_status';
+
+		/**
+		 * Post meta key where generated markdown is stored.
+		 *
+		 * @since X.X.X
+		 * @var string
+		 */
+		const META_MARKDOWN = 'w3tc_aicrawler_markdown';
+
+		/**
+		 * Post meta key for the public markdown URL.
+		 *
+		 * @since X.X.X
+		 * @var string
+		 */
+		const META_MARKDOWN_URL = 'w3tc_aicrawler_markdown_url';
+
+		/**
+		 * Initialize hooks for cron processing.
+		 *
+		 * @since X.X.X
+		 *
+		 * @return void
+		 */
+	public static function init() {
+			add_action( self::CRON_HOOK, array( __CLASS__, 'process_queue' ) );
+			add_filter( 'cron_schedules', array( __CLASS__, 'add_schedule' ) );
+			self::schedule_cron();
+	}
+
+		/**
+		 * Schedule the cron event if it is not already scheduled.
+		 *
+		 * @since X.X.X
+		 *
+		 * @return void
+		 */
+	private static function schedule_cron() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+				wp_schedule_event( time(), 'ten_seconds', self::CRON_HOOK );
+		}
+	}
+
+		/**
+		 * Adds a ten second cron schedule used by the queue worker.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param array $schedules Existing schedules.
+		 *
+		 * @return array
+		 */
+	public static function add_schedule( array $schedules = array() ) {
+		if ( ! isset( $schedules['ten_seconds'] ) ) {
+				$schedules['ten_seconds'] = array(
+					'interval' => 10,
+					'display'  => esc_html__( 'Every Ten Seconds', 'w3-total-cache' ),
+				);
+		}
+			return $schedules;
+	}
+
+		/**
+		 * Queue a URL for markdown generation.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param string $url URL to generate markdown for.
+		 *
+		 * @return bool True on success, false otherwise.
+		 */
+	public static function generate_markdown( $url ) {
+			$post_id = url_to_postid( $url );
+		if ( ! $post_id ) {
+				return false;
+		}
+
+			update_post_meta( $post_id, self::META_STATUS, 'queued' );
+			update_post_meta( $post_id, self::META_SOURCE_URL, esc_url_raw( $url ) );
+
+			self::schedule_cron();
+
+			return true;
+	}
+
+		/**
+		 * Process queued URLs and generate markdown.
+		 *
+		 * @since X.X.X
+		 *
+		 * @return void
+		 */
+	public static function process_queue() {
+			$query = new \WP_Query(
+				array(
+					'post_type'      => 'any',
+					'posts_per_page' => 5,
+					'post_status'    => 'any',
+					'fields'         => 'ids',
+					'meta_query'     => array(
+						array(
+							'key'   => self::META_STATUS,
+							'value' => 'queued',
+						),
+					),
+				)
+			);
+
+		if ( empty( $query->posts ) ) {
+				return;
+		}
+
+		foreach ( $query->posts as $post_id ) {
+				$url = get_post_meta( $post_id, self::META_SOURCE_URL, true );
+			if ( empty( $url ) ) {
+					update_post_meta( $post_id, self::META_STATUS, 'error' );
+					continue;
+			}
+
+				update_post_meta( $post_id, self::META_STATUS, 'processing' );
+				$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
+
+			if ( empty( $response['success'] ) || empty( $response['data']['markdown_content'] ) ) {
+					update_post_meta( $post_id, self::META_STATUS, 'error' );
+					continue;
+			}
+
+				$markdown     = $response['data']['markdown_content'];
+				$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
+
+				update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
+				update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
+				update_post_meta( $post_id, self::META_STATUS, 'complete' );
+		}
+	}
+}

--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -20,209 +20,207 @@ namespace W3TC;
  * @since X.X.X
  */
 class Extension_AiCrawler_Markdown {
-		/**
-		 * Cron hook name.
-		 *
-		 * @since X.X.X
-		 * @var string
-		 */
-		const CRON_HOOK = 'w3tc_aicrawler_markdown_cron';
+	/**
+	 * Cron hook name.
+	 *
+	 * @since X.X.X
+	 * @var   string
+	 */
+	const CRON_HOOK = 'w3tc_aicrawler_markdown_cron';
 
-		/**
-		 * Post meta key for original URL.
-		 *
-		 * @since X.X.X
-		 * @var string
-		 */
-		const META_SOURCE_URL = 'w3tc_aicrawler_source_url';
+	/**
+	 * Post meta key for original URL.
+	 *
+	 * @since X.X.X
+	 * @var   string
+	 */
+	const META_SOURCE_URL = 'w3tc_aicrawler_source_url';
 
-		/**
-		 * Post meta key for processing status.
-		 *
-		 * @since X.X.X
-		 * @var string
-		 */
-		const META_STATUS = 'w3tc_aicrawler_status';
+	/**
+	 * Post meta key for processing status.
+	 *
+	 * @since X.X.X
+	 * @var   string
+	 */
+	const META_STATUS = 'w3tc_aicrawler_status';
 
-		/**
-		 * Post meta key where generated markdown is stored.
-		 *
-		 * @since X.X.X
-		 * @var string
-		 */
-		const META_MARKDOWN = 'w3tc_aicrawler_markdown';
+	/**
+	 * Post meta key where generated markdown is stored.
+	 *
+	 * @since X.X.X
+	 * @var   string
+	 */
+	const META_MARKDOWN = 'w3tc_aicrawler_markdown';
 
-		/**
-		 * Post meta key for the public markdown URL.
-		 *
-		 * @since X.X.X
-		 * @var string
-		 */
-		const META_MARKDOWN_URL = 'w3tc_aicrawler_markdown_url';
+	/**
+	 * Post meta key for the public markdown URL.
+	 *
+	 * @since X.X.X
+	 * @var   string
+	 */
+	const META_MARKDOWN_URL = 'w3tc_aicrawler_markdown_url';
 
-		/**
-		 * Initialize hooks for cron processing.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return void
-		 */
+	/**
+	 * Initialize hooks for cron processing.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
 	public static function init() {
-			add_action( self::CRON_HOOK, array( __CLASS__, 'process_queue' ) );
-			add_filter( 'cron_schedules', array( __CLASS__, 'add_schedule' ) );
+		add_action( self::CRON_HOOK, array( __CLASS__, 'process_queue' ) );
+		add_filter( 'cron_schedules', array( __CLASS__, 'add_schedule' ) );
 
 		if ( self::queue_has_items() ) {
-				self::schedule_cron();
+			self::schedule_cron();
 		}
 	}
 
-		/**
-		 * Schedule the cron event if it is not already scheduled.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return void
-		 */
+	/**
+	 * Schedule the cron event if it is not already scheduled.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
 	private static function schedule_cron() {
 		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-				wp_schedule_event( time(), 'ten_seconds', self::CRON_HOOK );
+			wp_schedule_event( time(), 'ten_seconds', self::CRON_HOOK );
 		}
 	}
 
-		/**
-		 * Remove the cron event if scheduled.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return void
-		 */
+	/**
+	 * Remove the cron event if scheduled.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
 	private static function unschedule_cron() {
 		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
-				wp_clear_scheduled_hook( self::CRON_HOOK );
+			wp_clear_scheduled_hook( self::CRON_HOOK );
 		}
 	}
 
-		/**
-		 * Adds a ten second cron schedule used by the queue worker.
-		 *
-		 * @since X.X.X
-		 *
-		 * @param array $schedules Existing schedules.
-		 *
-		 * @return array
-		 */
+	/**
+	 * Adds a ten second cron schedule used by the queue worker.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $schedules Existing schedules.
+	 *
+	 * @return array
+	 */
 	public static function add_schedule( array $schedules = array() ) {
 		if ( ! isset( $schedules['ten_seconds'] ) ) {
-				$schedules['ten_seconds'] = array(
-					'interval' => 10,
-					'display'  => esc_html__( 'Every Ten Seconds', 'w3-total-cache' ),
-				);
-		}
-			return $schedules;
-	}
-
-		/**
-		 * Queue a URL for markdown generation.
-		 *
-		 * @since X.X.X
-		 *
-		 * @param string $url URL to generate markdown for.
-		 *
-		 * @return bool True on success, false otherwise.
-		 */
-	public static function generate_markdown( $url ) {
-			$post_id = url_to_postid( $url );
-		if ( ! $post_id ) {
-				return false;
-		}
-
-			update_post_meta( $post_id, self::META_STATUS, 'queued' );
-			update_post_meta( $post_id, self::META_SOURCE_URL, esc_url_raw( $url ) );
-
-			self::schedule_cron();
-
-			return true;
-	}
-
-		/**
-		 * Process queued URLs and generate markdown.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return void
-		 */
-	public static function process_queue() {
-			$query = new \WP_Query(
-				array(
-					'post_type'      => 'any',
-					'posts_per_page' => 5,
-					'post_status'    => 'any',
-					'fields'         => 'ids',
-					'meta_query'     => array(
-						array(
-							'key'   => self::META_STATUS,
-							'value' => 'queued',
-						),
-					),
-				)
+			$schedules['ten_seconds'] = array(
+				'interval' => 10,
+				'display'  => esc_html__( 'Every Ten Seconds', 'w3-total-cache' ),
 			);
+		}
+		return $schedules;
+	}
 
-		if ( empty( $query->posts ) ) {
-				self::unschedule_cron();
-				return;
+	/**
+	 * Queue a URL for markdown generation.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $url URL to generate markdown for.
+	 *
+	 * @return bool True on success, false otherwise.
+	 */
+	public static function generate_markdown( $url ) {
+		$post_id = url_to_postid( $url );
+		if ( ! $post_id ) {
+			return false;
 		}
 
-		foreach ( $query->posts as $post_id ) {
-				$url = get_post_meta( $post_id, self::META_SOURCE_URL, true );
+		update_post_meta( $post_id, self::META_STATUS, 'queued' );
+		update_post_meta( $post_id, self::META_SOURCE_URL, esc_url_raw( $url ) );
+
+		self::schedule_cron();
+
+		return true;
+	}
+
+	/**
+	 * Process queued URLs and generate markdown.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public static function process_queue() {
+		$posts = self::get_queue_posts();
+
+		if ( empty( $posts ) ) {
+			self::unschedule_cron();
+			return;
+		}
+
+		foreach ( $posts as $post_id ) {
+			$url = get_post_meta( $post_id, self::META_SOURCE_URL, true );
 			if ( empty( $url ) ) {
-					update_post_meta( $post_id, self::META_STATUS, 'error' );
-					continue;
+				update_post_meta( $post_id, self::META_STATUS, 'error' );
+				continue;
 			}
 
-				update_post_meta( $post_id, self::META_STATUS, 'processing' );
-				$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
+			update_post_meta( $post_id, self::META_STATUS, 'processing' );
+			$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
 
 			if ( empty( $response['success'] ) || empty( $response['data']['markdown_content'] ) ) {
-					update_post_meta( $post_id, self::META_STATUS, 'error' );
-					continue;
+				update_post_meta( $post_id, self::META_STATUS, 'error' );
+				continue;
 			}
 
-				$markdown     = $response['data']['markdown_content'];
-				$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
+			$markdown     = $response['data']['markdown_content'];
+			$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
 
-				update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
-				update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
-				update_post_meta( $post_id, self::META_STATUS, 'complete' );
+			update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
+			update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
+			update_post_meta( $post_id, self::META_STATUS, 'complete' );
 		}
 
 		if ( ! self::queue_has_items() ) {
-				self::unschedule_cron();
+			self::unschedule_cron();
 		}
 	}
 
-		/**
-		 * Determine if there are queued items waiting to be processed.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Determine if there are queued items waiting to be processed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool
+	 */
 	private static function queue_has_items() {
-			$query = new \WP_Query(
-				array(
-					'post_type'      => 'any',
-					'posts_per_page' => 1,
-					'post_status'    => 'any',
-					'fields'         => 'ids',
-					'meta_query'     => array(
-						array(
-							'key'   => self::META_STATUS,
-							'value' => 'queued',
-						),
-					),
-				)
-			);
+		return ! empty( self::get_queue_posts() );
+	}
 
-			return ! empty( $query->posts );
+	/**
+	 * Get Queue Posts
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array Array of WP_Post objects that are queued for markdown generation.
+	 */
+	public static function get_queue_posts() {
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'any',
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'   => self::META_STATUS,
+						'value' => 'queued',
+					),
+				),
+			)
+		);
+
+		return ! empty( $query->posts ) ? $query->posts : array();
 	}
 }

--- a/Extension_AiCrawler_Plugin.php
+++ b/Extension_AiCrawler_Plugin.php
@@ -25,11 +25,14 @@ class Extension_AiCrawler_Plugin {
 		/**
 		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
 		*/
-		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
+				add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
 
-		// If the AiCrawler Mock API class exists, run it.
+				// Initialize markdown generation queue.
+				Extension_AiCrawler_Markdown::init();
+
+				// If the AiCrawler Mock API class exists, run it.
 		if ( class_exists( '\W3TC\Extension_AiCrawler_Mock_Api' ) ) {
-			( new \W3TC\Extension_AiCrawler_Mock_Api() )->run();
+				( new \W3TC\Extension_AiCrawler_Mock_Api() )->run();
 		}
 	}
 

--- a/Extension_AiCrawler_Plugin.php
+++ b/Extension_AiCrawler_Plugin.php
@@ -25,14 +25,14 @@ class Extension_AiCrawler_Plugin {
 		/**
 		 * This filter is documented in Generic_AdminActions_Default.php under the read_request method.
 		*/
-				add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
+		add_filter( 'w3tc_config_key_descriptor', array( $this, 'w3tc_config_key_descriptor' ), 10, 2 );
 
-				// Initialize markdown generation queue.
-				Extension_AiCrawler_Markdown::init();
+		// Initialize markdown generation queue.
+		Extension_AiCrawler_Markdown::init();
 
-				// If the AiCrawler Mock API class exists, run it.
+		// If the AiCrawler Mock API class exists, run it.
 		if ( class_exists( '\W3TC\Extension_AiCrawler_Mock_Api' ) ) {
-				( new \W3TC\Extension_AiCrawler_Mock_Api() )->run();
+			( new \W3TC\Extension_AiCrawler_Mock_Api() )->run();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add `Extension_AiCrawler_Markdown` class with cron-based queue to convert URLs to markdown using the AI Crawler API
- initialize markdown queue in `Extension_AiCrawler_Plugin`

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpcs -n --standard=phpcs.xml Extension_AiCrawler_Markdown.php Extension_AiCrawler_Plugin.php`
- `./vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_b_689f64d8e67c8328bd7854e86c69f02f