### PR TITLE
Fix markdown permalinks for AI Crawler

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -190,7 +190,7 @@ class Extension_AiCrawler_Markdown {
 			}
 
 			$markdown     = $response['data']['markdown_content'];
-			$markdown_url = add_query_arg( array( 'w3tc_aicrawler_markdown' => $post_id ), home_url( '/' ) );
+			$markdown_url = Extension_AiCrawler_Markdown_Server::get_markdown_url( $post_id );
 
 			update_post_meta( $post_id, self::META_MARKDOWN, $markdown );
 			update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );

--- a/Extension_AiCrawler_Markdown_Server.php
+++ b/Extension_AiCrawler_Markdown_Server.php
@@ -66,18 +66,19 @@ class Extension_AiCrawler_Markdown_Server {
 	 */
 	public static function maybe_serve_markdown() {
 		$flag = get_query_var( 'w3tc_aicrawler_markdown' );
-
-		if ( '' === $flag ) {
-			return;
-		}
+		error_log( 'Serving markdown for flag: ' . $flag );
 
 		$post_id = 0;
 
 		if ( is_numeric( $flag ) ) {
 			$post_id = (int) $flag;
 		} else {
-			$path = ltrim( (string) $flag, '/' ); // phpcs:ignore Generic.Formatting.MultipleStatementAlignment.NotSameWarning
-			$post_id = url_to_postid( home_url( user_trailingslashit( $path ) ) );
+			// Get the current URI.
+			$current_uri = untrailingslashit( home_url( add_query_arg( array() ) ) );
+			// Remove the '.md' suffix.
+			$current_uri = preg_replace( '/\.md$/', '', $current_uri );
+			// Find the post ID by matching the permalink structure.
+			$post_id = url_to_postid( $current_uri );
 		}
 
 		if ( ! $post_id ) {


### PR DESCRIPTION
## Summary
- fix markdown server to resolve post IDs when using pretty permalinks

## Testing
- `vendor/bin/phpcs Extension_AiCrawler_Markdown_Server.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*

------
https://chatgpt.com/codex/tasks/task_b_68a774b84468832899613a54d8a8c72b