### PR TITLE
Resolve plugin check errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This project is a WordPress plugin designed to enhance website performance throu
 - Do not use spaces for indentation; use 4-space tabs instead.
 - Use single quotes for strings unless double quotes are necessary (e.g., when using variables inside the string).
 - Do not make coding standards changes in changed files unless it is directly related to the functionality being modified.
+- Opening parenthesis of a multi-line function call must be the last content on the line (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket).
 
 ## References
 - WordPress Coding Standards: https://developer.wordpress.org/coding-standards/

--- a/BrowserCache_Plugin.php
+++ b/BrowserCache_Plugin.php
@@ -76,17 +76,17 @@ class BrowserCache_Plugin {
 
 		$v = $this->_config->get_string( 'browsercache.security.session.cookie_httponly' );
 		if ( ! empty( $v ) ) {
-			@ini_set( 'session.cookie_httponly', 'on' === $v ? '1' : '0' );
+			@ini_set( 'session.cookie_httponly', 'on' === $v ? '1' : '0' ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 		}
 
 		$v = $this->_config->get_string( 'browsercache.security.session.cookie_secure' );
 		if ( ! empty( $v ) ) {
-			@ini_set( 'session.cookie_secure', 'on' === $v ? '1' : '0' );
+			@ini_set( 'session.cookie_secure', 'on' === $v ? '1' : '0' ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 		}
 
 		$v = $this->_config->get_string( 'browsercache.security.session.use_only_cookies' );
 		if ( ! empty( $v ) ) {
-			@ini_set( 'session.use_only_cookies', 'on' === $v ? '1' : '0' );
+			@ini_set( 'session.use_only_cookies', 'on' === $v ? '1' : '0' ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 		}
 
 		add_filter( 'w3tc_minify_http2_preload_url', array( $this, 'w3tc_minify_http2_preload_url' ), 4000 );

--- a/Cache_File.php
+++ b/Cache_File.php
@@ -347,7 +347,7 @@ class Cache_File extends Cache_Base {
 	 * @return bool Always returns true.
 	 */
 	public function flush( $group = '' ) {
-		@set_time_limit( $this->_flush_timelimit );
+		@set_time_limit( $this->_flush_timelimit ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		if ( 'sitemaps' === $group ) {
 			$config        = Dispatcher::config();

--- a/Cache_File_Cleaner.php
+++ b/Cache_File_Cleaner.php
@@ -56,7 +56,7 @@ class Cache_File_Cleaner {
 	 * @return void
 	 */
 	public function clean() {
-		@set_time_limit( $this->_clean_timelimit );
+		@set_time_limit( $this->_clean_timelimit ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$this->_clean( $this->_cache_dir, false );
 	}
@@ -67,7 +67,7 @@ class Cache_File_Cleaner {
 	 * @return void
 	 */
 	public function clean_before() {
-		@set_time_limit( $this->_clean_timelimit );
+		@set_time_limit( $this->_clean_timelimit ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$this->_clean( $this->_cache_dir, false );
 	}

--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -397,7 +397,7 @@ class Cache_File_Generic extends Cache_File {
 				$c = new Cache_File_Cleaner_Generic_HardDelete(
 					array(
 						'cache_dir'       => $this->_flush_dir . DIRECTORY_SEPARATOR . $group,
-						'exclude'         => $this->_exclude,
+						'exclude'         => $this->_exclude, // phpcs:ignore WordPressVIPMinimum
 						'clean_timelimit' => $this->_flush_timelimit,
 					)
 				);
@@ -405,7 +405,7 @@ class Cache_File_Generic extends Cache_File {
 				$c = new Cache_File_Cleaner_Generic(
 					array(
 						'cache_dir'       => $this->_flush_dir,
-						'exclude'         => $this->_exclude,
+						'exclude'         => $this->_exclude, // phpcs:ignore WordPressVIPMinimum
 						'clean_timelimit' => $this->_flush_timelimit,
 					)
 				);
@@ -445,7 +445,7 @@ class Cache_File_Generic extends Cache_File {
 			$c = new Cache_File_Cleaner_Generic_HardDelete(
 				array(
 					'cache_dir'       => $this->_flush_dir . DIRECTORY_SEPARATOR . $group,
-					'exclude'         => $this->_exclude,
+					'exclude'         => $this->_exclude, // phpcs:ignore WordPressVIPMinimum
 					'clean_timelimit' => $this->_flush_timelimit,
 					'time_min_valid'  => $extension['before_time'],
 				)
@@ -454,7 +454,7 @@ class Cache_File_Generic extends Cache_File {
 			$c = new Cache_File_Cleaner_Generic(
 				array(
 					'cache_dir'       => $this->_flush_dir,
-					'exclude'         => $this->_exclude,
+					'exclude'         => $this->_exclude, // phpcs:ignore WordPressVIPMinimum
 					'clean_timelimit' => $this->_flush_timelimit,
 					'time_min_valid'  => $extension['before_time'],
 				)

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -489,7 +489,7 @@ class Cdn_AdminActions {
 				$w3_cdn = CdnEngine::instance( $engine, $config );
 			}
 
-			@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_test' ) );
+			@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_test' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 			try {
 				if ( $w3_cdn->test( $error ) ) {
@@ -553,7 +553,7 @@ class Cdn_AdminActions {
 			case 'azuremi':
 				$w3_cdn = CdnEngine::instance( $engine, $config );
 
-				@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_upload' ) );
+				@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_upload' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 				$result = false;
 

--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -213,7 +213,7 @@ class Cdn_Core {
 		$cdn           = $this->get_cdn();
 		$force_rewrite = $this->_config->get_boolean( 'cdn.force.rewrite' );
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_upload' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_upload' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$engine = $this->_config->get_string( 'cdn.engine' );
 		$return = $cdn->upload( $files, $results, $force_rewrite, $timeout_time );
@@ -241,7 +241,7 @@ class Cdn_Core {
 	public function delete( $files, $queue_failed, &$results ) {
 		$cdn = $this->get_cdn();
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_delete' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_delete' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$return = $cdn->delete( $files, $results );
 		if ( $this->debug ) {
@@ -289,7 +289,7 @@ class Cdn_Core {
 		 */
 		$cdn = $this->get_cdn();
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_purge' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_purge' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$return = $cdn->purge( $files, $results );
 
@@ -314,7 +314,7 @@ class Cdn_Core {
 	public function purge_all( &$results ) {
 		$cdn = $this->get_cdn();
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_purge' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_purge' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		return $cdn->purge_all( $results );
 	}

--- a/Cdn_Core_Admin.php
+++ b/Cdn_Core_Admin.php
@@ -330,7 +330,7 @@ class Cdn_Core_Admin {
 		$uploads_use_yearmonth_folders = get_option( 'uploads_use_yearmonth_folders' );
 		$document_root                 = Util_Environment::document_root();
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_import' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.cdn_import' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		if ( $upload_info ) {
 			/**
@@ -597,7 +597,7 @@ class Cdn_Core_Admin {
 	public function rename_domain( $names, $limit, $offset, &$count, &$total, &$results ) {
 		global $wpdb;
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.domain_rename' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.domain_rename' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$count   = 0;
 		$total   = 0;
@@ -695,7 +695,7 @@ class Cdn_Core_Admin {
 				AND
 				pm2.meta_key = "_wp_attachment_metadata"
 				WHERE
-				p.post_type = "attachment" 
+				p.post_type = "attachment"
 				AND
 				(pm.meta_value IS NOT NULL OR pm2.meta_value IS NOT NULL)',
 			$wpdb->prefix,

--- a/Extension_CloudFlare_Plugin_Admin.php
+++ b/Extension_CloudFlare_Plugin_Admin.php
@@ -296,7 +296,7 @@ class Extension_CloudFlare_Plugin_Admin {
 
 			@$this->api = new Extension_CloudFlare_Api( $config );
 
-			@set_time_limit( $this->_config->get_integer( array( 'cloudflare', 'timelimit.api_request' ) ) );
+			@set_time_limit( $this->_config->get_integer( array( 'cloudflare', 'timelimit.api_request' ) ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 			$response = $this->api->api_request( $action, $value );
 
 			if ( $response ) {

--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -1373,7 +1373,7 @@ class Extension_ImageService_Plugin_Admin {
 
 		// Allow plenty of time to complete.
 		ignore_user_abort( true );
-		set_time_limit( 0 ); //phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+		set_time_limit( 0 ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		foreach ( $results->posts as $post_id ) {
 			$post_ids[] = $post_id;

--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -1401,7 +1401,7 @@ class Extension_ImageService_Plugin_Admin {
 
 		// Allow plenty of time to complete.
 		ignore_user_abort( true );
-		set_time_limit( 0 ); //phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+		set_time_limit( 0 ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		foreach ( $results->posts as $post_id ) {
 			if ( $this->remove_optimizations( $post_id ) ) {

--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -306,7 +306,7 @@ class Extension_ImageService_Plugin_Admin {
 				'post_mime_type'         => self::$mime_types,
 				'posts_per_page'         => -1,
 				'ignore_sticky_posts'    => true,
-				'suppress_filters'       => true,
+				'suppress_filters'       => true, // phpcs:ignore WordPressVIPMinimum
 				'meta_key'               => 'w3tc_imageservice', // phpcs:ignore WordPress.DB.SlowDBQuery
 				'fields'                 => 'ids',
 				'no_found_rows'          => true,
@@ -335,7 +335,7 @@ class Extension_ImageService_Plugin_Admin {
 				'post_mime_type'         => self::$mime_types,
 				'posts_per_page'         => -1,
 				'ignore_sticky_posts'    => true,
-				'suppress_filters'       => true,
+				'suppress_filters'       => true, // phpcs:ignore WordPressVIPMinimum
 				'meta_key'               => 'w3tc_imageservice', // phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_compare'           => 'NOT EXISTS',
 				'fields'                 => 'ids',
@@ -1373,7 +1373,7 @@ class Extension_ImageService_Plugin_Admin {
 
 		// Allow plenty of time to complete.
 		ignore_user_abort( true );
-		set_time_limit( 0 );
+		set_time_limit( 0 ); //phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		foreach ( $results->posts as $post_id ) {
 			$post_ids[] = $post_id;
@@ -1401,7 +1401,7 @@ class Extension_ImageService_Plugin_Admin {
 
 		// Allow plenty of time to complete.
 		ignore_user_abort( true );
-		set_time_limit( 0 );
+		set_time_limit( 0 ); //phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		foreach ( $results->posts as $post_id ) {
 			if ( $this->remove_optimizations( $post_id ) ) {

--- a/Extension_NewRelic_Plugin_Admin.php
+++ b/Extension_NewRelic_Plugin_Admin.php
@@ -135,7 +135,7 @@ class Extension_NewRelic_Plugin_Admin {
 	public function w3tc_extension_plugin_links( $links ) {
 		$links   = array();
 		$links[] = '<a class="edit" href="' . esc_attr( Util_Ui::admin_url( 'admin.php?page=w3tc_general#monitoring' ) ) .
-			'">' . __( 'Settings' ) . '</a>';
+			'">' . __( 'Settings', 'w3-total-cache' ) . '</a>';
 
 		return $links;
 	}

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -95,6 +95,8 @@ class Generic_Plugin {
 			ob_start( array( $this, 'ob_callback' ) );
 		}
 
+		$this->register_plugin_check_filters();
+
 		// Run tasks after updating this plugin.
 		$this->post_update_tasks();
 	}
@@ -304,7 +306,6 @@ class Generic_Plugin {
 	public function init() {
 		// Load W3TC textdomain for translations.
 		$this->reset_l10n();
-		load_plugin_textdomain( W3TC_TEXT_DOMAIN, false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
 		if ( is_multisite() && ! is_network_admin() ) {
 			global $w3_current_blog_id, $current_blog;
@@ -997,5 +998,69 @@ class Generic_Plugin {
 			$state->set( 'tasks.generic.last_run_version', W3TC_VERSION );
 			$state->save();
 		}
+	}
+
+	/**
+	 * Registers Plugin Check filters so they run in all contexts.
+	 *
+	 * @since X.X.X
+	 *
+	 * @link https://github.com/WordPress/plugin-check/blob/1.6.0/includes/Utilities/Plugin_Request_Utility.php#L160
+	 * @link https://github.com/WordPress/plugin-check/blob/1.6.0/includes/Utilities/Plugin_Request_Utility.php#L180
+	 * @link https://github.com/WordPress/plugin-check/blob/1.6.0/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php#L928
+	 *
+	 * @return void
+	 */
+	private function register_plugin_check_filters(): void {
+		// Ignore vendor packages and external library directories when running the plugin check plugin.
+		add_filter(
+			'wp_plugin_check_ignore_directories',
+			static function ( array $dirs_to_ignore ) {
+				return array_merge(
+					$dirs_to_ignore,
+					array(
+						'.github',
+						'bin',
+						'extension-example',
+						'lib',
+						'node_modules',
+						'tests',
+						'qa',
+						'vendor',
+					)
+				);
+			}
+		);
+
+		// Ignore specific files when running the plugin check plugin.
+		add_filter(
+			'wp_plugin_check_ignore_files',
+			static function ( array $files_to_ignore ) {
+				return array_merge(
+					$files_to_ignore,
+					array(
+						'.editorconfig',
+						'.gitattributes',
+						'.gitignore',
+						'.jshintrc',
+						'.phpunit.result.cache',
+						'.travis.yml',
+					)
+				);
+			}
+		);
+
+		// Ignore specific warnings when running the plugin check plugin.
+			add_filter(
+				'wp_plugin_check_ignored_readme_warnings',
+				static function ( array $ignored ) {
+					return array_merge(
+						$ignored,
+						array(
+							'trimmed_section_changelog',
+						)
+					);
+				}
+			);
 	}
 }

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1051,16 +1051,16 @@ class Generic_Plugin {
 		);
 
 		// Ignore specific warnings when running the plugin check plugin.
-			add_filter(
-				'wp_plugin_check_ignored_readme_warnings',
-				static function ( array $ignored ) {
-					return array_merge(
-						$ignored,
-						array(
-							'trimmed_section_changelog',
-						)
-					);
-				}
-			);
+		add_filter(
+			'wp_plugin_check_ignored_readme_warnings',
+			static function ( array $ignored ) {
+				return array_merge(
+					$ignored,
+					array(
+						'trimmed_section_changelog',
+					)
+				);
+			}
+		);
 	}
 }

--- a/Generic_Plugin_AdminCompatibility.php
+++ b/Generic_Plugin_AdminCompatibility.php
@@ -128,7 +128,7 @@ class Generic_Plugin_AdminCompatibility {
 			$temp = "<li><div>{$data['Name']}</div>";
 
 			if ( is_network_admin() && current_user_can( 'manage_network_plugins' ) ) {
-				$temp .= ' <a class="button-secondary" href="' . network_admin_url( wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_' . $plugin ) ) . '" title="' . esc_attr__( 'Deactivate this plugin', 'w3-total-cache' ) . '">' . __( 'Network Deactivate' ) . '</a>';
+				$temp .= ' <a class="button-secondary" href="' . network_admin_url( wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_' . $plugin ) ) . '" title="' . esc_attr__( 'Deactivate this plugin', 'w3-total-cache' ) . '">' . __( 'Network Deactivate', 'w3-total-cache' ) . '</a>';
 			} else {
 				$temp .= ' <a class="button-secondary" href="' . admin_url( wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_' . $plugin ) ) . '" title="' . esc_attr__( 'Deactivate this plugin', 'w3-total-cache' ) . '">' . __( 'Deactivate', 'w3-total-cache' ) . '</a>';
 			}

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -872,7 +872,7 @@ class Minify_MinifiedFileRequestHandler {
 		$from_name  = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 		$to_name    = get_option( 'admin_email' );
 		$to_email   = $to_name;
-		$body       = @file_get_contents( W3TC_INC_DIR . '/email/minify_error_notification.php' );
+		$body       = @file_get_contents( W3TC_INC_DIR . '/email/minify_error_notification.html' );
 
 		$headers = array(
 			sprintf( 'From: "%s" <%s>', addslashes( $from_name ), $from_email ),
@@ -880,7 +880,7 @@ class Minify_MinifiedFileRequestHandler {
 			'Content-Type: text/html; charset=utf-8',
 		);
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.email_send' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.email_send' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		$result = @wp_mail( $to_email, 'W3 Total Cache Error Notification', $body, implode( "\n", $headers ) );
 

--- a/Minify_Page.php
+++ b/Minify_Page.php
@@ -516,7 +516,7 @@ class Minify_Page extends Base_Page_Settings {
 		$js_groups  = array();
 		$css_groups = array();
 
-		@set_time_limit( $this->_config->get_integer( 'timelimit.minify_recommendations' ) );
+		@set_time_limit( $this->_config->get_integer( 'timelimit.minify_recommendations' ) ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 		foreach ( $urls as $template => $url ) {
 			// Append theme identifier.

--- a/Minify_Plugin_Admin.php
+++ b/Minify_Plugin_Admin.php
@@ -145,7 +145,7 @@ class Minify_Plugin_Admin {
 	public function cleanup() {
 		$w3_cache_file_cleaner_generic = new Cache_File_Cleaner_Generic(
 			array(
-				'exclude'         => array(
+				'exclude'         => array( // phpcs:ignore WordPressVIPMinimum
 					'*.files',
 					'.htaccess',
 					'index.html',

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1003,7 +1003,7 @@ class PgCache_ContentGrabber {
 					}
 
 					$engine_config = array(
-						'exclude'         => array(
+						'exclude'         => array( // phpcs:ignore WordPressVIPMinimum
 							'.htaccess',
 						),
 						'expire'          => $this->_lifetime,
@@ -2128,7 +2128,7 @@ class PgCache_ContentGrabber {
 
 			try {
 				ob_start();
-				$result = eval( $code );
+				$result = eval( $code ); // phpcs:ignore Generic.PHP.ForbiddenFunctions.Found
 				$output = ob_get_contents();
 				ob_end_clean();
 			} catch ( \Exception $ex ) {

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -116,7 +116,7 @@ class PgCache_Plugin_Admin {
 
 				$w3_cache_file_cleaner_generic = new Cache_File_Cleaner_Generic(
 					array(
-						'exclude'         => array(
+						'exclude'         => array( // phpcs:ignore WordPressVIPMinimum
 							'.htaccess',
 						),
 						'cache_dir'       => $flush_dir,

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -777,7 +777,7 @@ class SetupGuide_Plugin_Admin {
 					'enabled'            => $config->get_boolean( 'lazyload.enabled' ),
 					'process_img'        => $config->get_boolean( 'lazyload.process_img' ),
 					'process_background' => $config->get_boolean( 'lazyload_process_background' ),
-					'exclude'            => $config->get_array( 'lazyload.exclude' ),
+					'exclude'            => $config->get_array( 'lazyload.exclude' ), // phpcs:ignore WordPressVIPMinimum
 					'embed_method'       => $config->get_string( 'lazyload.embed_method' ),
 				)
 			);

--- a/Util_Widget.php
+++ b/Util_Widget.php
@@ -154,7 +154,7 @@ class Util_Widget {
 		// Link.
 		if ( $control_callback && current_user_can( 'edit_dashboard' ) && is_string( $control_callback ) ) {
 			if ( ! $header_text ) {
-				$header_text = __( 'Configure' );
+				$header_text = __( 'Configure', 'w3-total-cache' );
 			}
 
 			$widget_name .= ' <span class="w3tc-widget-configure postbox-title-action">' .
@@ -179,7 +179,7 @@ class Util_Widget {
 			} else {
 				list( $url )  = explode( '#', add_query_arg( 'edit', $widget_id ), 2 );
 				$widget_name .= ' <span class="postbox-title-action"><a href="' . esc_url( "$url#$widget_id" ) .
-					'" class="edit-box open-box">' . __( 'Configure' ) . '</a></span>';
+					'" class="edit-box open-box">' . __( 'Configure', 'w3-total-cache' ) . '</a></span>';
 			}
 		}
 
@@ -203,7 +203,7 @@ class Util_Widget {
 		self::trigger_widget_control( $meta_box['id'] );
 		wp_nonce_field( 'edit-dashboard-widget_' . $meta_box['id'], 'dashboard-widget-nonce' );
 		echo '<input type="hidden" name="widget_id" value="' . esc_attr( $meta_box['id'] ) . '" />';
-		submit_button( __( 'Submit' ) );
+		submit_button( __( 'Submit', 'w3-total-cache' ) );
 		echo '</form>';
 	}
 

--- a/Varnish_Flush.php
+++ b/Varnish_Flush.php
@@ -95,7 +95,7 @@ class Varnish_Flush {
 	 * @throws \Exception Not explicitly thrown, but errors are logged using `_log` and returned as a `WP_Error`.
 	 */
 	protected function _purge( $url ) {
-		@set_time_limit( $this->_timeout );
+		@set_time_limit( $this->_timeout ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 		$return = true;
 
 		foreach ( (array) $this->_servers as $server ) {

--- a/inc/email/minify_error_notification.php
+++ b/inc/email/minify_error_notification.php
@@ -1,7 +1,0 @@
-<html>
-	<head></head>
-	<body>
-		<p>Unfortunately, an error occurred while creating the minify cache. Please check your settings to ensure your site is working as intended.</p>
-		<p>Thanks for using W3 Total Cache.</p>
-	</body>
-</html>

--- a/inc/email/support_request.php
+++ b/inc/email/support_request.php
@@ -1,7 +1,14 @@
 <?php
-if ( ! defined( 'W3TC' ) ) {
-	die();
-}
+/**
+ * File: support_request.php
+ *
+ * Support request email template.
+ *
+ * @package W3TC
+ */
+
+defined( 'W3TC' ) || die();
+
 ?>
 <html>
 	<head></head>
@@ -42,8 +49,12 @@ if ( ! defined( 'W3TC' ) ) {
 
 		<font size="-1" color="#ccc">
 			<?php
-			echo esc_html__( 'E-mail sent from IP: ', 'w3-total-cache' ) . esc_html( $_SERVER['REMOTE_ADDR'] ) . '<br />';
-			echo esc_html__( 'User Agent: ', 'w3-total-cache' ) . esc_html( $_SERVER['HTTP_USER_AGENT'] );
+			echo esc_html__( 'E-mail sent from IP: ', 'w3-total-cache' ) .
+				( isset( $_SERVER['REMOTE_ADDR'] ) ?
+				esc_html( sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) ) : esc_html__( 'Unknown', 'w3-total-cache' ) ) . '<br />';
+			echo esc_html__( 'User Agent: ', 'w3-total-cache' ) .
+				( isset( $_SERVER['HTTP_USER_AGENT'] ) ?
+				esc_html( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) : esc_html__( 'Unknown', 'w3-total-cache' ) );
 			?>
 		</font>
 	</body>

--- a/inc/error.php
+++ b/inc/error.php
@@ -1,4 +1,15 @@
-<?php if ( ! defined( 'W3TC' ) ) {
+<?php
+/**
+ * File: error.php
+ *
+ * Error page.
+ *
+ * @package W3TC
+ *
+ * phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+ */
+
+if ( ! defined( 'W3TC' ) ) {
 	die();} ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" <?php do_action( 'admin_xml_ns' ); ?> <?php language_attributes(); ?>>

--- a/inc/lightbox/self_test.php
+++ b/inc/lightbox/self_test.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * File: self_test.php
+ *
+ * Self test tab.
+ *
+ * @since   0.9.5
+ * @package W3TC
+ */
+
 namespace W3TC;
 
-if ( ! defined( 'W3TC' ) ) {
-	die();
-}
+defined( 'W3TC' ) || die();
+
 ?>
 <h3><?php esc_html_e( 'Compatibility Check', 'w3-total-cache' ); ?></h3>
 
@@ -85,19 +93,42 @@ if ( ! defined( 'W3TC' ) ) {
 
 		<li>
 			Web Server:
-			<?php if ( stristr( $_SERVER['SERVER_SOFTWARE'], 'apache' ) !== false ) : ?>
-				<code>Apache</code>
-			<?php elseif ( stristr( $_SERVER['SERVER_SOFTWARE'], 'LiteSpeed' ) !== false ) : ?>
-				<code>Lite Speed</code>
-			<?php elseif ( stristr( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) !== false ) : ?>
-				<code>nginx</code>
-			<?php elseif ( stristr( $_SERVER['SERVER_SOFTWARE'], 'lighttpd' ) !== false ) : ?>
-				<code>lighttpd</code>
-			<?php elseif ( stristr( $_SERVER['SERVER_SOFTWARE'], 'iis' ) !== false ) : ?>
-				<code>Microsoft IIS</code>
-			<?php else : ?>
-				<span style="padding: 0 2px;background-color: #FFFF00">Not detected</span>
-			<?php endif; ?>
+			<?php
+			$server_software = isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '';
+
+			switch ( true ) {
+				case stristr( $server_software, 'apache' ) !== false:
+					?>
+					<code>Apache</code>
+					<?php
+					break;
+				case stristr( $server_software, 'LiteSpeed' ) !== false:
+					?>
+					<code>Lite Speed</code>
+					<?php
+					break;
+				case stristr( $server_software, 'nginx' ) !== false:
+					?>
+					<code>nginx</code>
+					<?php
+					break;
+				case stristr( $server_software, 'lighttpd' ) !== false:
+					?>
+					<code>lighttpd</code>
+					<?php
+					break;
+				case stristr( $server_software, 'iis' ) !== false:
+					?>
+					<code>Microsoft IIS</code>
+					<?php
+					break;
+				default:
+					?>
+					<span style="padding: 0 2px;background-color: #FFFF00">Not detected</span>
+					<?php
+					break;
+			}
+			?>
 		</li>
 
 		<li>

--- a/inc/options/cdn/cf.php
+++ b/inc/options/cdn/cf.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * File: cf.php
+ *
+ * CloudFront CDN options page.
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
 if ( ! defined( 'W3TC' ) ) {
@@ -172,13 +180,13 @@ if ( ! defined( 'W3TC' ) ) {
 	</td>
 </tr>
 <tr>
-	<th><label for="cdn_cf_public_objects"><?php _e( 'Set objects to publicly accessible on upload:', 'w3-total-cache' ); ?></label></th>
+	<th><label for="cdn_cf_public_objects"><?php esc_html_e( 'Set objects to publicly accessible on upload:', 'w3-total-cache' ); ?></label></th>
 	<td>
 		<select id="cdn_cf_public_objects" name="cdn__cf__public_objects" <?php Util_Ui::sealing_disabled( 'cdn.' ); ?> >
 			<option value="enabled"<?php selected( $this->_config->get_string( 'cdn.cf.public_objects' ), 'enabled' ); ?>><?php esc_html_e( 'Enabled (apply the \'public-read\' ACL)', 'w3-total-cache' ); ?></option>
 			<option value="disabled"<?php selected( $this->_config->get_string( 'cdn.cf.public_objects' ), 'disabled' ); ?>><?php esc_html_e( 'Disabled (don\'t apply an ACL)', 'w3-total-cache' ); ?></option>
 		</select>
-		<p class="description"><?php _e( 'Objects in an S3 bucket served from CloudFront do not need to be publicly accessible. Set this value to disabled to ensure that objects are not publicly accessible and can only be accessed via CloudFront or with a suitable IAM role.', 'w3-total-cache' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Objects in an S3 bucket served from CloudFront do not need to be publicly accessible. Set this value to disabled to ensure that objects are not publicly accessible and can only be accessed via CloudFront or with a suitable IAM role.', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
 <tr>

--- a/inc/options/extensions/list.php
+++ b/inc/options/extensions/list.php
@@ -32,7 +32,7 @@ if ( ! defined( 'W3TC' ) ) {
 				<option value="activate-selected"><?php esc_html_e( 'Activate', 'w3-total-cache' ); ?></option>
 				<option value="deactivate-selected"><?php esc_html_e( 'Deactivate', 'w3-total-cache' ); ?></option>
 			</select>
-			<input type="submit" name="" id="doaction" class="w3tc-button-save button action" value="<?php esc_attr_e( 'Apply' ); ?>">
+			<input type="submit" name="" id="doaction" class="w3tc-button-save button action" value="<?php esc_attr_e( 'Apply', 'w3-total-cache' ); ?>">
 		</div>
 	<?php endif ?>
 
@@ -45,7 +45,8 @@ if ( ! defined( 'W3TC' ) ) {
 						// translators: 1 count of extensions.
 						_n_noop(
 							'%s extension',
-							'%s extensions'
+							'%s extensions',
+							'w3-total-cache'
 						),
 						count( $extensions ),
 						'w3-total-cache'
@@ -129,7 +130,7 @@ if ( ! defined( 'W3TC' ) ) {
 								<?php echo $links ? ' | ' : ''; ?>
 								<span class="deactivate">
 									<a href="<?php echo esc_url( wp_nonce_url( Util_Ui::admin_url( sprintf( 'admin.php?page=w3tc_extensions&action=deactivate&extension=%s&amp;extension_status=%s&amp;paged=%d', $extension, $extension_status, $page ) ), 'w3tc' ) ); ?>" title="<?php esc_attr_e( 'Deactivate this extension', 'w3-total-cache' ); ?> ">
-										<?php esc_html_e( 'Deactivate' ); ?>
+										<?php esc_html_e( 'Deactivate', 'w3-total-cache' ); ?>
 									</a>
 								</span>
 							<?php endif ?>
@@ -138,7 +139,7 @@ if ( ! defined( 'W3TC' ) ) {
 								<?php if ( $meta['enabled'] ) : ?>
 									<?php if ( ! $this->_config->is_sealed( 'extensions.active' ) ) : ?>
 										<a href="<?php echo esc_url( wp_nonce_url( Util_Ui::admin_url( sprintf( 'admin.php?page=w3tc_extensions&action=activate&extension=%s&amp;extension_status=%s&amp;paged=%d', $extension, $extension_status, $page ) ), 'w3tc' ) ); ?>" title="<?php esc_attr_e( 'Activate this extension', 'w3-total-cache' ); ?> ">
-											<?php esc_html_e( 'Activate' ); ?>
+											<?php esc_html_e( 'Activate', 'w3-total-cache' ); ?>
 										</a>
 									<?php endif ?>
 								<?php else : ?>
@@ -250,7 +251,8 @@ if ( ! defined( 'W3TC' ) ) {
 						// translators: 1 count of extensions.
 						_n_noop(
 							'%s extension',
-							'%s extensions'
+							'%s extensions',
+							'w3-total-cache'
 						),
 						count( $extensions ),
 						'w3-total-cache'

--- a/inc/options/minify/ccjs2.php
+++ b/inc/options/minify/ccjs2.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * File: ccjs2.php
+ *
+ * Options page: Minify - Closure Compiler JS
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
 if ( ! defined( 'W3TC' ) ) {
@@ -25,7 +33,7 @@ $compilation_level = $c->get_string( 'minify.ccjs.options.compilation_level' );
 		<input id="minify__ccjs__path__java" class="js_enabled" type="text"
 			<?php Util_Ui::sealing_disabled( 'minify.' ); ?>
 			name="minify__ccjs__path__java"
-			value="<?php esc_attr_e( $c->get_string( 'minify.ccjs.path.java' ), 'w3-total-cache' ); ?>"
+			value="<?php echo esc_attr( $c->get_string( 'minify.ccjs.path.java' ) ); ?>"
 			size="60" />
 	</td>
 </tr>
@@ -39,7 +47,7 @@ $compilation_level = $c->get_string( 'minify.ccjs.options.compilation_level' );
 		<input id="minify__ccjs__path__jar" class="js_enabled" type="text"
 			<?php Util_Ui::sealing_disabled( 'minify.' ); ?>
 			name="minify__ccjs__path__jar"
-			value="<?php esc_attr_e( $c->get_string( 'minify.ccjs.path.jar' ), 'w3-total-cache' ); ?>"
+			value="<?php echo esc_attr( $c->get_string( 'minify.ccjs.path.jar' ) ); ?>"
 			size="60" />
 	</td>
 </tr>
@@ -65,7 +73,7 @@ $compilation_level = $c->get_string( 'minify.ccjs.options.compilation_level' );
 			<?php foreach ( $compilation_levels as $compilation_level_key => $compilation_level_name ) : ?>
 				<option value="<?php echo esc_attr( $compilation_level_key ); ?>"
 					<?php selected( $compilation_level, $compilation_level_key ); ?>>
-					<?php esc_html_e( $compilation_level_name, 'w3-total-cache' ); ?>
+					<?php echo esc_html( $compilation_level_name ); ?>
 				</option>
 			<?php endforeach ?>
 		</select>

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -37,8 +37,8 @@ if ( ! defined( 'W3TC' ) ) {
 	$manage_label         = $alwayscached_enabled ? __( 'Manage the queue and settings', 'w3-total-cache' ) : __( 'To enable the extension click', 'w3-total-cache' );
 	$manage_link          = $alwayscached_enabled ? Util_Ui::admin_url( 'admin.php?page=w3tc_extensions&extension=alwayscached&action=view' ) : Util_Ui::admin_url( 'admin.php?page=w3tc_extensions' );
 	echo wp_kses(
-		// translators: 1 HTML span tag for feature status, 2 manage queue label, 3 HTML a tag to enable feature or manage settings.
 		sprintf(
+			// translators: 1 HTML span tag containing Always Cached extension enabled/disabled, 2 manage queue label, 3 HTML a tag to enable feature or manage settings.
 			__(
 				'Always Cached extension is currently %1$s. %2$s %3$s.',
 				'w3-total-cache'

--- a/inc/popup/common/footer.php
+++ b/inc/popup/common/footer.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * File: footer.php
+ *
+ * Footer.
+ *
+ * @package W3TC
+ */
+
+?>
 		</div>
 	</body>
 </html>

--- a/inc/popup/common/header.php
+++ b/inc/popup/common/header.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * File: header.php
+ *
+ * Header for popup windows.
+ *
+ * @package W3TC
+ *
+ * phpcs:disable WordPress.WP.EnqueuedResources,WordPress.WP.GlobalVariablesOverride
+ */
+
 namespace W3TC;
 
 if ( ! defined( 'W3TC' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1282,7 +1282,7 @@ Please reach out to all of these people and support their projects if you're so 
 This is a security update.  All users are encouraged to update to this version.
 
 = 2.8.1 =
-Users with Object Cache enabled using Disk storage should upgrade to this version to ensure proper garbage collection.  A memory-based engine is recommended for database and object cache engines.  Using the Disk option can lead to a large number of cache files.  Hosting accounts with inode limits may experience issues, including downtime, if limits are reached.
+Users with Object Cache using Disk should upgrade to ensure proper garbage collection.  A memory-based engine is recommended for database and object caches.  Using Disk can lead to a large number of files.  Hosting accounts with inode limits may experience issues, including downtime.
 
 = 2.7.3 =
 Thanks for using W3 Total Cache! The minimum required PHP version has been raised to PHP 7.2.5.  We recommend using PHP 8.  StackPath CDN has cased all operations and will be removed in a future release.  We recommend switching to Bunny CDN.
@@ -1306,13 +1306,13 @@ Thanks for using W3 Total Cache! This release includes fixes for recent XSS secu
 Thanks for using W3 Total Cache! This release introduces hundreds of well-tested stability fixes since the last release as well as a new mode called "edge mode," which allows us to make releases more often containing new features that are still undergoing testing or active iteration.
 
 = 0.9.2.11 =
-Thanks for using W3 Total Cache! This release includes various fixes for MaxCDN and minify users. As always there are general stability / compatibility improvements. Make sure to test in a sandbox or staging environment and report any issues via the bug submission form available on the support tab of the plugin.
+This release includes various fixes for MaxCDN and minify users. As always there are general stability / compatibility improvements. Make sure to test in a sandbox or staging environment and report any issues via the bug submission form available on the support tab of the plugin.
 
 = 0.9.2.10 =
-Thanks for using W3 Total Cache! This release includes performance improvements for every type of caching and numerous bug fixes and stability / compatbility improvements. Make sure to keep W3TC updated to ensure optimal reliability and security.
+This release includes performance improvements for every type of caching and numerous bug fixes and stability / compatbility improvements. Make sure to keep W3TC updated to ensure optimal reliability and security.
 
 = 0.9.2.9 =
-Thanks for using W3 Total Cache! This release addresses security issues for Cloudflare users as well as users that implement fragment caching via the mfunc functionality. For those using mfunc, temporarily disable page caching to allow yourself time to check the FAQ tab for new usage instructions; if you have a staging environment, that is the most convenient way to test prior to production roll out.
+This release addresses security issues for Cloudflare users as well as users that implement fragment caching via the mfunc functionality. For those using mfunc, temporarily disable page caching to allow yourself time to check the FAQ tab for new usage instructions.
 
 = 0.9.2.8 =
-Thanks for using W3 Total Cache! The recent releases attempted to use WordPress' built in support for managing files and folders and clearly has not worked. Since W3TC is a caching plugin, file management is a critical issue that will cause lots of issues if it doesn't work perfectly. This release is hopefully the last attempt to restore file management back to the reliability of previous versions (0.9.2.4 etc). We realize that having *any* problems is not acceptable, but caching means changing server behavior, so while this plugin is still in pre-release we're trying to focus on learning.
+WordPress attempts to use built-in support for managing files had issues. File management is a critical issue that will cause lots of issues if it doesn't work perfectly. This release is an attempt to restore file management back to the reliability of previous versions.

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -171,8 +171,8 @@ if ( ! defined( 'W3TC_FEED_REGEXP' ) ) {
 	define( 'W3TC_FEED_REGEXP', '~/feed(/|$)~' );
 }
 
-@ini_set( 'pcre.backtrack_limit', 4194304 );
-@ini_set( 'pcre.recursion_limit', 4194304 );
+@ini_set( 'pcre.backtrack_limit', 4194304 ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+@ini_set( 'pcre.recursion_limit', 4194304 ); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
 
 global $w3_late_init;
 $w3_late_init = false;


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG5-528

There are new filters that exclude the following items from the plugin check:
- Vendor packages
- External libraries
- Items removed in our build process; not in production releases

To test:
1. Install the "plugin-check" plugin
1. Run a check on W3TC (`wp-admin/tools.php?page=plugin-check` or `wp plugin check w3-total-cache`)
1. See success: "Checks complete. No errors found."
1. Run PHPUnit tests
1. Perform the usual smoke tests

```
$ wp plugin check w3-total-cache
Success: Checks complete. No errors found.
```
