### PR TITLE
Improve pagination styling and behavior

### DIFF
--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -206,8 +206,9 @@ class Extension_AiCrawler_Markdown {
 
 			if ( empty( $response['success'] ) || empty( $response['data']['markdown_content'] ) ) {
 				update_post_meta( $post_id, self::META_STATUS, 'error' );
+				$code    = ! empty( $response['error']['code'] ) ? $response['error']['code'] : '';
 				$message = ! empty( $response['error']['message'] ) ? $response['error']['message'] : __( 'Unknown error.', 'w3-total-cache' );
-				update_post_meta( $post_id, self::META_ERROR_MESSAGE, $message );
+				update_post_meta( $post_id, self::META_ERROR_MESSAGE, sprintf( __( 'Error %s: %s', 'w3-total-cache' ), esc_html( $code ), esc_html( $message ) ) );
 				continue;
 			}
 

--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -208,7 +208,16 @@ class Extension_AiCrawler_Markdown {
 				update_post_meta( $post_id, self::META_STATUS, 'error' );
 				$code    = ! empty( $response['error']['code'] ) ? $response['error']['code'] : '';
 				$message = ! empty( $response['error']['message'] ) ? $response['error']['message'] : __( 'Unknown error.', 'w3-total-cache' );
-				update_post_meta( $post_id, self::META_ERROR_MESSAGE, sprintf( __( 'Error %s: %s', 'w3-total-cache' ), esc_html( $code ), esc_html( $message ) ) );
+				update_post_meta(
+					$post_id,
+					self::META_ERROR_MESSAGE,
+					sprintf(
+						// translators: 1%s$s: error code, %2$s: error message.
+						__( 'Error %1$s: %2$s', 'w3-total-cache' ),
+						esc_html( $code ),
+						esc_html( $message )
+					)
+				);
 				continue;
 			}
 

--- a/Extension_AiCrawler_Markdown.php
+++ b/Extension_AiCrawler_Markdown.php
@@ -212,7 +212,7 @@ class Extension_AiCrawler_Markdown {
 					$post_id,
 					self::META_ERROR_MESSAGE,
 					sprintf(
-						// translators: 1%s$s: error code, %2$s: error message.
+						// translators: 1%$s: error code, %2$s: error message.
 						__( 'Error %1$s: %2$s', 'w3-total-cache' ),
 						esc_html( $code ),
 						esc_html( $message )

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -388,6 +388,7 @@ class Generic_Plugin_Admin {
 		wp_register_script( 'w3tc-lightbox', plugins_url( 'pub/js/lightbox.js', W3TC_FILE ), array(), W3TC_VERSION, false );
 		wp_register_script( 'w3tc-widget', plugins_url( 'pub/js/widget.js', W3TC_FILE ), array(), W3TC_VERSION, false );
 		wp_register_script( 'w3tc-jquery-masonry', plugins_url( 'pub/js/jquery.masonry.min.js', W3TC_FILE ), array( 'jquery' ), W3TC_VERSION, false );
+		wp_register_script( 'w3tc-pagination', plugins_url( 'pub/js/pagination.js', W3TC_FILE ), array( 'jquery' ), W3TC_VERSION, true );
 
 		// New feature count for the Feature Showcase.
 		wp_register_script( 'w3tc-feature-counter', plugins_url( 'pub/js/feature-counter.js', W3TC_FILE ), array(), W3TC_VERSION, true );
@@ -684,6 +685,7 @@ class Generic_Plugin_Admin {
 		wp_enqueue_script( 'w3tc-metadata' );
 		wp_enqueue_script( 'w3tc-options' );
 		wp_enqueue_script( 'w3tc-lightbox' );
+		wp_enqueue_script( 'w3tc-pagination' );
 
 		if ( $this->is_w3tc_page ) {
 			wp_localize_script(

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -1893,7 +1893,10 @@ td .w3tc-control-after span {
                 padding: 0 5px;
         }
 }
-
+#w3tc-aicrawler-settings .tablenav {
+	display: flex;
+	justify-content: center;
+}
 /* Pagination styling */
 .tablenav-pages {
 	float: none;

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -1883,13 +1883,40 @@ td .w3tc-control-after span {
 }
 
 @media ( max-width: 600px) {
-	#w3tc-top-nav-bar {
-		top: 0px;
-	}
+        #w3tc-top-nav-bar {
+                top: 0px;
+        }
 
-	#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links>a,
-	#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links>input,
-	#w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links .w3tc-top-nav-dropdown>a {
-		padding: 0 5px;
-	}
+        #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links>a,
+        #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links>input,
+        #w3tc-top-nav-bar #w3tc-top-nav-bar-content #w3tc-top-nav-bar-content-links .w3tc-top-nav-dropdown>a {
+                padding: 0 5px;
+        }
+}
+
+/* Pagination styling */
+.tablenav-pages {
+	float: none;
+	text-align: center;
+	margin-top: 10px;
+}
+
+.tablenav-pages .page-numbers {
+	display: inline-block;
+	padding: 4px 8px;
+	margin: 0 2px;
+	border: 1px solid #ccd0d4;
+	background: #fff;
+	border-radius: 3px;
+	text-decoration: none;
+}
+
+.tablenav-pages .page-numbers:hover {
+	background: #f1f1f1;
+}
+
+.tablenav-pages .page-numbers.current {
+	background: #007cba;
+	border-color: #007cba;
+	color: #fff;
 }

--- a/pub/js/pagination.js
+++ b/pub/js/pagination.js
@@ -1,0 +1,16 @@
+jQuery( function( $ ) {
+	var scrollKey = 'w3tc-pagination-scroll';
+
+	var stored = sessionStorage.getItem( scrollKey );
+	if ( stored ) {
+		var pos = parseInt( stored, 10 );
+		if ( ! isNaN( pos ) ) {
+			window.scrollTo( 0, pos );
+		}
+		sessionStorage.removeItem( scrollKey );
+	}
+
+	$( document ).on( 'click', '.tablenav-pages a', function() {
+		sessionStorage.setItem( scrollKey, $( window ).scrollTop() );
+	} );
+} );


### PR DESCRIPTION
## Summary
- center and style admin pagination links as buttons
- load new script to remember scroll position when changing pages

## Testing
- `./vendor/bin/phpcs Generic_Plugin_Admin.php`
- `./vendor/bin/phpunit` *(fails: require_once(/tmp/wordpress-tests-lib/includes/functions.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a8c0976f948328a0bb099a5c00eff6