### PR TITLE
Adjust Dashboard CDN Widget

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -200,6 +200,11 @@ class Cache {
 			case 'bunnycdn':
 				$engine_name = 'Bunny CDN';
 				break;
+
+			case 'cloudflare':
+				$engine_name = 'Cloudflare';
+				break;
+
 			case 'totalcdn':
 				$engine_name = W3TC_CDN_NAME;
 				break;

--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -973,7 +973,8 @@ class Cdn_Core {
 				break;
 
 			case 'cloudflare':
-				$is_cdnfsd_authorized = ! empty( $cloudflare_config['email'] ) &&
+				$is_cdnfsd_authorized = $this->_config->is_extension_active( 'cloudflare' ) &&
+					! empty( $cloudflare_config['email'] ) &&
 					! empty( $cloudflare_config['key'] ) &&
 					! empty( $cloudflare_config['zone_id'] ) &&
 					! empty( $cloudflare_config['zone_name'] );

--- a/Cdn_TotalCdn_Widget.php
+++ b/Cdn_TotalCdn_Widget.php
@@ -25,7 +25,19 @@ class Cdn_TotalCdn_Widget {
 	 * @return void
 	 */
 	public static function admin_init_w3tc_dashboard() {
-		$o = new Cdn_TotalCdn_Widget();
+		$config = Dispatcher::config();
+		$o      = new Cdn_TotalCdn_Widget();
+
+		$cdn_enabled    = $config->get_boolean( 'cdn.enabled' );
+		$cdnfsd_enabled = $config->get_boolean( 'cdnfsd.enabled' );
+
+		if ( 'cloudflare' === $config->get_string( 'cdnfsd.engine' ) && ! $config->is_extension_active( 'cloudflare' ) ) {
+			$cdnfsd_enabled = false;
+		}
+
+		$configuration_link = $cdn_enabled || $cdnfsd_enabled
+			? Util_Ui::admin_url( 'admin.php?page=w3tc_cdn' )
+			: Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' );
 
 		add_action( 'admin_print_styles', array( $o, 'admin_print_styles' ) );
 
@@ -34,7 +46,7 @@ class Cdn_TotalCdn_Widget {
 			400,
 			'<div class="w3tc-widget-totalcdn-logo"></div>',
 			array( $o, 'widget_form' ),
-			Util_Ui::admin_url( 'admin.php?page=w3tc_cdn' ),
+			$configuration_link,
 			'normal'
 		);
 	}

--- a/Cdn_TotalCdn_Widget_View.css
+++ b/Cdn_TotalCdn_Widget_View.css
@@ -3,6 +3,7 @@
 	height: 50px;
 	background: url('pub/img/totalcdn-logo.png') 0 8px no-repeat;
 	background-size: contain;
+	background-position: initial;
 	float: left;
 }
 

--- a/Cdn_TotalCdn_Widget_View_Unauthorized.php
+++ b/Cdn_TotalCdn_Widget_View_Unauthorized.php
@@ -21,7 +21,16 @@ defined( 'W3TC' ) || die();
 
 	$cdnfsd_engine  = $config->get_string( 'cdnfsd.engine' );
 	$cdnfsd_enabled = $config->get_boolean( 'cdnfsd.enabled' );
-	$cdnfsd_name    = Cache::engine_name( $cdnfsd_engine );
+
+	// If Cloudflare was previously configured for CDN/FSD but the extension
+	// is no longer active, treat CDN/FSD as disabled so the dashboard does
+	// not show stale configuration notices.
+	if ( 'cloudflare' === $cdnfsd_engine && ! $config->is_extension_active( 'cloudflare' ) ) {
+		$cdnfsd_enabled = false;
+		$cdnfsd_engine  = '';
+	}
+
+	$cdnfsd_name = Cache::engine_name( $cdnfsd_engine );
 
 	// Check if Total CDN is selected but not fully configured.
 	$is_w3tc_cdn_incomplete = (

--- a/Generic_Page_Dashboard_View.css
+++ b/Generic_Page_Dashboard_View.css
@@ -38,7 +38,7 @@
 }
 
 .w3tc-widget-configure {
-    float: left;
+    float: right;
 }
 
 .w3tc-widget-text {

--- a/Util_Widget.php
+++ b/Util_Widget.php
@@ -157,8 +157,8 @@ class Util_Widget {
 				$header_text = __( 'Configure' );
 			}
 
-			$widget_name .= ' <span class="w3tc-widget-configure postbox-title-action">' .
-				'<a href="' . esc_url( $control_callback ) . '" class="edit-box open-box ' .
+			$widget_name .= ' <span class="w3tc-widget-configure postbox-title-action button">' .
+				'<a href="' . esc_url( $control_callback ) . '" class="open-box ' .
 				esc_attr( $header_class ) . '">' . $header_text . '</a></span>';
 		}
 


### PR DESCRIPTION
This PR adjusts the dashboard CDN widget logic so that if the Cloudflare extension is configured but not active, it won't show as active in the CDN widget.

This also adjusts the "Configure" link to properly link to the CDN settings or General Settings CDN metabox, depending on if a CDN is active and configured. This includes a check if the engine is Cloudflare and if the extension is active.

Lastly, this PR adjusts some CSS so that the configure link is a button and always visible.