### PR TITLE
Optimize WP_Query and fix filter return

### DIFF
--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -325,7 +325,7 @@ class Extension_ImageService_Plugin_Admin {
 	 *
 	 * @link https://developer.wordpress.org/reference/classes/wp_query/
 	 *
-	 * @return WP_Query Post IDs (due to the "fields" argument with value "ids").
+	 * @return WP_Query WP_Query object containing post IDs in the posts property (due to the "fields" argument with value "ids").
 	 */
 	public static function get_eligible_attachments(): \WP_Query {
 		return new \WP_Query(

--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -296,7 +296,7 @@ class Extension_ImageService_Plugin_Admin {
 	 *
 	 * @link https://developer.wordpress.org/reference/classes/wp_query/
 	 *
-	 * @return WP_Query Post IDs (due to the "fields" argument with value "ids").
+	 * @return WP_Query WP_Query object containing post IDs in the posts property (due to the "fields" argument with value "ids").
 	 */
 	public static function get_imageservice_attachments(): \WP_Query {
 		return new \WP_Query(


### PR DESCRIPTION
This update fixes a filter callback return and optimizes the WP_Query calls (reduced object contents; post IDs, since we only need the IDs).

To test:
1. Enable the WebP Converted extension
2. Start tailing your error log
3. Add some images to the Media Library
4. Go to the "Total Cache WebP Converter" page (`wp-admin/upload.php?page=w3tc_extension_page_imageservice`)
5. Click "Revert All"
6. Watch the counts update
8. Click "Convert All"
9. Watch the counts update
10. Go to the Media Library and see that the images have been converted
