### PR TITLE
Refactor AI Crawler queue retrieval

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -165,6 +165,8 @@ class Extension_AiCrawler_Markdown {
 		update_post_meta( $post_id, self::META_STATUS, 'queued' );
 		update_post_meta( $post_id, self::META_SOURCE_URL, $url );
 		delete_post_meta( $post_id, self::META_ERROR_MESSAGE );
+		// Update the timestamp when added to the queue.
+		update_post_meta( $post_id, self::META_TIMESTAMP, time() );
 
 		self::schedule_cron();
 

--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -268,29 +268,20 @@ class Extension_AiCrawler_Markdown {
 	 *
 	 * @since X.X.X
 	 *
+	 * @param array $queue_items Queue item IDs.
+	 *
 	 * @return array
 	 */
-	public static function get_status_counts() {
+	public static function get_status_counts( $queue_items ) {
 		$statuses = array( 'queued', 'processing', 'complete', 'error' );
-		$counts   = array();
+		$counts   = array_fill_keys( $statuses, 0 );
 
-		foreach ( $statuses as $status ) {
-			$q = new \WP_Query(
-				array(
-					'post_type'      => 'any',
-					'posts_per_page' => -1,
-					'post_status'    => 'any',
-					'fields'         => 'ids',
-					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery
-						array(
-							'key'   => self::META_STATUS,
-							'value' => $status,
-						),
-					),
-				)
-			);
+		foreach ( $queue_items as $item_id ) {
+			$status = get_post_meta( $item_id, self::META_STATUS, true );
 
-			$counts[ $status ] = ! empty( $q->posts ) ? count( $q->posts ) : 0;
+			if ( isset( $counts[ $status ] ) ) {
+				++$counts[ $status ];
+			}
 		}
 
 		$counts['total'] = array_sum( $counts );
@@ -298,27 +289,23 @@ class Extension_AiCrawler_Markdown {
 		return $counts;
 	}
 
-		/**
-		 * Get queue items with pagination.
-		 *
-		 * @since X.X.X
-		 *
-		 * @param int $paged    Page number.
-		 * @param int $per_page Items per page.
-		 *
-		 * @return array
-		 */
-	public static function get_queue_items( $paged = 1, $per_page = 20 ) {
+	/**
+	 * Get all queue items.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array
+	 */
+	public static function get_queue_items() {
 		$query = new \WP_Query(
 			array(
 				'post_type'              => 'any',
 				'post_status'            => 'any',
-				'posts_per_page'         => $per_page,
-				'paged'                  => $paged,
+				'posts_per_page'         => -1,
 
 				// Only return IDs (faster).
 				'fields'                 => 'ids',
-				'update_post_meta_cache' => false,
+				'update_post_meta_cache' => true,
 				'update_post_term_cache' => false,
 				'ignore_sticky_posts'    => true,
 
@@ -331,10 +318,7 @@ class Extension_AiCrawler_Markdown {
 			)
 		);
 
-		return array(
-			'items' => ! empty( $query->posts ) ? $query->posts : array(),
-			'total' => (int) $query->found_posts,
-		);
+		return ! empty( $query->posts ) ? $query->posts : array();
 	}
 
 	/**

--- a/Extension_AiCrawler_Page_View_Queue.php
+++ b/Extension_AiCrawler_Page_View_Queue.php
@@ -14,16 +14,16 @@ if ( ! defined( 'W3TC' ) ) {
 		die();
 }
 
-$counts         = Extension_AiCrawler_Markdown::get_status_counts();
+$queue_items    = Extension_AiCrawler_Markdown::get_queue_items();
+$counts         = Extension_AiCrawler_Markdown::get_status_counts( $queue_items );
 $queue_paged    = isset( $_GET['queue_page'] ) ? absint( $_GET['queue_page'] ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $queue_per_page = 20;
-$queue_items    = Extension_AiCrawler_Markdown::get_queue_items( $queue_paged, $queue_per_page );
-$queue_posts    = $queue_items['items'];
-$queue_total    = $queue_items['total'];
+$queue_total    = count( $queue_items );
+$queue_posts    = array_slice( $queue_items, ( $queue_paged - 1 ) * $queue_per_page, $queue_per_page );
 $queue_pages    = max( 1, ceil( $queue_total / $queue_per_page ) );
 
 // Get the formatted timestamp of the last run queue item, which will be the first item in the $queue_items array.
-$last_run_timestamp = ! empty( $queue_posts ) ? get_post_meta( reset( $queue_posts ), Extension_AiCrawler_Markdown::META_TIMESTAMP, true ) : 0;
+$last_run_timestamp = ! empty( $queue_items ) ? get_post_meta( reset( $queue_items ), Extension_AiCrawler_Markdown::META_TIMESTAMP, true ) : 0;
 $last_run_formatted = $last_run_timestamp ? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_run_timestamp ) : __( 'Never', 'w3-total-cache' );
 ?>
 <div class="metabox-holder">

--- a/Extension_AiCrawler_Page_View_Queue.php
+++ b/Extension_AiCrawler_Page_View_Queue.php
@@ -17,7 +17,7 @@ if ( ! defined( 'W3TC' ) ) {
 $queue_items    = Extension_AiCrawler_Markdown::get_queue_items();
 $counts         = Extension_AiCrawler_Markdown::get_status_counts( $queue_items );
 $queue_paged    = isset( $_GET['queue_page'] ) ? absint( $_GET['queue_page'] ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$queue_per_page = 20;
+$queue_per_page = 10;
 $queue_total    = count( $queue_items );
 $queue_posts    = array_slice( $queue_items, ( $queue_paged - 1 ) * $queue_per_page, $queue_per_page );
 $queue_pages    = max( 1, ceil( $queue_total / $queue_per_page ) );


### PR DESCRIPTION
## Summary
- avoid redundant queries by letting `get_queue_items` fetch all items without pagination
- compute status tallies from a provided item list via updated `get_status_counts`
- paginate queue items in the view after counting

## Testing
- `vendor/bin/phpcs Extension_AiCrawler_Markdown.php Extension_AiCrawler_Page_View_Queue.php`
- `vendor/bin/phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ba3619f483289cb1639c97a50478