### PR TITLE
feat: add regenerate all support

### DIFF
--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -9,154 +9,185 @@
  */
 
 document.addEventListener("DOMContentLoaded", function () {
-	const testTokenButton      = document.getElementById('w3tc-aicrawler-test-ctoken-button');
-	const regenerateUrlButton  = document.getElementById('w3tc-aicrawler-regenerate-url-button');
-	const regenerateUrlInput   = document.getElementById('w3tc-aicrawler-regenerate-url');
-	const regenerateUrlMessage = document.getElementById('w3tc-aicrawler-regenerate-url-message');
-	const regenerateAllButton  = document.getElementById('w3tc-aicrawler-regenerate-all-button');
+  const testTokenButton = document.getElementById(
+    "w3tc-aicrawler-test-ctoken-button",
+  );
+  const regenerateUrlButton = document.getElementById(
+    "w3tc-aicrawler-regenerate-url-button",
+  );
+  const regenerateUrlInput = document.getElementById(
+    "w3tc-aicrawler-regenerate-url",
+  );
+  const regenerateUrlMessage = document.getElementById(
+    "w3tc-aicrawler-regenerate-url-message",
+  );
+  const regenerateAllButton = document.getElementById(
+    "w3tc-aicrawler-regenerate-all-button",
+  );
+  const regenerateAllMessage = document.getElementById(
+    "w3tc-aicrawler-regenerate-all-message",
+  );
 
-	if (testTokenButton) {
-		// Add a click event listener to the button.
-		testTokenButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent the default button behavior.
+  if (testTokenButton) {
+    // Add a click event listener to the button.
+    testTokenButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent the default button behavior.
 
-			// Display a loading message or spinner (optional).
-			testTokenButton.textContent = w3tcData.lang.testing;
+      // Display a loading message or spinner (optional).
+      testTokenButton.textContent = w3tcData.lang.testing;
 
-			// Example AJAX request to test the token.
-			fetch(ajaxurl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
-					action: 'test_aicrawler_token', // WordPress AJAX action.
-					token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
-				}),
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					if (data.success) {
-						alert(w3tcData.lang.tokenValid);
-					} else {
-						alert(w3tcData.lang.tokenInvalid);
-					}
-				})
-				.catch((error) => {
-					console.error(w3tcData.lang.error + ':', error);
-					alert(w3tcData.lang.tokenError + '.');
-				})
-				.finally(() => {
-					// Reset the button text.
-					testTokenButton.textContent = w3tcData.lang.test;
-				});
-		});
-	}
+      // Example AJAX request to test the token.
+      fetch(ajaxurl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          _wpnonce: w3tcData.nonces.testToken, // Nonce for security.
+          action: "test_aicrawler_token", // WordPress AJAX action.
+          token: document.getElementById("aicrawler___imh_central_token").value, // InMotion Central token to be tested.
+        }),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          if (data.success) {
+            alert(w3tcData.lang.tokenValid);
+          } else {
+            alert(w3tcData.lang.tokenInvalid);
+          }
+        })
+        .catch((error) => {
+          console.error(w3tcData.lang.error + ":", error);
+          alert(w3tcData.lang.tokenError + ".");
+        })
+        .finally(() => {
+          // Reset the button text.
+          testTokenButton.textContent = w3tcData.lang.test;
+        });
+    });
+  }
 
-	// Handle the "Regenerate URL" button click.
-	if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
-		regenerateUrlButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent default button behavior.
+  // Handle the "Regenerate URL" button click.
+  if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
+    regenerateUrlButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent default button behavior.
 
-			const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
+      const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
 
-			regenerateUrlMessage.textContent = '';
-			regenerateUrlMessage.classList.remove(
-				'w3tc-aicrawler-message-success',
-				'w3tc-aicrawler-message-error',
-			);
+      regenerateUrlMessage.textContent = "";
+      regenerateUrlMessage.classList.remove(
+        "w3tc-aicrawler-message-success",
+        "w3tc-aicrawler-message-error",
+      );
 
-			if (!url) {
-				regenerateUrlMessage.textContent = w3tcData.lang.noUrl + '.';
-				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
-				return;
-			}
+      if (!url) {
+        regenerateUrlMessage.textContent = w3tcData.lang.noUrl + ".";
+        regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+        return;
+      }
 
-			// Display a loading message or spinner (optional).
-			regenerateUrlButton.textContent = w3tcData.lang.regenerating + '...';
+      // Display a loading message or spinner (optional).
+      regenerateUrlButton.textContent = w3tcData.lang.regenerating + "...";
 
-			const params = new URLSearchParams();
-			params.append("url", url);
-			params.append("_wpnonce", w3tcData.nonces.regenerateUrl); // Nonce for security.
+      const params = new URLSearchParams();
+      params.append("url", url);
+      params.append("_wpnonce", w3tcData.nonces.regenerateUrl); // Nonce for security.
 
-			// AJAX request to regenerate the specified URL.
-			fetch(ajaxurl + '?action=w3tc_aicrawler_regenerate_url', {
-				method: 'POST',
-				body: params,
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					regenerateUrlMessage.textContent = '';
-					regenerateUrlMessage.classList.remove(
-						'w3tc-aicrawler-message-success',
-						'w3tc-aicrawler-message-error',
-					);
+      // AJAX request to regenerate the specified URL.
+      fetch(ajaxurl + "?action=w3tc_aicrawler_regenerate_url", {
+        method: "POST",
+        body: params,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          regenerateUrlMessage.textContent = "";
+          regenerateUrlMessage.classList.remove(
+            "w3tc-aicrawler-message-success",
+            "w3tc-aicrawler-message-error",
+          );
 
-					if (data.success) {
-						regenerateUrlMessage.textContent = data.data.message;
-						regenerateUrlMessage.classList.add(
-							'w3tc-aicrawler-message-success',
-						);
-					} else {
-						regenerateUrlMessage.textContent =
-						data.data && data.data.message
-							? data.data.message
-							: w3tcData.lang.regenerateUrlFailed + '.';
-						regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
-					}
-				})
-				.catch((error) => {
-					console.error('Error:', error);
-					regenerateUrlMessage.textContent =
-						w3tcData.lang.regenerateUrlError + '.';
-					regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
-				})
-				.finally(() => {
-					// Reset the button text.
-					regenerateUrlButton.textContent = w3tcData.lang.regenerate;
-				});
-		});
-	}
+          if (data.success) {
+            regenerateUrlMessage.textContent = data.data.message;
+            regenerateUrlMessage.classList.add(
+              "w3tc-aicrawler-message-success",
+            );
+          } else {
+            regenerateUrlMessage.textContent =
+              data.data && data.data.message
+                ? data.data.message
+                : w3tcData.lang.regenerateUrlFailed + ".";
+            regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          regenerateUrlMessage.textContent =
+            w3tcData.lang.regenerateUrlError + ".";
+          regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
+        })
+        .finally(() => {
+          // Reset the button text.
+          regenerateUrlButton.textContent = w3tcData.lang.regenerate;
+        });
+    });
+  }
 
-	// Handle the "Regenerate All" button click.
-	if (regenerateAllButton) {
-		regenerateAllButton.addEventListener('click', function (event) {
-			event.preventDefault(); // Prevent default button behavior.
+  // Handle the "Regenerate All" button click.
+  if (regenerateAllButton && regenerateAllMessage) {
+    regenerateAllButton.addEventListener("click", function (event) {
+      event.preventDefault(); // Prevent default button behavior.
 
-			// Display a loading message or spinner (optional).
-			regenerateAllButton.textContent = w3tcData.lang.regenerating + '...';
+      regenerateAllMessage.textContent = "";
+      regenerateAllMessage.classList.remove(
+        "w3tc-aicrawler-message-success",
+        "w3tc-aicrawler-message-error",
+      );
 
-			// Example AJAX request to regenerate all URLs.
-			fetch(ajaxurl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({
-					_wpnonce: w3tcData.nonces.regenerateAll, // Nonce for security.
-					action: 'regenerate_aicrawler_all', // WordPress AJAX action.
-				}),
-			})
-				.then((response) => response.json())
-				.then((data) => {
-					// Handle the response from the server.
-					if (data.success) {
-						alert(w3tcData.lang.regenerateAll + '.');
-					} else {
-						alert(w3tcData.lang.regenerateAllFailed + '.');
-					}
-				})
-				.catch((error) => {
-					console.error('Error:', error);
-					alert(w3tcData.lang.regenerateAllError + '.');
-				})
-				.finally(() => {
-					// Reset the button text.
-					regenerateAllButton.textContent = w3tcData.lang.regenerate;
-				});
-		});
-	}
+      // Display a loading message or spinner (optional).
+      regenerateAllButton.textContent = w3tcData.lang.regenerating + "...";
+
+      const params = new URLSearchParams();
+      params.append("_wpnonce", w3tcData.nonces.regenerateAll);
+
+      // AJAX request to regenerate all URLs.
+      fetch(ajaxurl + "?action=w3tc_aicrawler_regenerate_all", {
+        method: "POST",
+        body: params,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          // Handle the response from the server.
+          regenerateAllMessage.textContent = "";
+          regenerateAllMessage.classList.remove(
+            "w3tc-aicrawler-message-success",
+            "w3tc-aicrawler-message-error",
+          );
+
+          if (data.success) {
+            regenerateAllMessage.textContent = data.data.message;
+            regenerateAllMessage.classList.add(
+              "w3tc-aicrawler-message-success",
+            );
+          } else {
+            regenerateAllMessage.textContent =
+              data.data && data.data.message
+                ? data.data.message
+                : w3tcData.lang.regenerateAllFailed + ".";
+            regenerateAllMessage.classList.add("w3tc-aicrawler-message-error");
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          regenerateAllMessage.textContent =
+            w3tcData.lang.regenerateAllError + ".";
+          regenerateAllMessage.classList.add("w3tc-aicrawler-message-error");
+        })
+        .finally(() => {
+          // Reset the button text.
+          regenerateAllButton.textContent = w3tcData.lang.regenerate;
+        });
+    });
+  }
 });

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -9,185 +9,173 @@
  */
 
 document.addEventListener("DOMContentLoaded", function () {
-  const testTokenButton = document.getElementById(
-    "w3tc-aicrawler-test-ctoken-button",
-  );
-  const regenerateUrlButton = document.getElementById(
-    "w3tc-aicrawler-regenerate-url-button",
-  );
-  const regenerateUrlInput = document.getElementById(
-    "w3tc-aicrawler-regenerate-url",
-  );
-  const regenerateUrlMessage = document.getElementById(
-    "w3tc-aicrawler-regenerate-url-message",
-  );
-  const regenerateAllButton = document.getElementById(
-    "w3tc-aicrawler-regenerate-all-button",
-  );
-  const regenerateAllMessage = document.getElementById(
-    "w3tc-aicrawler-regenerate-all-message",
-  );
+	const testTokenButton      = document.getElementById('w3tc-aicrawler-test-ctoken-button');
+	const regenerateUrlButton  = document.getElementById('w3tc-aicrawler-regenerate-url-button');
+	const regenerateUrlInput   = document.getElementById('w3tc-aicrawler-regenerate-url');
+	const regenerateUrlMessage = document.getElementById('w3tc-aicrawler-regenerate-url-message');
+	const regenerateAllButton  = document.getElementById('w3tc-aicrawler-regenerate-all-button');
+	const regenerateAllMessage = document.getElementById('w3tc-aicrawler-regenerate-all-message');
 
-  if (testTokenButton) {
-    // Add a click event listener to the button.
-    testTokenButton.addEventListener("click", function (event) {
-      event.preventDefault(); // Prevent the default button behavior.
+	if (testTokenButton) {
+	// Add a click event listener to the button.
+	testTokenButton.addEventListener('click', function (event) {
+		event.preventDefault(); // Prevent the default button behavior.
 
-      // Display a loading message or spinner (optional).
-      testTokenButton.textContent = w3tcData.lang.testing;
+		// Display a loading message or spinner (optional).
+		testTokenButton.textContent = w3tcData.lang.testing;
 
-      // Example AJAX request to test the token.
-      fetch(ajaxurl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          _wpnonce: w3tcData.nonces.testToken, // Nonce for security.
-          action: "test_aicrawler_token", // WordPress AJAX action.
-          token: document.getElementById("aicrawler___imh_central_token").value, // InMotion Central token to be tested.
-        }),
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          // Handle the response from the server.
-          if (data.success) {
-            alert(w3tcData.lang.tokenValid);
-          } else {
-            alert(w3tcData.lang.tokenInvalid);
-          }
-        })
-        .catch((error) => {
-          console.error(w3tcData.lang.error + ":", error);
-          alert(w3tcData.lang.tokenError + ".");
-        })
-        .finally(() => {
-          // Reset the button text.
-          testTokenButton.textContent = w3tcData.lang.test;
-        });
-    });
-  }
+		// Example AJAX request to test the token.
+		fetch(ajaxurl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
+			action: 'test_aicrawler_token', // WordPress AJAX action.
+			token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
+		}),
+		})
+		.then((response) => response.json())
+		.then((data) => {
+			// Handle the response from the server.
+			if (data.success) {
+			alert(w3tcData.lang.tokenValid);
+			} else {
+			alert(w3tcData.lang.tokenInvalid);
+			}
+		})
+		.catch((error) => {
+			console.error(w3tcData.lang.error + ':', error);
+			alert(w3tcData.lang.tokenError + '.');
+		})
+		.finally(() => {
+			// Reset the button text.
+			testTokenButton.textContent = w3tcData.lang.test;
+		});
+	});
+	}
 
-  // Handle the "Regenerate URL" button click.
-  if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
-    regenerateUrlButton.addEventListener("click", function (event) {
-      event.preventDefault(); // Prevent default button behavior.
+	// Handle the 'Regenerate URL' button click.
+	if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
+		regenerateUrlButton.addEventListener('click', function (event) {
+			event.preventDefault(); // Prevent default button behavior.
 
-      const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
+			const url = regenerateUrlInput.value.trim(); // Get the URL from the input field.
 
-      regenerateUrlMessage.textContent = "";
-      regenerateUrlMessage.classList.remove(
-        "w3tc-aicrawler-message-success",
-        "w3tc-aicrawler-message-error",
-      );
+			regenerateUrlMessage.textContent = '';
+			regenerateUrlMessage.classList.remove(
+				'w3tc-aicrawler-message-success',
+				'w3tc-aicrawler-message-error',
+			);
 
-      if (!url) {
-        regenerateUrlMessage.textContent = w3tcData.lang.noUrl + ".";
-        regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
-        return;
-      }
+			if (!url) {
+				regenerateUrlMessage.textContent = w3tcData.lang.noUrl + '.';
+				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+				return;
+			}
 
-      // Display a loading message or spinner (optional).
-      regenerateUrlButton.textContent = w3tcData.lang.regenerating + "...";
+			// Display a loading message or spinner (optional).
+			regenerateUrlButton.textContent = w3tcData.lang.regenerating + '...';
 
-      const params = new URLSearchParams();
-      params.append("url", url);
-      params.append("_wpnonce", w3tcData.nonces.regenerateUrl); // Nonce for security.
+			const params = new URLSearchParams();
+			params.append('url', url);
+			params.append('_wpnonce', w3tcData.nonces.regenerateUrl); // Nonce for security.
 
-      // AJAX request to regenerate the specified URL.
-      fetch(ajaxurl + "?action=w3tc_aicrawler_regenerate_url", {
-        method: "POST",
-        body: params,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          // Handle the response from the server.
-          regenerateUrlMessage.textContent = "";
-          regenerateUrlMessage.classList.remove(
-            "w3tc-aicrawler-message-success",
-            "w3tc-aicrawler-message-error",
-          );
+			// AJAX request to regenerate the specified URL.
+			fetch(ajaxurl + '?action=w3tc_aicrawler_regenerate_url', {
+				method: 'POST',
+				body: params,
+			})
+			.then((response) => response.json())
+			.then((data) => {
+				// Handle the response from the server.
+				regenerateUrlMessage.textContent = '';
+				regenerateUrlMessage.classList.remove(
+					'w3tc-aicrawler-message-success',
+					'w3tc-aicrawler-message-error',
+				);
 
-          if (data.success) {
-            regenerateUrlMessage.textContent = data.data.message;
-            regenerateUrlMessage.classList.add(
-              "w3tc-aicrawler-message-success",
-            );
-          } else {
-            regenerateUrlMessage.textContent =
-              data.data && data.data.message
-                ? data.data.message
-                : w3tcData.lang.regenerateUrlFailed + ".";
-            regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          regenerateUrlMessage.textContent =
-            w3tcData.lang.regenerateUrlError + ".";
-          regenerateUrlMessage.classList.add("w3tc-aicrawler-message-error");
-        })
-        .finally(() => {
-          // Reset the button text.
-          regenerateUrlButton.textContent = w3tcData.lang.regenerate;
-        });
-    });
-  }
+				if (data.success) {
+				regenerateUrlMessage.textContent = data.data.message;
+				regenerateUrlMessage.classList.add(
+					'w3tc-aicrawler-message-success',
+				);
+				} else {
+				regenerateUrlMessage.textContent =
+					data.data && data.data.message
+					? data.data.message
+					: w3tcData.lang.regenerateUrlFailed + '.';
+				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+				}
+			})
+			.catch((error) => {
+				console.error('Error:', error);
+				regenerateUrlMessage.textContent =
+				w3tcData.lang.regenerateUrlError + '.';
+				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+			})
+			.finally(() => {
+				// Reset the button text.
+				regenerateUrlButton.textContent = w3tcData.lang.regenerate;
+			});
+		});
+	}
 
-  // Handle the "Regenerate All" button click.
-  if (regenerateAllButton && regenerateAllMessage) {
-    regenerateAllButton.addEventListener("click", function (event) {
-      event.preventDefault(); // Prevent default button behavior.
+	// Handle the 'Regenerate All' button click.
+	if (regenerateAllButton && regenerateAllMessage) {
+		regenerateAllButton.addEventListener('click', function (event) {
+			event.preventDefault(); // Prevent default button behavior.
 
-      regenerateAllMessage.textContent = "";
-      regenerateAllMessage.classList.remove(
-        "w3tc-aicrawler-message-success",
-        "w3tc-aicrawler-message-error",
-      );
+			regenerateAllMessage.textContent = '';
+			regenerateAllMessage.classList.remove(
+				'w3tc-aicrawler-message-success',
+				'w3tc-aicrawler-message-error',
+			);
 
-      // Display a loading message or spinner (optional).
-      regenerateAllButton.textContent = w3tcData.lang.regenerating + "...";
+			// Display a loading message or spinner (optional).
+			regenerateAllButton.textContent = w3tcData.lang.regenerating + '...';
 
-      const params = new URLSearchParams();
-      params.append("_wpnonce", w3tcData.nonces.regenerateAll);
+			const params = new URLSearchParams();
+			params.append('_wpnonce', w3tcData.nonces.regenerateAll);
 
-      // AJAX request to regenerate all URLs.
-      fetch(ajaxurl + "?action=w3tc_aicrawler_regenerate_all", {
-        method: "POST",
-        body: params,
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          // Handle the response from the server.
-          regenerateAllMessage.textContent = "";
-          regenerateAllMessage.classList.remove(
-            "w3tc-aicrawler-message-success",
-            "w3tc-aicrawler-message-error",
-          );
+			// AJAX request to regenerate all URLs.
+			fetch(ajaxurl + '?action=w3tc_aicrawler_regenerate_all', {
+			method: 'POST',
+			body: params,
+			})
+			.then((response) => response.json())
+			.then((data) => {
+				// Handle the response from the server.
+				regenerateAllMessage.textContent = '';
+				regenerateAllMessage.classList.remove(
+					'w3tc-aicrawler-message-success',
+					'w3tc-aicrawler-message-error',
+				);
 
-          if (data.success) {
-            regenerateAllMessage.textContent = data.data.message;
-            regenerateAllMessage.classList.add(
-              "w3tc-aicrawler-message-success",
-            );
-          } else {
-            regenerateAllMessage.textContent =
-              data.data && data.data.message
-                ? data.data.message
-                : w3tcData.lang.regenerateAllFailed + ".";
-            regenerateAllMessage.classList.add("w3tc-aicrawler-message-error");
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          regenerateAllMessage.textContent =
-            w3tcData.lang.regenerateAllError + ".";
-          regenerateAllMessage.classList.add("w3tc-aicrawler-message-error");
-        })
-        .finally(() => {
-          // Reset the button text.
-          regenerateAllButton.textContent = w3tcData.lang.regenerate;
-        });
-    });
-  }
+				if (data.success) {
+					regenerateAllMessage.textContent = data.data.message;
+					regenerateAllMessage.classList.add(
+						'w3tc-aicrawler-message-success',
+					);
+				} else {
+					regenerateAllMessage.textContent =
+						data.data && data.data.message
+						? data.data.message
+						: w3tcData.lang.regenerateAllFailed + '.';
+					regenerateAllMessage.classList.add('w3tc-aicrawler-message-error');
+				}
+			})
+			.catch((error) => {
+				console.error('Error:', error);
+				regenerateAllMessage.textContent =
+				w3tcData.lang.regenerateAllError + '.';
+				regenerateAllMessage.classList.add('w3tc-aicrawler-message-error');
+			})
+			.finally(() => {
+				// Reset the button text.
+				regenerateAllButton.textContent = w3tcData.lang.regenerate;
+			});
+		});
+	}
 });

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -36,23 +36,23 @@ document.addEventListener("DOMContentLoaded", function () {
 					token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
 				}),
 			})
-			.then((response) => response.json())
-			.then((data) => {
-				// Handle the response from the server.
-				if (data.success) {
-				alert(w3tcData.lang.tokenValid);
-				} else {
-				alert(w3tcData.lang.tokenInvalid);
-				}
-			})
-			.catch((error) => {
-				console.error(w3tcData.lang.error + ':', error);
-				alert(w3tcData.lang.tokenError + '.');
-			})
-			.finally(() => {
-				// Reset the button text.
-				testTokenButton.textContent = w3tcData.lang.test;
-			});
+				.then((response) => response.json())
+				.then((data) => {
+					// Handle the response from the server.
+					if (data.success) {
+					alert(w3tcData.lang.tokenValid);
+					} else {
+					alert(w3tcData.lang.tokenInvalid);
+					}
+				})
+				.catch((error) => {
+					console.error(w3tcData.lang.error + ':', error);
+					alert(w3tcData.lang.tokenError + '.');
+				})
+				.finally(() => {
+					// Reset the button text.
+					testTokenButton.textContent = w3tcData.lang.test;
+				});
 		});
 	}
 

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -26,15 +26,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
 			// Example AJAX request to test the token.
 			fetch(ajaxurl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({
-				_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
-				action: 'test_aicrawler_token', // WordPress AJAX action.
-				token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
-			}),
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
+					action: 'test_aicrawler_token', // WordPress AJAX action.
+					token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
+				}),
 			})
 			.then((response) => response.json())
 			.then((data) => {

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -40,9 +40,9 @@ document.addEventListener("DOMContentLoaded", function () {
 				.then((data) => {
 					// Handle the response from the server.
 					if (data.success) {
-					alert(w3tcData.lang.tokenValid);
+						alert(w3tcData.lang.tokenValid);
 					} else {
-					alert(w3tcData.lang.tokenInvalid);
+						alert(w3tcData.lang.tokenInvalid);
 					}
 				})
 				.catch((error) => {
@@ -56,7 +56,7 @@ document.addEventListener("DOMContentLoaded", function () {
 		});
 	}
 
-	// Handle the 'Regenerate URL' button click.
+	// Handle the "Regenerate URL" button click.
 	if (regenerateUrlButton && regenerateUrlInput && regenerateUrlMessage) {
 		regenerateUrlButton.addEventListener('click', function (event) {
 			event.preventDefault(); // Prevent default button behavior.
@@ -79,46 +79,46 @@ document.addEventListener("DOMContentLoaded", function () {
 			regenerateUrlButton.textContent = w3tcData.lang.regenerating + '...';
 
 			const params = new URLSearchParams();
-			params.append('url', url);
-			params.append('_wpnonce', w3tcData.nonces.regenerateUrl); // Nonce for security.
+			params.append("url", url);
+			params.append("_wpnonce", w3tcData.nonces.regenerateUrl); // Nonce for security.
 
 			// AJAX request to regenerate the specified URL.
 			fetch(ajaxurl + '?action=w3tc_aicrawler_regenerate_url', {
 				method: 'POST',
 				body: params,
 			})
-			.then((response) => response.json())
-			.then((data) => {
-				// Handle the response from the server.
-				regenerateUrlMessage.textContent = '';
-				regenerateUrlMessage.classList.remove(
-					'w3tc-aicrawler-message-success',
-					'w3tc-aicrawler-message-error',
-				);
+				.then((response) => response.json())
+				.then((data) => {
+					// Handle the response from the server.
+					regenerateUrlMessage.textContent = '';
+					regenerateUrlMessage.classList.remove(
+						'w3tc-aicrawler-message-success',
+						'w3tc-aicrawler-message-error',
+					);
 
-				if (data.success) {
-				regenerateUrlMessage.textContent = data.data.message;
-				regenerateUrlMessage.classList.add(
-					'w3tc-aicrawler-message-success',
-				);
-				} else {
-				regenerateUrlMessage.textContent =
-					data.data && data.data.message
-					? data.data.message
-					: w3tcData.lang.regenerateUrlFailed + '.';
-				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
-				}
-			})
-			.catch((error) => {
-				console.error('Error:', error);
-				regenerateUrlMessage.textContent =
-				w3tcData.lang.regenerateUrlError + '.';
-				regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
-			})
-			.finally(() => {
-				// Reset the button text.
-				regenerateUrlButton.textContent = w3tcData.lang.regenerate;
-			});
+					if (data.success) {
+					regenerateUrlMessage.textContent = data.data.message;
+					regenerateUrlMessage.classList.add(
+						'w3tc-aicrawler-message-success',
+					);
+					} else {
+					regenerateUrlMessage.textContent =
+						data.data && data.data.message
+						? data.data.message
+						: w3tcData.lang.regenerateUrlFailed + '.';
+					regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+					}
+				})
+				.catch((error) => {
+					console.error('Error:', error);
+					regenerateUrlMessage.textContent =
+					w3tcData.lang.regenerateUrlError + '.';
+					regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+				})
+				.finally(() => {
+					// Reset the button text.
+					regenerateUrlButton.textContent = w3tcData.lang.regenerate;
+				});
 		});
 	}
 

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -17,43 +17,43 @@ document.addEventListener("DOMContentLoaded", function () {
 	const regenerateAllMessage = document.getElementById('w3tc-aicrawler-regenerate-all-message');
 
 	if (testTokenButton) {
-	// Add a click event listener to the button.
-	testTokenButton.addEventListener('click', function (event) {
-		event.preventDefault(); // Prevent the default button behavior.
+		// Add a click event listener to the button.
+		testTokenButton.addEventListener('click', function (event) {
+			event.preventDefault(); // Prevent the default button behavior.
 
-		// Display a loading message or spinner (optional).
-		testTokenButton.textContent = w3tcData.lang.testing;
+			// Display a loading message or spinner (optional).
+			testTokenButton.textContent = w3tcData.lang.testing;
 
-		// Example AJAX request to test the token.
-		fetch(ajaxurl, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({
-			_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
-			action: 'test_aicrawler_token', // WordPress AJAX action.
-			token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
-		}),
-		})
-		.then((response) => response.json())
-		.then((data) => {
-			// Handle the response from the server.
-			if (data.success) {
-			alert(w3tcData.lang.tokenValid);
-			} else {
-			alert(w3tcData.lang.tokenInvalid);
-			}
-		})
-		.catch((error) => {
-			console.error(w3tcData.lang.error + ':', error);
-			alert(w3tcData.lang.tokenError + '.');
-		})
-		.finally(() => {
-			// Reset the button text.
-			testTokenButton.textContent = w3tcData.lang.test;
+			// Example AJAX request to test the token.
+			fetch(ajaxurl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				_wpnonce: w3tcData.nonces.testToken, // Nonce for security.
+				action: 'test_aicrawler_token', // WordPress AJAX action.
+				token: document.getElementById('aicrawler___imh_central_token').value, // InMotion Central token to be tested.
+			}),
+			})
+			.then((response) => response.json())
+			.then((data) => {
+				// Handle the response from the server.
+				if (data.success) {
+				alert(w3tcData.lang.tokenValid);
+				} else {
+				alert(w3tcData.lang.tokenInvalid);
+				}
+			})
+			.catch((error) => {
+				console.error(w3tcData.lang.error + ':', error);
+				alert(w3tcData.lang.tokenError + '.');
+			})
+			.finally(() => {
+				// Reset the button text.
+				testTokenButton.textContent = w3tcData.lang.test;
+			});
 		});
-	});
 	}
 
 	// Handle the 'Regenerate URL' button click.

--- a/Extension_AiCrawler_Page.js
+++ b/Extension_AiCrawler_Page.js
@@ -97,22 +97,22 @@ document.addEventListener("DOMContentLoaded", function () {
 					);
 
 					if (data.success) {
-					regenerateUrlMessage.textContent = data.data.message;
-					regenerateUrlMessage.classList.add(
-						'w3tc-aicrawler-message-success',
-					);
+						regenerateUrlMessage.textContent = data.data.message;
+						regenerateUrlMessage.classList.add(
+							'w3tc-aicrawler-message-success',
+						);
 					} else {
-					regenerateUrlMessage.textContent =
-						data.data && data.data.message
-						? data.data.message
-						: w3tcData.lang.regenerateUrlFailed + '.';
-					regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
+						regenerateUrlMessage.textContent =
+							data.data && data.data.message
+							? data.data.message
+							: w3tcData.lang.regenerateUrlFailed + '.';
+						regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
 					}
 				})
 				.catch((error) => {
 					console.error('Error:', error);
 					regenerateUrlMessage.textContent =
-					w3tcData.lang.regenerateUrlError + '.';
+						w3tcData.lang.regenerateUrlError + '.';
 					regenerateUrlMessage.classList.add('w3tc-aicrawler-message-error');
 				})
 				.finally(() => {
@@ -122,7 +122,7 @@ document.addEventListener("DOMContentLoaded", function () {
 		});
 	}
 
-	// Handle the 'Regenerate All' button click.
+	// Handle the "Regenerate All" button click.
 	if (regenerateAllButton && regenerateAllMessage) {
 		regenerateAllButton.addEventListener('click', function (event) {
 			event.preventDefault(); // Prevent default button behavior.

--- a/Extension_AiCrawler_Page_View_Tools.php
+++ b/Extension_AiCrawler_Page_View_Tools.php
@@ -35,6 +35,7 @@ $config = Dispatcher::config();
 			</th>
 			<td>
 				<button id="w3tc-aicrawler-regenerate-all-button" class="button"><?php esc_html_e( 'Regenerate', 'w3-total-cache' ); ?></button>
+				<p id="w3tc-aicrawler-regenerate-all-message" class="w3tc-aicrawler-message"></p>
 			</td>
 		</tr>
 	</table>

--- a/Extension_AiCrawler_Plugin_Admin.php
+++ b/Extension_AiCrawler_Plugin_Admin.php
@@ -134,6 +134,7 @@ class Extension_AiCrawler_Plugin_Admin {
 		add_filter( 'w3tc_extension_plugin_links_aicrawler', array( $this, 'w3tc_extension_plugin_links' ) );
 		add_action( 'w3tc_settings_page-w3tc_aicrawler', array( $this, 'w3tc_extension_page' ) );
 		add_action( 'wp_ajax_w3tc_aicrawler_regenerate_url', array( $this, 'wp_ajax_regenerate_aicrawler_url' ) );
+		add_action( 'wp_ajax_w3tc_aicrawler_regenerate_all', array( $this, 'wp_ajax_regenerate_aicrawler_all' ) );
 
 		// Site Health: STATUS card.
 		add_filter(
@@ -237,5 +238,57 @@ class Extension_AiCrawler_Plugin_Admin {
 		}
 
 		wp_send_json_error( array( 'message' => __( 'Failed to add URL to the markdown generation queue.', 'w3-total-cache' ) ) );
+	}
+
+	/**
+	 * AJAX handler to queue all posts and pages for markdown generation.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function wp_ajax_regenerate_aicrawler_all() {
+		if ( ! check_ajax_referer( 'w3tc_aicrawler_regenerate_all', '_wpnonce', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid nonce.', 'w3-total-cache' ) ) );
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		$post_ids    = ! empty( $query->posts ) ? $query->posts : array();
+		$allowed_ids = Extension_AiCrawler_Util::filter_excluded( $post_ids );
+
+		$added = 0;
+		foreach ( $allowed_ids as $post_id ) {
+			$url = get_permalink( $post_id );
+			if ( Extension_AiCrawler_Markdown::generate_markdown( $url ) ) {
+				++$added;
+			}
+		}
+
+		if ( $added ) {
+			wp_send_json_success(
+				array(
+					'message' => sprintf(
+						/* translators: %d: Number of URLs. */
+						_n(
+							'%d item added to the markdown generation queue.',
+							'%d items added to the markdown generation queue.',
+							$added,
+							'w3-total-cache'
+						),
+						$added
+					),
+				)
+			);
+		}
+
+		wp_send_json_error( array( 'message' => __( 'No items were added to the markdown generation queue.', 'w3-total-cache' ) ) );
 	}
 }


### PR DESCRIPTION
## Summary
- queue all posts/pages for AI crawler regeneration, skipping exclusions
- show status message under "Regenerate All" button
- add client-side handler for bulk regeneration

## Testing
- `npx prettier-eslint Extension_AiCrawler_Page.js --list-different`
- `vendor/bin/phpcs Extension_AiCrawler_Plugin_Admin.php Extension_AiCrawler_Page_View_Tools.php`

------
https://chatgpt.com/codex/tasks/task_b_68a8c82f004883288f73938b0b51163a