### PR TITLE
Discard simplexml errors

### DIFF
--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -209,8 +209,16 @@ class PgCache_Plugin_Admin {
 			$url_matches     = null;
 			$sitemap_matches = null;
 
-			$xml = simplexml_load_string( $response['body'] );
+			// Disable libxml errors to prevent warnings from breaking the XML parsing.
+			$previous = \libxml_use_internal_errors( true );
+			// Load the XML response.
+			$xml = \simplexml_load_string( $response['body'] );
+			// Clear any errors that may have occurred during parsing.
+			\libxml_clear_errors();
+			// Restore the previous libxml error handling.
+			\libxml_use_internal_errors( $previous );
 
+			// Check if the XML load failed; return the URLs found so far (sitemap URL).
 			if ( false === $xml ) {
 				return $urls;
 			}


### PR DESCRIPTION
Fixes #1163

To test:
1. Checkout the `master` branch
1. Enable Page Cache
1. Enable Cache Preload (`wp-admin/admin.php?page=w3tc_pgcache#cache_preload`) with a valid sitemap URL leading to "wp-sitemap.xml" or similar.
1. Add to "PgCache_Plugin_Admin.php" line 211: $response['body'] = '&raquo';
1. Tail the PHP error log
1. Purge the Page Cache
1. Run `wp cron event run w3_pgcache_prime`
1. See warnings
1. Revert the line added containing the invalid XML.
1. Checkout this fix branch
1. Add the line back
1. Purge the Page Cache
1. Run `wp cron event run w3_pgcache_prime`
1. See no errors logged