### PR TITLE
Sanitize mfunc comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ This project is a WordPress plugin designed to enhance website performance throu
 - WordPress Documentation Standards for JavaScript: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/
 
 ## Contribution Process
+- Add `@since X.X.X` to all new doc blocks -- it's updated in our build process.
+- Do not update POT files -- it's done in our build process.
+- Do not change the `readme.txt` file -- it's done on release branches.
+- Do not increment the plugin version number -- it's done in our build process.
 - All changes must be submitted via pull requests.
 - Public-facing work may originate from GitHub issues to ensure public visibility.
   - Create a GitHub issue describing the change, implement the change in a branch, and open a pull request that references the GitHub issue.

--- a/tests/test-generic-plugin.php
+++ b/tests/test-generic-plugin.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for the Generic Plugin.
+ *
+ * @package W3TC\Tests
+ *
+ * @since X.X.X
+ */
+
+use W3TC\Generic_Plugin;
+
+/**
+ * Class Generic_Plugin_DynamicFragments_Test.
+ *
+ * @since X.X.X
+ */
+class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
+	/**
+	 * Generic plugin instance under test.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var Generic_Plugin
+	 */
+	protected $plugin;
+
+	/**
+	 * Sets up test fixtures.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'W3TC_DYNAMIC_SECURITY' ) ) {
+			define( 'W3TC_DYNAMIC_SECURITY', 'unit-test-token' );
+		}
+
+		$this->plugin = new Generic_Plugin();
+	}
+
+	/**
+	 * Confirms comment preprocessing strips fragment directives and secrets.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_strip_dynamic_fragment_tags_from_comment_removes_fragments() {
+		$fragment = '<!-- mfunc ' . W3TC_DYNAMIC_SECURITY . " -->echo 'danger';<!-- /mfunc " . W3TC_DYNAMIC_SECURITY . ' -->';
+		$comment  = array( 'comment_content' => 'Before ' . $fragment . ' After ' . W3TC_DYNAMIC_SECURITY );
+
+		$result = $this->plugin->strip_dynamic_fragment_tags_from_comment( $comment );
+
+		$this->assertArrayHasKey( 'comment_content', $result );
+		$this->assertStringNotContainsString( W3TC_DYNAMIC_SECURITY, $result['comment_content'] );
+		$this->assertStringNotContainsString( 'mfunc', $result['comment_content'] );
+	}
+
+	/**
+	 * Ensures feed filtering removes fragment directives.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_strip_dynamic_fragment_tags_filter_removes_fragments_from_feeds() {
+		$fragment = '<!-- mclude ' . W3TC_DYNAMIC_SECURITY . ' -->foo.php<!-- /mclude ' . W3TC_DYNAMIC_SECURITY . ' -->';
+		$content  = '<p>Before</p>' . $fragment . '<p>After ' . W3TC_DYNAMIC_SECURITY . '</p>';
+
+		$filtered = $this->plugin->strip_dynamic_fragment_tags_filter( $content );
+
+		$this->assertStringNotContainsString( W3TC_DYNAMIC_SECURITY, $filtered );
+		$this->assertStringNotContainsString( 'mclude', $filtered );
+	}
+
+	/**
+	 * Tests REST responses are sanitized outside of edit context.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_rest_response_dynamic_tags_removes_fragments_for_view_context() {
+		$fragment = '<!-- mfunc ' . W3TC_DYNAMIC_SECURITY . " -->echo 'danger';<!-- /mfunc " . W3TC_DYNAMIC_SECURITY . ' -->';
+		$data     = array(
+			'rendered' => 'Prefix ' . $fragment . ' Suffix',
+			'nested'   => array(
+				'value' => 'Nested ' . W3TC_DYNAMIC_SECURITY,
+			),
+		);
+
+		$response = new WP_REST_Response( $data );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'context', 'view' );
+
+		$sanitized = $this->plugin->sanitize_rest_response_dynamic_tags( $response, null, $request );
+		$payload   = $sanitized->get_data();
+
+		$this->assertArrayHasKey( 'rendered', $payload );
+		$this->assertStringNotContainsString( W3TC_DYNAMIC_SECURITY, $payload['rendered'] );
+		$this->assertStringNotContainsString( 'mfunc', $payload['rendered'] );
+		$this->assertStringNotContainsString( W3TC_DYNAMIC_SECURITY, $payload['nested']['value'] );
+	}
+
+	/**
+	 * Ensures edit-context REST responses remain untouched for editors.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_rest_response_dynamic_tags_skips_edit_context() {
+		$fragment = '<!-- mfunc ' . W3TC_DYNAMIC_SECURITY . " -->echo 'danger';<!-- /mfunc " . W3TC_DYNAMIC_SECURITY . ' -->';
+		$data     = array( 'rendered' => $fragment );
+		$response = new WP_REST_Response( $data );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'context', 'edit' );
+
+		$sanitized = $this->plugin->sanitize_rest_response_dynamic_tags( $response, null, $request );
+
+		$this->assertSame( $response, $sanitized );
+		$this->assertStringContainsString( W3TC_DYNAMIC_SECURITY, $sanitized->get_data()['rendered'] );
+	}
+}


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG5-524

To test:
1. Enable mfunc -- see [how-does-page-fragment-cache-work](https://github.com/BoldGrid/w3-total-cache/wiki/FAQ:-Developers#how-does-page-fragment-cache-work)
1. Ensure that Page Cache is enabled.
1. Create a test page with HTML to utilize the feature.
1. In Incognito, browse to the page and review the source.  The literal comment/code added should not be visible.
1. View the page via REST API - "/wp-json/wp/v2/pages/{post_id}".  The comment/code should be stripped out.
1. Change the branch to the latest tag and reload the REST API page.  You will see the comment/code.
