### PR TITLE
Add AI Crawler regenerate URL queue endpoint

### DIFF
--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -8,135 +8,166 @@
  * @global w3tcData Object containing localized strings and settings.
  */
 
-document.addEventListener('DOMContentLoaded', function () {
-	const testTokenButton     = document.getElementById('w3tc-aicrawler-test-ctoken-button');
-	const regenerateUrlButton = document.getElementById('w3tc-aicrawler-regenerate-url-button');
-	const regenerateUrlInput  = document.getElementById('w3tc-aicrawler-regenerate-url');
-	const regenerateAllButton = document.getElementById('w3tc-aicrawler-regenerate-all-button');
+document.addEventListener("DOMContentLoaded", function () {
+  const testTokenButton = document.getElementById(
+    "w3tc-aicrawler-test-ctoken-button",
+  );
+  const regenerateUrlButton = document.getElementById(
+    "w3tc-aicrawler-regenerate-url-button",
+  );
+  const regenerateUrlInput = document.getElementById(
+    "w3tc-aicrawler-regenerate-url",
+  );
+  const regenerateUrlMessage = document.getElementById(
+    "w3tc-aicrawler-regenerate-url-message",
+  );
+  const regenerateAllButton = document.getElementById(
+    "w3tc-aicrawler-regenerate-all-button",
+  );
 
-	if (testTokenButton) {
-		// Add a click event listener to the button.
-		testTokenButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent the default button behavior.
+  if (testTokenButton) {
+    // Add a click event listener to the button.
+    testTokenButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent the default button behavior.
 
-			// Display a loading message or spinner (optional).
-			testTokenButton.textContent = w3tcData.lang.testing;
+      // Display a loading message or spinner (optional).
+      testTokenButton.textContent = w3tcData.lang.testing;
 
-			// Example AJAX request to test the token.
-			fetch(ajaxurl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
-					action: 'test_aicrawler_token', // WordPress AJAX action.
-					token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
-				}),
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					if (data.success) {
-						alert(w3tcData.lang.tokenValid);
-					} else {
-						alert(w3tcData.lang.tokenInvalid);
-					}
-				})
-				.catch((error) => {
-					console.error(w3tcData.lang.error + ':', error);
-					alert(w3tcData.lang.tokenError + '.');
-				})
-				.finally(() => {
-					// Reset the button text.
-					testTokenButton.textContent = w3tcData.lang.test;
-				});
-		});
-	}
+      // Example AJAX request to test the token.
+      fetch(ajaxurl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          _wpnonce: w3tcData.nonces.testToken, // Nonce for security.
+          action: "test_aicrawler_token", // WordPress AJAX action.
+          token: document.getElementById("aicrawler___imh_central_token").value, // InMotion Central token to be tested.
+        }),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          if (data.success) {
+            alert(w3tcData.lang.tokenValid);
+          } else {
+            alert(w3tcData.lang.tokenInvalid);
+          }
+        })
+        .catch((error) => {
+          console.error(w3tcData.lang.error + ":", error);
+          alert(w3tcData.lang.tokenError + ".");
+        })
+        .finally(() => {
+          // Reset the button text.
+          testTokenButton.textContent = w3tcData.lang.test;
+        });
+    });
+  }
 
-	// Handle the "Regenerate URL" button click.
-	if (regenerateUrlButton && regenerateUrlInput) {
-		regenerateUrlButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent default button behavior.
+  // Handle the "Regenerate URL" button click.
+  if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
+    regenerateUrlButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent default button behavior.
 
-			const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
+      const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
 
-			if (!url) {
-				alert(w3tcData.lang.noUrl + '.');
-				return;
-			}
+      regenerateUrlMessage.textContent = "";
+      regenerateUrlMessage.classList.remove(
+        "w3tc-aicrawler-message-success",
+        "w3tc-aicrawler-message-error",
+      );
 
-			// Display a loading message or spinner (optional).
-			regenerateUrlButton.textContent = w3tcData.lang.regenerating + '...';
+      if (!url) {
+        regenerateUrlMessage.textContent = w3tcData.lang.noUrl + ".";
+        regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+        return;
+      }
 
-			// Example AJAX request to regenerate the specified URL.
-			fetch(ajaxurl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					_wpnonce: w3tcData.nonces.regenerateUrl, // Nonce for security.
-					action: 'regenerate_aicrawler_url', // WordPress AJAX action.
-					url: url, // Pass the URL to the server.
-				}),
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					if (data.success) {
-						alert(w3tcData.lang.regeneratedUrl + '.');
-					} else {
-						alert(w3tcData.lang.regenerateUrlFailed + '.');
-					}
-				})
-				.catch((error) => {
-					console.error('Error:', error);
-					alert(w3tcData.lang.regenerateUrlError + '.');
-				})
-				.finally(() => {
-					// Reset the button text.
-					regenerateUrlButton.textContent = w3tcData.lang.regenerate;
-				});
-		});
-	}
+      // Display a loading message or spinner (optional).
+      regenerateUrlButton.textContent = w3tcData.lang.regenerating + "...";
 
-	// Handle the "Regenerate All" button click.
-	if (regenerateAllButton) {
-		regenerateAllButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent default button behavior.
+      const params = new URLSearchParams();
+      params.append("_wpnonce", w3tcData.nonces.regenerateUrl);
+      params.append("action", "regenerate_aicrawler_url");
+      params.append("url", url);
 
-			// Display a loading message or spinner (optional).
-			regenerateAllButton.textContent = w3tcData.lang.regenerating + '...';
+      // AJAX request to regenerate the specified URL.
+      fetch(ajaxurl, {
+        method: "POST",
+        body: params,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          regenerateUrlMessage.textContent = "";
+          regenerateUrlMessage.classList.remove(
+            "w3tc-aicrawler-message-success",
+            "w3tc-aicrawler-message-error",
+          );
 
-			// Example AJAX request to regenerate all URLs.
-			fetch(ajaxurl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					_wpnonce: w3tcData.nonces.regenerateAll, // Nonce for security.
-					action: 'regenerate_aicrawler_all', // WordPress AJAX action.
-				}),
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					if (data.success) {
-						alert(w3tcData.lang.regenerateAll + '.');
-					} else {
-						alert(w3tcData.lang.regenerateAllFailed + '.');
-					}
-				})
-				.catch((error) => {
-					console.error('Error:', error);
-					alert(w3tcData.lang.regenerateAllError + '.');
-				})
-				.finally(() => {
-					// Reset the button text.
-					regenerateAllButton.textContent = w3tcData.lang.regenerate;
-				});
-		});
-	}
+          if (data.success) {
+            regenerateUrlMessage.textContent = data.data.message;
+            regenerateUrlMessage.classList.add(
+              "w3tc-aicrawler-message-success",
+            );
+          } else {
+            regenerateUrlMessage.textContent =
+              data.data && data.data.message
+                ? data.data.message
+                : w3tcData.lang.regenerateUrlFailed + ".";
+            regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          regenerateUrlMessage.textContent =
+            w3tcData.lang.regenerateUrlError + ".";
+          regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+        })
+        .finally(() => {
+          // Reset the button text.
+          regenerateUrlButton.textContent = w3tcData.lang.regenerate;
+        });
+    });
+  }
+
+  // Handle the "Regenerate All" button click.
+  if (regenerateAllButton) {
+    regenerateAllButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent default button behavior.
+
+      // Display a loading message or spinner (optional).
+      regenerateAllButton.textContent = w3tcData.lang.regenerating + "...";
+
+      // Example AJAX request to regenerate all URLs.
+      fetch(ajaxurl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          _wpnonce: w3tcData.nonces.regenerateAll, // Nonce for security.
+          action: "regenerate_aicrawler_all", // WordPress AJAX action.
+        }),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          if (data.success) {
+            alert(w3tcData.lang.regenerateAll + ".");
+          } else {
+            alert(w3tcData.lang.regenerateAllFailed + ".");
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          alert(w3tcData.lang.regenerateAllError + ".");
+        })
+        .finally(() => {
+          // Reset the button text.
+          regenerateAllButton.textContent = w3tcData.lang.regenerate;
+        });
+    });
+  }
 });

--- a/Extension_AiCrawler_Page_View.css
+++ b/Extension_AiCrawler_Page_View.css
@@ -62,3 +62,15 @@
         text-align: center;
         margin-bottom: 12px;
 }
+
+.w3tc-aicrawler-message {
+        margin-top: 8px;
+}
+
+.w3tc-aicrawler-message-success {
+        color: #46b450;
+}
+
+.w3tc-aicrawler-message-error {
+        color: #dc3232;
+}

--- a/Extension_AiCrawler_Page_View_Tools.php
+++ b/Extension_AiCrawler_Page_View_Tools.php
@@ -24,8 +24,9 @@ $config = Dispatcher::config();
 				<label for="w3tc-aicrawler-regenerate-url"><?php esc_html_e( 'Regenerate URL:', 'w3-total-cache' ); ?></label>
 			</th>
 			<td>
-				<input id="w3tc-aicrawler-regenerate-url" type="text" size="60" placeholder="<?php esc_attr_e( 'Specify URL to regenerate', 'w3-total-cache' ); ?>"/>
-				<button id="w3tc-aicrawler-regenerate-url-button" class="button"><?php esc_html_e( 'Regenerate', 'w3-total-cache' ); ?></button>
+								<input id="w3tc-aicrawler-regenerate-url" type="text" size="60" placeholder="<?php esc_attr_e( 'Specify URL to regenerate', 'w3-total-cache' ); ?>"/>
+								<button id="w3tc-aicrawler-regenerate-url-button" class="button"><?php esc_html_e( 'Regenerate', 'w3-total-cache' ); ?></button>
+								<p id="w3tc-aicrawler-regenerate-url-message" class="w3tc-aicrawler-message"></p>
 			</td>
 		</tr>
 		<tr>

--- a/Extension_AiCrawler_Plugin_Admin.php
+++ b/Extension_AiCrawler_Plugin_Admin.php
@@ -130,9 +130,10 @@ class Extension_AiCrawler_Plugin_Admin {
 	 * @return void
 	 */
 	public function run() {
-		add_filter( 'w3tc_admin_menu', array( $this, 'w3tc_admin_menu' ) );
-		add_filter( 'w3tc_extension_plugin_links_aicrawler', array( $this, 'w3tc_extension_plugin_links' ) );
-		add_action( 'w3tc_settings_page-w3tc_aicrawler', array( $this, 'w3tc_extension_page' ) );
+			add_filter( 'w3tc_admin_menu', array( $this, 'w3tc_admin_menu' ) );
+			add_filter( 'w3tc_extension_plugin_links_aicrawler', array( $this, 'w3tc_extension_plugin_links' ) );
+			add_action( 'w3tc_settings_page-w3tc_aicrawler', array( $this, 'w3tc_extension_page' ) );
+			add_action( 'wp_ajax_regenerate_aicrawler_url', array( $this, 'wp_ajax_regenerate_aicrawler_url' ) );
 
 		// Site Health: STATUS card.
 		add_filter(
@@ -195,10 +196,41 @@ class Extension_AiCrawler_Plugin_Admin {
 	 * @return array Modified array of plugin links with New Relic settings link added.
 	 */
 	public function w3tc_extension_plugin_links( $links ) {
-		$links   = array();
-		$links[] = '<a class="edit" href="' . esc_attr( Util_Ui::admin_url( 'admin.php?page=w3tc_aicrawler' ) ) .
-			'">' . __( 'Settings' ) . '</a>';
+			$links   = array();
+			$links[] = '<a class="edit" href="' . esc_attr( Util_Ui::admin_url( 'admin.php?page=w3tc_aicrawler' ) ) .
+					'">' . __( 'Settings' ) . '</a>';
 
-		return $links;
+			return $links;
+	}
+
+		/**
+		 * AJAX handler to queue a URL for markdown generation.
+		 *
+		 * @since X.X.X
+		 *
+		 * @return void
+		 */
+	public function wp_ajax_regenerate_aicrawler_url() {
+		if ( ! check_ajax_referer( 'w3tc_aicrawler_regenerate_url', '_wpnonce', false ) ) {
+				wp_send_json_error( array( 'message' => __( 'Invalid nonce.', 'w3-total-cache' ) ) );
+		}
+
+			$url = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+
+		if ( empty( $url ) ) {
+				wp_send_json_error( array( 'message' => __( 'Please specify a URL to regenerate.', 'w3-total-cache' ) ) );
+		}
+
+		if ( Extension_AiCrawler_Util::is_url_excluded( $url ) ) {
+				wp_send_json_error( array( 'message' => __( 'This URL is excluded from markdown generation.', 'w3-total-cache' ) ) );
+		}
+
+			$result = Extension_AiCrawler_Markdown::generate_markdown( $url );
+
+		if ( $result ) {
+				wp_send_json_success( array( 'message' => __( 'URL added to the markdown generation queue.', 'w3-total-cache' ) ) );
+		}
+
+			wp_send_json_error( array( 'message' => __( 'Failed to add URL to the markdown generation queue.', 'w3-total-cache' ) ) );
 	}
 }

--- a/Extension_AiCrawler_Util.php
+++ b/Extension_AiCrawler_Util.php
@@ -181,4 +181,20 @@ class Extension_AiCrawler_Util {
 			<?php
 		endif;
 	}
+
+		/**
+		 * Determine if the provided URL matches any exclusion rules.
+		 *
+		 * Placeholder for future exclusion logic.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param string $url URL to check against exclusions.
+		 *
+		 * @return bool True if the URL should be excluded, otherwise false.
+		 */
+	public static function is_url_excluded( $url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			// @todo Implement exclusion filters.
+			return false;
+	}
 }


### PR DESCRIPTION
## Summary
- queue selected URLs for AI Crawler markdown generation via new AJAX endpoint
- show success and error messages on the tools page when URLs are queued
- add placeholder helper for future exclusion filters and basic styling

## Testing
- `npm run js-lint` *(fails: many files require formatting)*
- `npx prettier-eslint Extension_AiCrawler_Page.js --list-different`
- `vendor/bin/phpcs Extension_AiCrawler_Plugin_Admin.php Extension_AiCrawler_Page_View_Tools.php Extension_AiCrawler_Util.php`
- `vendor/bin/phpunit` *(fails: missing /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_b_689f6d7363f48328b4d9efcb73788c28