### PR TITLE
Handle llms.txt with plain permalinks

### DIFF
--- a/Extension_AiCrawler_LlmsTxt_Server.php
+++ b/Extension_AiCrawler_LlmsTxt_Server.php
@@ -63,7 +63,25 @@ class Extension_AiCrawler_LlmsTxt_Server {
 	 * @return void
 	 */
 	public static function maybe_serve_llms() {
-		if ( ! get_query_var( 'w3tc_llms' ) ) {
+		$serve = get_query_var( 'w3tc_llms' );
+
+		if ( ! $serve ) {
+			$permalink_structure = get_option( 'permalink_structure' );
+
+			if ( empty( $permalink_structure ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+				$home_path    = wp_parse_url( home_url( '/' ), PHP_URL_PATH );
+				$request_path = wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+
+				$home_path    = untrailingslashit( $home_path );
+				$request_path = untrailingslashit( $request_path );
+
+				if ( $home_path . '/llms.txt' === $request_path ) {
+					$serve = true;
+				}
+			}
+		}
+
+		if ( ! $serve ) {
 			return;
 		}
 
@@ -74,24 +92,24 @@ class Extension_AiCrawler_LlmsTxt_Server {
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				'meta_query'     => array( //phpcs:ignore WordPress.DB.SlowDBQuery
-					'relation' => 'AND',
-					array(
-						'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN,
-						'compare' => '!=',
-						'value'   => '',
+				'relation' => 'AND',
+				array(
+					'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN,
+					'compare' => '!=',
+					'value'   => '',
 					),
 					array(
-						'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN,
-						'compare' => 'EXISTS',
+					'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN,
+					'compare' => 'EXISTS',
 					),
 					array(
-						'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN_URL,
-						'compare' => '!=',
-						'value'   => '',
+					'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN_URL,
+					'compare' => '!=',
+					'value'   => '',
 					),
 					array(
-						'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN_URL,
-						'compare' => 'EXISTS',
+					'key'     => Extension_AiCrawler_Markdown::META_MARKDOWN_URL,
+					'compare' => 'EXISTS',
 					),
 				),
 			)


### PR DESCRIPTION
## Summary
- ensure `llms.txt` requests are served even when permalink structure is set to Plain by checking the request path

## Testing
- `vendor/bin/phpcs -n Extension_AiCrawler_LlmsTxt_Server.php`
- `vendor/bin/phpunit` *(fails: Failed opening required '/tmp/wordpress-tests-lib/includes/functions.php')*
- `npm run js-lint` *(reports numerous files needing formatting)*


------
https://chatgpt.com/codex/tasks/task_b_68accfa245ac8328a800f51a2ad497de