### PR TITLE
Refresh markdown URLs when permalink changes

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -68,8 +68,9 @@ class Extension_AiCrawler_Markdown {
 	 * @return void
 	 */
 	public static function init() {
-		add_action( self::CRON_HOOK, array( __CLASS__, 'process_queue' ) );
-		add_filter( 'cron_schedules', array( __CLASS__, 'add_schedule' ) );
+				add_action( self::CRON_HOOK, array( __CLASS__, 'process_queue' ) );
+				add_filter( 'cron_schedules', array( __CLASS__, 'add_schedule' ) );
+				add_action( 'update_option_permalink_structure', array( __CLASS__, 'refresh_markdown_urls' ), 10, 0 );
 
 		if ( self::queue_has_items() ) {
 			self::schedule_cron();
@@ -121,12 +122,45 @@ class Extension_AiCrawler_Markdown {
 	 */
 	public static function add_schedule( array $schedules = array() ) {
 		if ( ! isset( $schedules['ten_seconds'] ) ) {
-			$schedules['ten_seconds'] = array(
-				'interval' => 10,
-				'display'  => esc_html__( 'Every Ten Seconds', 'w3-total-cache' ),
-			);
+				$schedules['ten_seconds'] = array(
+					'interval' => 10,
+					'display'  => esc_html__( 'Every Ten Seconds', 'w3-total-cache' ),
+				);
 		}
-		return $schedules;
+			return $schedules;
+	}
+
+		/**
+		 * Regenerate stored markdown URLs when permalink structure changes.
+		 *
+		 * @since X.X.X
+		 *
+		 * @return void
+		 */
+	public static function refresh_markdown_urls() {
+			$query = new \WP_Query(
+				array(
+					'post_type'      => 'any',
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'meta_query'     => array(
+						array(
+							'key'     => self::META_MARKDOWN_URL,
+							'compare' => 'EXISTS',
+						),
+					),
+				)
+			);
+
+		if ( empty( $query->posts ) ) {
+				return;
+		}
+
+		foreach ( $query->posts as $post_id ) {
+				$markdown_url = Extension_AiCrawler_Markdown_Server::get_markdown_url( $post_id );
+				update_post_meta( $post_id, self::META_MARKDOWN_URL, $markdown_url );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- regenerate stored markdown URLs when permalink structure changes
- hook into permalink option updates

## Testing
- `vendor/bin/phpcs Extension_AiCrawler_Markdown.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*


------
https://chatgpt.com/codex/tasks/task_b_68a7793b5d208328af88f9a029678857