### PR TITLE
Added FSD DSN test

### DIFF
--- a/Cdnfsd_TotalCdn_Page.php
+++ b/Cdnfsd_TotalCdn_Page.php
@@ -25,6 +25,7 @@ class Cdnfsd_TotalCdn_Page {
 	public static function w3tc_ajax() {
 		$instance = new self();
 
+		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ), 10 );
 		\add_action( 'w3tc_ajax_cdn_totalcdn_fsd_status_check', array( $instance, 'w3tc_ajax_cdn_totalcdn_fsd_status_check' ) );
 	}
 
@@ -127,6 +128,10 @@ class Cdnfsd_TotalCdn_Page {
 		$errors  = array();
 
 		foreach ( $tests as $test ) {
+			if ( ! has_filter( $test['filter'] ) ) {
+				break;
+			}
+
 			$test_result            = self::execute_test( $test );
 			$results[ $test['id'] ] = $test_result['status'];
 
@@ -145,9 +150,7 @@ class Cdnfsd_TotalCdn_Page {
 				);
 			}
 		} elseif (
-			! empty( $results )
-			&& \count( \array_unique( $results ) ) === 1
-			&& 'untested' === \reset( $results )
+			empty( $results )
 		) {
 			$notices[] = array(
 				'type'    => 'warning',
@@ -229,7 +232,7 @@ class Cdnfsd_TotalCdn_Page {
 
 		return \sprintf(
 			/* translators: 1: Total CDN test title. */
-			\esc_html__( '%s failed.', 'w3-total-cache' ),
+			\esc_html__( '%s: status check failed.', 'w3-total-cache' ),
 			\esc_html( $title )
 		);
 	}

--- a/Cdnfsd_TotalCdn_Status_Dns.php
+++ b/Cdnfsd_TotalCdn_Status_Dns.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * File: Cdnfsd_TotalCdn_Status_Dns.php
+ *
+ * @since X.X.X
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+defined( 'W3TC' ) || die;
+
+/**
+ * Class: Cdnfsd_TotalCdn_Status_Dns
+ *
+ * @since X.X.X
+ */
+class Cdnfsd_TotalCdn_Status_Dns {
+	/**
+	 * Runs the Total CDN dns status test.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array {
+	 *     Test result data.
+	 *
+	 *     @type string $status  Normalized status string (pass|fail|untested).
+	 *     @type string $message Optional message describing the outcome.
+	 *     @type string $log     Optional technical error message.
+	 * }
+	 */
+	public static function test_dns_status() {
+		$config = Dispatcher::config();
+
+		$account_api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
+		$pull_zone_id    = (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+
+		$hostname = self::resolve_site_hostname();
+
+		$api = new Cdn_TotalCdn_Api(
+			array(
+				'account_api_key' => $account_api_key,
+				'pull_zone_id'    => $pull_zone_id,
+			)
+		);
+
+		try {
+			$response = $api->verify_hostname_cdn( $hostname );
+		} catch ( \Exception $exception ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Failed to verify if the hostname points to a CDN provider.', 'w3-total-cache' ),
+				'log'     => $exception->getMessage(),
+			);
+		}
+
+		return array(
+			'status'  => 'pass',
+			'message' => \__( 'The custom hostname is pointed to a CDN provider.', 'w3-total-cache' ),
+		);
+	}
+
+	/**
+	 * Resolves the hostname that should be configured for Total CDN FSD.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string
+	 */
+	protected static function resolve_site_hostname() {
+		$site_url = \get_option( 'siteurl' );
+		$hostname = \is_string( $site_url ) ? \wp_parse_url( $site_url, PHP_URL_HOST ) : '';
+
+		if ( empty( $hostname ) ) {
+			$hostname = \wp_parse_url( \home_url(), PHP_URL_HOST );
+		}
+
+		return \is_string( $hostname ) ? \strtolower( trim( $hostname ) ) : '';
+	}
+}

--- a/Cdnfsd_TotalCdn_Status_Dns.php
+++ b/Cdnfsd_TotalCdn_Status_Dns.php
@@ -36,7 +36,14 @@ class Cdnfsd_TotalCdn_Status_Dns {
 		$account_api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
 		$pull_zone_id    = (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' );
 
-		$hostname = self::resolve_site_hostname();
+		$hostname = Util_Environment::get_site_hostname();
+
+		if ( empty( $hostname ) ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Unable to determine the site hostname.', 'w3-total-cache' ),
+			);
+		}
 
 		$api = new Cdn_TotalCdn_Api(
 			array(
@@ -59,7 +66,11 @@ class Cdnfsd_TotalCdn_Status_Dns {
 		if ( ! $verified ) {
 			return array(
 				'status'  => 'fail',
-				'message' => \__( 'DNS is not pointed to a CDN provider', 'w3-total-cache' ),
+				'message' => \sprintf(
+					// Translators: 1 host name.
+					\__( '%1$s is not pointed to a CDN provider', 'w3-total-cache' ),
+					$hostname
+				),
 			);
 		}
 

--- a/Cdnfsd_TotalCdn_Status_Dns.php
+++ b/Cdnfsd_TotalCdn_Status_Dns.php
@@ -79,22 +79,4 @@ class Cdnfsd_TotalCdn_Status_Dns {
 			'message' => \__( 'The custom hostname is pointed to a CDN provider.', 'w3-total-cache' ),
 		);
 	}
-
-	/**
-	 * Resolves the hostname that should be configured for Total CDN FSD.
-	 *
-	 * @since X.X.X
-	 *
-	 * @return string
-	 */
-	protected static function resolve_site_hostname() {
-		$site_url = \get_option( 'siteurl' );
-		$hostname = \is_string( $site_url ) ? \wp_parse_url( $site_url, PHP_URL_HOST ) : '';
-
-		if ( empty( $hostname ) ) {
-			$hostname = \wp_parse_url( \home_url(), PHP_URL_HOST );
-		}
-
-		return \is_string( $hostname ) ? \strtolower( trim( $hostname ) ) : '';
-	}
 }

--- a/Cdnfsd_TotalCdn_Status_Dns.php
+++ b/Cdnfsd_TotalCdn_Status_Dns.php
@@ -55,6 +55,14 @@ class Cdnfsd_TotalCdn_Status_Dns {
 			);
 		}
 
+		$verified = isset( $response['Success'] ) ? (bool) $response['Success'] : false;
+		if ( ! $verified ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'DNS is not pointed to a CDN provider', 'w3-total-cache' ),
+			);
+		}
+
 		return array(
 			'status'  => 'pass',
 			'message' => \__( 'The custom hostname is pointed to a CDN provider.', 'w3-total-cache' ),


### PR DESCRIPTION
This PR adds the DNS status test for the CDN FSD status section

To test setup with a pro license with total CDN and enable/configure FSD. This should set the hostname on save. Then update the DNS to point to the CDN

Then go to the CDN settings page and click on the Check Status button within the FSD box. It should pass. To see the failure state modify Cdnfsd_TotalCdn_Status_DNS.php to manually trigger a failure or perform the test before pointing the DNS

NOTE: This test won't run without the hostname test so may need to wait for that PR to be merged and then update this one so it has that. Or you can comment out line 132 in Cdnfsd_TotalCdn_Page.php
