### PR TITLE
Add AI Crawler queue summary and error tracking

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -6,7 +6,7 @@
  * AI Crawler API.
  *
  * @package W3TC
- * @since	X.X.X
+ * @since   X.X.X
  */
 
 namespace W3TC;
@@ -24,7 +24,7 @@ class Extension_AiCrawler_Markdown {
 	 * Cron hook name.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const CRON_HOOK = 'w3tc_aicrawler_markdown_cron';
 
@@ -32,7 +32,7 @@ class Extension_AiCrawler_Markdown {
 	 * Post meta key for original URL.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const META_SOURCE_URL = 'w3tc_aicrawler_source_url';
 
@@ -40,7 +40,7 @@ class Extension_AiCrawler_Markdown {
 	 * Post meta key for processing status.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const META_STATUS = 'w3tc_aicrawler_status';
 
@@ -48,7 +48,7 @@ class Extension_AiCrawler_Markdown {
 	 * Post meta key for error messages.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const META_ERROR_MESSAGE = 'w3tc_aicrawler_error_message';
 
@@ -56,7 +56,7 @@ class Extension_AiCrawler_Markdown {
 	 * Post meta key where generated markdown is stored.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const META_MARKDOWN = 'w3tc_aicrawler_markdown';
 
@@ -64,7 +64,7 @@ class Extension_AiCrawler_Markdown {
 	 * Post meta key for the public markdown URL.
 	 *
 	 * @since X.X.X
-	 * @var	  string
+	 * @var   string
 	 */
 	const META_MARKDOWN_URL = 'w3tc_aicrawler_markdown_url';
 
@@ -152,11 +152,11 @@ class Extension_AiCrawler_Markdown {
 			return false;
 		}
 
-				update_post_meta( $post_id, self::META_STATUS, 'queued' );
-				update_post_meta( $post_id, self::META_SOURCE_URL, esc_url_raw( $url ) );
-				delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
+		update_post_meta( $post_id, self::META_STATUS, 'queued' );
+		update_post_meta( $post_id, self::META_SOURCE_URL, esc_url_raw( $url ) );
+		delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
 
-				self::schedule_cron();
+		self::schedule_cron();
 
 		return true;
 	}
@@ -169,39 +169,38 @@ class Extension_AiCrawler_Markdown {
 	 * @return void
 	 */
 	public static function process_queue() {
-				$posts = self::get_queue_posts();
+		$posts = self::get_queue_posts();
 
 		if ( empty( $posts ) ) {
-				self::unschedule_cron();
-				return;
+			self::unschedule_cron();
+			return;
 		}
 
 		foreach ( $posts as $post_id ) {
-				$url = get_post_meta( $post_id, self::META_SOURCE_URL, true );
+			$url = get_post_meta( $post_id, self::META_SOURCE_URL, true );
 			if ( empty( $url ) ) {
-						update_post_meta( $post_id, self::META_STATUS, 'error' );
-						update_post_meta( $post_id, self::META_ERROR_MESSAGE, __( 'Missing URL.', 'w3-total-cache' ) );
-						continue;
+				update_post_meta( $post_id, self::META_STATUS, 'error' );
+				update_post_meta( $post_id, self::META_ERROR_MESSAGE, __( 'Missing URL.', 'w3-total-cache' ) );
+				continue;
 			}
-
 				update_post_meta( $post_id, self::META_STATUS, 'processing' );
 				delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
 				$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
 
 			if ( empty( $response['success'] ) || empty( $response['data']['markdown_content'] ) ) {
-							update_post_meta( $post_id, self::META_STATUS, 'error' );
-							$message = ! empty( $response['error']['message'] ) ? $response['error']['message'] : __( 'Unknown error.', 'w3-total-cache' );
-							update_post_meta( $post_id, self::META_ERROR_MESSAGE, $message );
-							continue;
+				update_post_meta( $post_id, self::META_STATUS, 'error' );
+				$message = ! empty( $response['error']['message'] ) ? $response['error']['message'] : __( 'Unknown error.', 'w3-total-cache' );
+				update_post_meta( $post_id, self::META_ERROR_MESSAGE, $message );
+				continue;
 			}
 
-							$markdown	  = $response['data']['markdown_content'];
-							$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
+			$markdown     = $response['data']['markdown_content'];
+			$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
 
-							update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
-							update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
-							update_post_meta( $post_id, self::META_STATUS, 'complete' );
-							delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
+			update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
+			update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
+			update_post_meta( $post_id, self::META_STATUS, 'complete' );
+			delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
 		}
 
 		if ( ! self::queue_has_items() ) {
@@ -228,57 +227,57 @@ class Extension_AiCrawler_Markdown {
 	 * @return array Array of WP_Post objects that are queued for markdown generation.
 	 */
 	public static function get_queue_posts() {
-			$query = new \WP_Query(
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'any',
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'meta_query'    => array(
+					array(
+						'key'   => self::META_STATUS,
+						'value' => 'queued',
+					),
+				),
+			)
+		);
+
+		return ! empty( $query->posts ) ? $query->posts : array();
+	}
+
+	/**
+	 * Get counts of items by status.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array
+	 */
+	public static function get_status_counts() {
+		$statuses = array( 'queued', 'processing', 'complete', 'error' );
+		$counts   = array();
+
+		foreach ( $statuses as $status ) {
+			$q = new \WP_Query(
 				array(
-					'post_type'		 => 'any',
+					'post_type'      => 'any',
 					'posts_per_page' => -1,
-					'post_status'	 => 'any',
-					'fields'		 => 'ids',
-					'meta_query'	 => array(
+					'post_status'    => 'any',
+					'fields'         => 'ids',
+					'meta_query'     => array(
 						array(
-							'key'	=> self::META_STATUS,
-							'value' => 'queued',
+							'key'   => self::META_STATUS,
+							'value' => $status,
 						),
 					),
 				)
 			);
 
-			return ! empty( $query->posts ) ? $query->posts : array();
-	}
-
-		/**
-		 * Get counts of items by status.
-		 *
-		 * @since X.X.X
-		 *
-		 * @return array
-		 */
-	public static function get_status_counts() {
-			$statuses = array( 'queued', 'processing', 'complete', 'error' );
-			$counts	  = array();
-
-		foreach ( $statuses as $status ) {
-				$q = new \WP_Query(
-					array(
-						'post_type'		 => 'any',
-						'posts_per_page' => -1,
-						'post_status'	 => 'any',
-						'fields'		 => 'ids',
-						'meta_query'	 => array(
-							array(
-								'key'	=> self::META_STATUS,
-								'value' => $status,
-							),
-						),
-					)
-				);
-
-				$counts[ $status ] = ! empty( $q->posts ) ? count( $q->posts ) : 0;
+			$counts[ $status ] = ! empty( $q->posts ) ? count( $q->posts ) : 0;
 		}
 
-			$counts['total'] = array_sum( $counts );
+		$counts['total'] = array_sum( $counts );
 
-			return $counts;
+		return $counts;
 	}
 
 		/**
@@ -286,27 +285,29 @@ class Extension_AiCrawler_Markdown {
 		 *
 		 * @since X.X.X
 		 *
-		 * @param int $paged	Page number.
+		 * @param int $paged    Page number.
 		 * @param int $per_page Items per page.
 		 *
 		 * @return array
 		 */
 	public static function get_queue_items( $paged = 1, $per_page = 20 ) {
-			$query = new \WP_Query(
-				array(
-					'post_type'		 => 'any',
-					'posts_per_page' => $per_page,
-					'post_status'	 => 'any',
-					'fields'		 => 'ids',
-					'paged'			 => $paged,
-					'meta_key'		 => self::META_STATUS,
-					'meta_compare'	 => 'EXISTS',
-				)
-			);
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'any',
+				'posts_per_page' => $per_page,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'paged'          => $paged,
+				'meta_key'       => self::META_STATUS,
+				'meta_compare'   => 'EXISTS',
+				'sort_order'     => 'ASC',
+				'orderby'        => 'post_id',
+			)
+		);
 
-			return array(
-				'items' => ! empty( $query->posts ) ? $query->posts : array(),
-				'total' => (int) $query->found_posts,
-			);
+		return array(
+			'items' => ! empty( $query->posts ) ? $query->posts : array(),
+			'total' => (int) $query->found_posts,
+		);
 	}
 }

--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -183,9 +183,10 @@ class Extension_AiCrawler_Markdown {
 				update_post_meta( $post_id, self::META_ERROR_MESSAGE, __( 'Missing URL.', 'w3-total-cache' ) );
 				continue;
 			}
-				update_post_meta( $post_id, self::META_STATUS, 'processing' );
-				delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
-				$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
+
+			update_post_meta( $post_id, self::META_STATUS, 'processing' );
+			delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
+			$response = Extension_AiCrawler_Central_Api::call( 'convert', 'POST', array( 'url' => $url ) );
 
 			if ( empty( $response['success'] ) || empty( $response['data']['markdown_content'] ) ) {
 				update_post_meta( $post_id, self::META_STATUS, 'error' );

--- a/Extension_AiCrawler_Page_View.php
+++ b/Extension_AiCrawler_Page_View.php
@@ -43,8 +43,8 @@ $config = Dispatcher::config();
 
 	require __DIR__ . '/Extension_AiCrawler_Page_View_Status.php';
 	require __DIR__ . '/Extension_AiCrawler_Page_View_Settings.php';
-		require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
-		require __DIR__ . '/Extension_AiCrawler_Page_View_Queue.php';
+	require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
+	require __DIR__ . '/Extension_AiCrawler_Page_View_Queue.php';
 	?>
 </form>
 <?php require W3TC_INC_DIR . '/options/common/footer.php'; ?>

--- a/Extension_AiCrawler_Page_View.php
+++ b/Extension_AiCrawler_Page_View.php
@@ -43,7 +43,8 @@ $config = Dispatcher::config();
 
 	require __DIR__ . '/Extension_AiCrawler_Page_View_Status.php';
 	require __DIR__ . '/Extension_AiCrawler_Page_View_Settings.php';
-	require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
+		require __DIR__ . '/Extension_AiCrawler_Page_View_Tools.php';
+		require __DIR__ . '/Extension_AiCrawler_Page_View_Queue.php';
 	?>
 </form>
 <?php require W3TC_INC_DIR . '/options/common/footer.php'; ?>

--- a/Extension_AiCrawler_Page_View_Queue.php
+++ b/Extension_AiCrawler_Page_View_Queue.php
@@ -23,92 +23,92 @@ $queue_total    = $queue_items['total'];
 $queue_pages    = max( 1, ceil( $queue_total / $queue_per_page ) );
 ?>
 <div class="metabox-holder">
-		<?php Util_Ui::postbox_header( esc_html__( 'Queue', 'w3-total-cache' ), '', 'queue' ); ?>
-		<p>
+	<?php Util_Ui::postbox_header( esc_html__( 'Queue', 'w3-total-cache' ), '', 'queue' ); ?>
+	<p>
+		<?php
+		/* translators: %d: total number of items. */
+		printf( esc_html__( 'Total items: %d', 'w3-total-cache' ), intval( $counts['total'] ) );
+		?>
+	</p>
+	<ul>
+		<li>
+			<?php
+			/* translators: %d: number of queued items. */
+			printf( esc_html__( 'Queued: %d', 'w3-total-cache' ), intval( $counts['queued'] ) );
+			?>
+		</li>
+		<li>
+			<?php
+			/* translators: %d: number of processing items. */
+			printf( esc_html__( 'Processing: %d', 'w3-total-cache' ), intval( $counts['processing'] ) );
+			?>
+		</li>
+		<li>
+			<?php
+			/* translators: %d: number of completed items. */
+			printf( esc_html__( 'Complete: %d', 'w3-total-cache' ), intval( $counts['complete'] ) );
+			?>
+		</li>
+		<li>
+			<?php
+			/* translators: %d: number of error items. */
+			printf( esc_html__( 'Error: %d', 'w3-total-cache' ), intval( $counts['error'] ) );
+			?>
+		</li>
+	</ul>
+	<table class="widefat fixed striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'ID', 'w3-total-cache' ); ?></th>
+				<th><?php esc_html_e( 'Name', 'w3-total-cache' ); ?></th>
+				<th><?php esc_html_e( 'URL', 'w3-total-cache' ); ?></th>
+				<th><?php esc_html_e( 'Status', 'w3-total-cache' ); ?></th>
+				<th><?php esc_html_e( 'Message', 'w3-total-cache' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php if ( ! empty( $queue_posts ) ) : ?>
+				<?php foreach ( $queue_posts as $queue_post_id ) : ?>
+					<?php
+					$queue_title   = get_the_title( $queue_post_id );
+					$queue_url     = wp_make_link_relative( get_permalink( $queue_post_id ) );
+					$queue_status  = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_STATUS, true );
+					$queue_message = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_ERROR_MESSAGE, true );
+					?>
+					<tr>
+						<td><?php echo esc_html( $queue_post_id ); ?></td>
+						<td><?php echo esc_html( $queue_title ); ?></td>
+						<td><?php echo esc_html( $queue_url ); ?></td>
+						<td><?php echo esc_html( $queue_status ); ?></td>
+						<td><?php echo esc_html( $queue_message ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			<?php else : ?>
+				<tr>
+					<td colspan="5"><?php esc_html_e( 'No items found.', 'w3-total-cache' ); ?></td>
+				</tr>
+			<?php endif; ?>
+		</tbody>
+	</table>
+	<?php if ( $queue_pages > 1 ) : ?>
+		<div class="tablenav">
+			<div class="tablenav-pages">
 				<?php
-				/* translators: %d: total number of items. */
-				printf( esc_html__( 'Total items: %d', 'w3-total-cache' ), intval( $counts['total'] ) );
+				echo wp_kses_post(
+					paginate_links(
+						array(
+							'base'      => add_query_arg( 'queue_page', '%#%' ),
+							'format'    => '',
+							'current'   => $queue_paged,
+							'total'     => $queue_pages,
+							'prev_text' => '&laquo;',
+							'next_text' => '&raquo;',
+						)
+					)
+				);
 				?>
-		</p>
-		<ul>
-				<li>
-						<?php
-						/* translators: %d: number of queued items. */
-						printf( esc_html__( 'Queued: %d', 'w3-total-cache' ), intval( $counts['queued'] ) );
-						?>
-				</li>
-				<li>
-						<?php
-						/* translators: %d: number of processing items. */
-						printf( esc_html__( 'Processing: %d', 'w3-total-cache' ), intval( $counts['processing'] ) );
-						?>
-				</li>
-				<li>
-						<?php
-						/* translators: %d: number of completed items. */
-						printf( esc_html__( 'Complete: %d', 'w3-total-cache' ), intval( $counts['complete'] ) );
-						?>
-				</li>
-				<li>
-						<?php
-						/* translators: %d: number of error items. */
-						printf( esc_html__( 'Error: %d', 'w3-total-cache' ), intval( $counts['error'] ) );
-						?>
-				</li>
-		</ul>
-		<table class="widefat fixed striped">
-				<thead>
-						<tr>
-								<th><?php esc_html_e( 'ID', 'w3-total-cache' ); ?></th>
-								<th><?php esc_html_e( 'Name', 'w3-total-cache' ); ?></th>
-								<th><?php esc_html_e( 'URL', 'w3-total-cache' ); ?></th>
-								<th><?php esc_html_e( 'Status', 'w3-total-cache' ); ?></th>
-								<th><?php esc_html_e( 'Message', 'w3-total-cache' ); ?></th>
-						</tr>
-				</thead>
-				<tbody>
-						<?php if ( ! empty( $queue_posts ) ) : ?>
-								<?php foreach ( $queue_posts as $queue_post_id ) : ?>
-										<?php
-										$queue_title   = get_the_title( $queue_post_id );
-										$queue_url     = wp_make_link_relative( get_permalink( $queue_post_id ) );
-										$queue_status  = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_STATUS, true );
-										$queue_message = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_ERROR_MESSAGE, true );
-										?>
-										<tr>
-												<td><?php echo esc_html( $queue_post_id ); ?></td>
-												<td><?php echo esc_html( $queue_title ); ?></td>
-												<td><?php echo esc_html( $queue_url ); ?></td>
-												<td><?php echo esc_html( $queue_status ); ?></td>
-												<td><?php echo esc_html( $queue_message ); ?></td>
-										</tr>
-								<?php endforeach; ?>
-						<?php else : ?>
-								<tr>
-										<td colspan="5"><?php esc_html_e( 'No items found.', 'w3-total-cache' ); ?></td>
-								</tr>
-						<?php endif; ?>
-				</tbody>
-		</table>
-		<?php if ( $queue_pages > 1 ) : ?>
-				<div class="tablenav">
-						<div class="tablenav-pages">
-								<?php
-								echo wp_kses_post(
-									paginate_links(
-										array(
-											'base'      => add_query_arg( 'queue_page', '%#%' ),
-											'format'    => '',
-											'current'   => $queue_paged,
-											'total'     => $queue_pages,
-											'prev_text' => '&laquo;',
-											'next_text' => '&raquo;',
-										)
-									)
-								);
-								?>
-						</div>
-				</div>
-		<?php endif; ?>
-		<?php Util_Ui::postbox_footer(); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+	<?php Util_Ui::postbox_footer(); ?>
 </div>

--- a/Extension_AiCrawler_Page_View_Queue.php
+++ b/Extension_AiCrawler_Page_View_Queue.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * File: Extension_AiCrawler_Page_View_Queue.php
+ *
+ * Render the AI Crawler queue section.
+ *
+ * @package W3TC
+ * @since   X.X.X
+ */
+
+namespace W3TC;
+
+if ( ! defined( 'W3TC' ) ) {
+		die();
+}
+
+$counts         = Extension_AiCrawler_Markdown::get_status_counts();
+$queue_paged    = isset( $_GET['queue_page'] ) ? absint( $_GET['queue_page'] ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$queue_per_page = 20;
+$queue_items    = Extension_AiCrawler_Markdown::get_queue_items( $queue_paged, $queue_per_page );
+$queue_posts    = $queue_items['items'];
+$queue_total    = $queue_items['total'];
+$queue_pages    = max( 1, ceil( $queue_total / $queue_per_page ) );
+?>
+<div class="metabox-holder">
+		<?php Util_Ui::postbox_header( esc_html__( 'Queue', 'w3-total-cache' ), '', 'queue' ); ?>
+		<p>
+				<?php
+				/* translators: %d: total number of items. */
+				printf( esc_html__( 'Total items: %d', 'w3-total-cache' ), intval( $counts['total'] ) );
+				?>
+		</p>
+		<ul>
+				<li>
+						<?php
+						/* translators: %d: number of queued items. */
+						printf( esc_html__( 'Queued: %d', 'w3-total-cache' ), intval( $counts['queued'] ) );
+						?>
+				</li>
+				<li>
+						<?php
+						/* translators: %d: number of processing items. */
+						printf( esc_html__( 'Processing: %d', 'w3-total-cache' ), intval( $counts['processing'] ) );
+						?>
+				</li>
+				<li>
+						<?php
+						/* translators: %d: number of completed items. */
+						printf( esc_html__( 'Complete: %d', 'w3-total-cache' ), intval( $counts['complete'] ) );
+						?>
+				</li>
+				<li>
+						<?php
+						/* translators: %d: number of error items. */
+						printf( esc_html__( 'Error: %d', 'w3-total-cache' ), intval( $counts['error'] ) );
+						?>
+				</li>
+		</ul>
+		<table class="widefat fixed striped">
+				<thead>
+						<tr>
+								<th><?php esc_html_e( 'ID', 'w3-total-cache' ); ?></th>
+								<th><?php esc_html_e( 'Name', 'w3-total-cache' ); ?></th>
+								<th><?php esc_html_e( 'URL', 'w3-total-cache' ); ?></th>
+								<th><?php esc_html_e( 'Status', 'w3-total-cache' ); ?></th>
+								<th><?php esc_html_e( 'Message', 'w3-total-cache' ); ?></th>
+						</tr>
+				</thead>
+				<tbody>
+						<?php if ( ! empty( $queue_posts ) ) : ?>
+								<?php foreach ( $queue_posts as $queue_post_id ) : ?>
+										<?php
+										$queue_title   = get_the_title( $queue_post_id );
+										$queue_url     = wp_make_link_relative( get_permalink( $queue_post_id ) );
+										$queue_status  = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_STATUS, true );
+										$queue_message = get_post_meta( $queue_post_id, Extension_AiCrawler_Markdown::META_ERROR_MESSAGE, true );
+										?>
+										<tr>
+												<td><?php echo esc_html( $queue_post_id ); ?></td>
+												<td><?php echo esc_html( $queue_title ); ?></td>
+												<td><?php echo esc_html( $queue_url ); ?></td>
+												<td><?php echo esc_html( $queue_status ); ?></td>
+												<td><?php echo esc_html( $queue_message ); ?></td>
+										</tr>
+								<?php endforeach; ?>
+						<?php else : ?>
+								<tr>
+										<td colspan="5"><?php esc_html_e( 'No items found.', 'w3-total-cache' ); ?></td>
+								</tr>
+						<?php endif; ?>
+				</tbody>
+		</table>
+		<?php if ( $queue_pages > 1 ) : ?>
+				<div class="tablenav">
+						<div class="tablenav-pages">
+								<?php
+								echo wp_kses_post(
+									paginate_links(
+										array(
+											'base'      => add_query_arg( 'queue_page', '%#%' ),
+											'format'    => '',
+											'current'   => $queue_paged,
+											'total'     => $queue_pages,
+											'prev_text' => '&laquo;',
+											'next_text' => '&raquo;',
+										)
+									)
+								);
+								?>
+						</div>
+				</div>
+		<?php endif; ?>
+		<?php Util_Ui::postbox_footer(); ?>
+</div>


### PR DESCRIPTION
## Summary
- track AI Crawler processing errors in new post meta field
- expose queue breakdown and paginated table in new Queue section
- wire Queue section into AI Crawler extension page

## Testing
- `vendor/bin/phpcs Extension_AiCrawler_Markdown.php Extension_AiCrawler_Page_View_Queue.php Extension_AiCrawler_Page_View.php`
- `php -l Extension_AiCrawler_Markdown.php Extension_AiCrawler_Page_View_Queue.php Extension_AiCrawler_Page_View.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_b_68a61606b56c83289b5cded0a43c55d6