### PR TITLE
Added FSD SSL test

### DIFF
--- a/Cdn_TotalCdn_Api.php
+++ b/Cdn_TotalCdn_Api.php
@@ -186,6 +186,7 @@ class Cdn_TotalCdn_Api {
 	 * @link https://developer.wordpress.org/reference/hooks/http_request_timeout/
 	 *
 	 * @param float $timeout_value Time in seconds until a request times out. Default 5.
+	 *
 	 * @return float The adjusted timeout time.
 	 */
 	public function filter_timeout_time( $timeout_value ): float {
@@ -258,14 +259,15 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param int $id The pull zone ID.
-	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_index2
+	 *
+	 * @param int $id The pull zone ID.
 	 *
 	 * @return array|WP_Error API response or error object.
 	 */
 	public function get_pull_zone( $id ) {
 		$this->api_type = 'account';
+		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
 		return $this->wp_remote_get(
 			\esc_url( $this->api_base_url . '/pullzone/' . $id )
@@ -277,14 +279,15 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param int $id The pull zone ID.
-	 *
 	 * @link https://cdn-api-dev-joec.boldgrid.com/docs/api#/operations/pullzone.get_from_provider
+	 *
+	 * @param int $id The pull zone ID.
 	 *
 	 * @return array|WP_Error API response or error object.
 	 */
 	public function get_pull_zone_from_provider( $id ) {
 		$this->api_type = 'account';
+		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
 		return $this->wp_remote_get(
 			\esc_url( $this->api_base_url . '/pullzone/' . $id . '/getFromProvider' )
@@ -296,9 +299,9 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param array $data Data for the new pull zone.
-	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_add
+	 *
+	 * @param array $data Data for the new pull zone.
 	 *
 	 * @return array|WP_Error API response or error object.
 	 *
@@ -336,10 +339,10 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
+	 * @link https://docs.bunny.net/reference/pullzonepublic_updatepullzone
+	 *
 	 * @param int   $id   The pull zone ID.
 	 * @param array $data Data for updating the pull zone.
-	 *
-	 * @link https://docs.bunny.net/reference/pullzonepublic_updatepullzone
 	 *
 	 * @return array|WP_Error API response or error object.
 	 *
@@ -347,7 +350,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function update_pull_zone( $id, array $data ) {
 		$this->api_type = 'account';
-		$id             = empty( $this->pull_zone_id ) ? $id : $this->pull_zone_id;
+		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
 		if ( empty( $id ) || ! \is_int( $id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -365,9 +368,9 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param int $id The pull zone ID.
-	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_delete
+	 *
+	 * @param int $id The pull zone ID.
 	 *
 	 * @return array|WP_Error API response or error object.
 	 *
@@ -375,7 +378,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function delete_pull_zone( $id ) {
 		$this->api_type = 'account';
-		$id             = empty( $this->pull_zone_id ) ? $id : $this->pull_zone_id;
+		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
 		if ( empty( $id ) || ! \is_int( $id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -404,7 +407,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function add_custom_hostname( $hostname, $pull_zone_id = null ) {
 		$this->api_type = 'account';
-		$pull_zone_id   = empty( $this->pull_zone_id ) ? $pull_zone_id : $this->pull_zone_id;
+		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
 		// Convert pullzone to int if it's a string.
 		if ( \is_string( $pull_zone_id ) ) {
@@ -441,7 +444,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function check_custom_hostname( string $hostname, ?int $pull_zone_id = null ) {
 		$this->api_type = 'account';
-		$pull_zone_id   = empty( $this->pull_zone_id ) ? $pull_zone_id : $this->pull_zone_id;
+		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
 		if ( empty( $pull_zone_id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -469,7 +472,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function load_free_certificate( $hostname, $pull_zone_id = null ) {
 		$this->api_type = 'account';
-		$pull_zone_id   = empty( $this->pull_zone_id ) ? $pull_zone_id : $this->pull_zone_id;
+		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
 		// Convert pullzone to int if it's a string.
 		if ( \is_string( $pull_zone_id ) ) {
@@ -511,7 +514,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function add_edge_rule( array $data, $pull_zone_id = null ) {
 		$this->api_type = 'account';
-		$pull_zone_id   = empty( $this->pull_zone_id ) ? $pull_zone_id : $this->pull_zone_id;
+		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
 		if ( empty( $pull_zone_id ) || ! \is_int( $pull_zone_id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -570,7 +573,7 @@ class Cdn_TotalCdn_Api {
 	 */
 	public function purge_pull_zone( $pull_zone_id = null ) {
 		$this->api_type = 'account';
-		$pull_zone_id   = empty( $this->pull_zone_id ) ? $pull_zone_id : $this->pull_zone_id;
+		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
 		if ( empty( $pull_zone_id ) || ! \is_int( $pull_zone_id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -583,10 +586,13 @@ class Cdn_TotalCdn_Api {
 	 * Verify that a specified hostname points to a Total CDN provider.
 	 *
 	 * @since X.X.X
+	 *
 	 * @link  https://cdn-api-dev.boldgrid.com/docs/api#/operations/dns.verifyCdnCname
 	 *
 	 * @param  string $hostname The hostname to verify.
+	 *
 	 * @return array|WP_Error API response or error object.
+	 *
 	 * @throws \Exception If the pull zone name is invalid.
 	 */
 	public function verify_hostname_cdn( string $hostname ) {

--- a/Cdn_TotalCdn_Api.php
+++ b/Cdn_TotalCdn_Api.php
@@ -273,6 +273,25 @@ class Cdn_TotalCdn_Api {
 	}
 
 	/**
+	 * Gets the details of a specific pull zone from the provider.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $id The pull zone ID.
+	 *
+	 * @link https://cdn-api-dev-joec.boldgrid.com/docs/api#/operations/pullzone.get_from_provider
+	 *
+	 * @return array|WP_Error API response or error object.
+	 */
+	public function get_pull_zone_from_provider( $id ) {
+		$this->api_type = 'account';
+
+		return $this->wp_remote_get(
+			\esc_url( $this->api_base_url . '/pullzone/' . $id . '/getFromProvider' )
+		);
+	}
+
+	/**
 	 * Adds a new pull zone.
 	 *
 	 * @since x.x.x

--- a/Cdn_TotalCdn_Api.php
+++ b/Cdn_TotalCdn_Api.php
@@ -261,11 +261,11 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_index2
 	 *
-	 * @param int $id The pull zone ID.
+	 * @param int|null $id The pull zone ID. (optional).
 	 *
 	 * @return array|WP_Error API response or error object.
 	 */
-	public function get_pull_zone( $id ) {
+	public function get_pull_zone( ?int $id = null ) {
 		$this->api_type = 'account';
 		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
@@ -281,11 +281,11 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @link https://cdn-api-dev-joec.boldgrid.com/docs/api#/operations/pullzone.get_from_provider
 	 *
-	 * @param int $id The pull zone ID.
+	 * @param int|null $id The pull zone ID. (optional).
 	 *
 	 * @return array|WP_Error API response or error object.
 	 */
-	public function get_pull_zone_from_provider( $id ) {
+	public function get_pull_zone_from_provider( ?int $id = null ) {
 		$this->api_type = 'account';
 		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
@@ -341,14 +341,14 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_updatepullzone
 	 *
-	 * @param int   $id   The pull zone ID.
-	 * @param array $data Data for updating the pull zone.
+	 * @param int|null $id The pull zone ID. (optional).
+	 * @param array    $data Data for updating the pull zone.
 	 *
 	 * @return array|WP_Error API response or error object.
 	 *
 	 * @throws \Exception If the pull zone ID is invalid.
 	 */
-	public function update_pull_zone( $id, array $data ) {
+	public function update_pull_zone( ?int $id = null, array $data ) {
 		$this->api_type = 'account';
 		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
@@ -370,13 +370,13 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @link https://docs.bunny.net/reference/pullzonepublic_delete
 	 *
-	 * @param int $id The pull zone ID.
+	 * @param int|null $id The pull zone ID. (optional).
 	 *
 	 * @return array|WP_Error API response or error object.
 	 *
 	 * @throws \Exception If the pull zone ID is invalid.
 	 */
-	public function delete_pull_zone( $id ) {
+	public function delete_pull_zone( ?int $id = null ) {
 		$this->api_type = 'account';
 		$id             = empty( $id ) ? $this->pull_zone_id : $id;
 
@@ -405,7 +405,7 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @throws \Exception If the pull zone ID or hostname is invalid.
 	 */
-	public function add_custom_hostname( $hostname, $pull_zone_id = null ) {
+	public function add_custom_hostname( $hostname, ?int $pull_zone_id = null ) {
 		$this->api_type = 'account';
 		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
@@ -465,19 +465,14 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param string $hostname     The custom hostname to add.
-	 * @param string $pull_zone_id The pull zone ID (optional).
+	 * @param string   $hostname     The custom hostname to add.
+	 * @param int|null $pull_zone_id The pull zone ID (optional).
 	 *
 	 * @throws \Exception If the pull zone ID or hostname is invalid.
 	 */
-	public function load_free_certificate( $hostname, $pull_zone_id = null ) {
+	public function load_free_certificate( $hostname, ?int $pull_zone_id = null ) {
 		$this->api_type = 'account';
 		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
-
-		// Convert pullzone to int if it's a string.
-		if ( \is_string( $pull_zone_id ) ) {
-			$pull_zone_id = (int) $pull_zone_id;
-		}
 
 		if ( empty( $pull_zone_id ) || ! \is_int( $pull_zone_id ) ) {
 			throw new \Exception( \esc_html__( 'Invalid pull zone id.', 'w3-total-cache' ) );
@@ -512,7 +507,7 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @throws \Exception If any required parameters are missing or invalid.
 	 */
-	public function add_edge_rule( array $data, $pull_zone_id = null ) {
+	public function add_edge_rule( array $data, ?int $pull_zone_id = null ) {
 		$this->api_type = 'account';
 		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 
@@ -571,7 +566,7 @@ class Cdn_TotalCdn_Api {
 	 *
 	 * @throws \Exception If the pull zone ID is invalid.
 	 */
-	public function purge_pull_zone( $pull_zone_id = null ) {
+	public function purge_pull_zone( ?int $pull_zone_id = null ) {
 		$this->api_type = 'account';
 		$pull_zone_id   = empty( $pull_zone_id ) ? $this->pull_zone_id : $pull_zone_id;
 

--- a/Cdnfsd_TotalCdn_Page.php
+++ b/Cdnfsd_TotalCdn_Page.php
@@ -25,8 +25,9 @@ class Cdnfsd_TotalCdn_Page {
 	public static function w3tc_ajax() {
 		$instance = new self();
 
-		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ), 10 );
 		\add_filter( 'w3tc_fsd_totalcdn_hostname', array( '\W3TC\Cdnfsd_TotalCdn_Status_Hostname', 'test_hostname_status' ), 10 );
+		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ), 10 );
+		\add_filter( 'w3tc_fsd_totalcdn_ssl', array( '\W3TC\Cdnfsd_TotalCdn_Status_Ssl', 'test_ssl_status' ), 10 );
 		\add_action( 'w3tc_ajax_cdn_totalcdn_fsd_status_check', array( $instance, 'w3tc_ajax_cdn_totalcdn_fsd_status_check' ) );
 	}
 

--- a/Cdnfsd_TotalCdn_Page.php
+++ b/Cdnfsd_TotalCdn_Page.php
@@ -25,9 +25,9 @@ class Cdnfsd_TotalCdn_Page {
 	public static function w3tc_ajax() {
 		$instance = new self();
 
-		\add_filter( 'w3tc_fsd_totalcdn_hostname', array( '\W3TC\Cdnfsd_TotalCdn_Status_Hostname', 'test_hostname_status' ), 10 );
-		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ), 10 );
-		\add_filter( 'w3tc_fsd_totalcdn_ssl', array( '\W3TC\Cdnfsd_TotalCdn_Status_Ssl', 'test_ssl_status' ), 10 );
+		\add_filter( 'w3tc_fsd_totalcdn_hostname', array( '\W3TC\Cdnfsd_TotalCdn_Status_Hostname', 'test_hostname_status' ) );
+		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ) );
+		\add_filter( 'w3tc_fsd_totalcdn_ssl', array( '\W3TC\Cdnfsd_TotalCdn_Status_Ssl', 'test_ssl_status' ) );
 		\add_action( 'w3tc_ajax_cdn_totalcdn_fsd_status_check', array( $instance, 'w3tc_ajax_cdn_totalcdn_fsd_status_check' ) );
 	}
 

--- a/Cdnfsd_TotalCdn_Page.php
+++ b/Cdnfsd_TotalCdn_Page.php
@@ -25,6 +25,7 @@ class Cdnfsd_TotalCdn_Page {
 	public static function w3tc_ajax() {
 		$instance = new self();
 
+		\add_filter( 'w3tc_fsd_totalcdn_dns', array( '\W3TC\Cdnfsd_TotalCdn_Status_Dns', 'test_dns_status' ), 10 );
 		\add_filter( 'w3tc_fsd_totalcdn_hostname', array( '\W3TC\Cdnfsd_TotalCdn_Status_Hostname', 'test_hostname_status' ), 10 );
 		\add_action( 'w3tc_ajax_cdn_totalcdn_fsd_status_check', array( $instance, 'w3tc_ajax_cdn_totalcdn_fsd_status_check' ) );
 	}
@@ -128,6 +129,10 @@ class Cdnfsd_TotalCdn_Page {
 		$errors  = array();
 
 		foreach ( $tests as $test ) {
+			if ( ! has_filter( $test['filter'] ) ) {
+				break;
+			}
+
 			$test_result            = self::execute_test( $test );
 			$results[ $test['id'] ] = $test_result['status'];
 
@@ -150,9 +155,7 @@ class Cdnfsd_TotalCdn_Page {
 				);
 			}
 		} elseif (
-			! empty( $results )
-			&& \count( \array_unique( $results ) ) === 1
-			&& 'untested' === \reset( $results )
+			empty( $results )
 		) {
 			$notices[] = array(
 				'type'    => 'warning',
@@ -240,7 +243,7 @@ class Cdnfsd_TotalCdn_Page {
 
 		return \sprintf(
 			/* translators: 1: Total CDN test title. */
-			\esc_html__( '%s failed.', 'w3-total-cache' ),
+			\esc_html__( '%s: status check failed.', 'w3-total-cache' ),
 			\esc_html( $title )
 		);
 	}

--- a/Cdnfsd_TotalCdn_Status_Dns.php
+++ b/Cdnfsd_TotalCdn_Status_Dns.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * File: Cdnfsd_TotalCdn_Status_Dns.php
+ *
+ * @since X.X.X
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+defined( 'W3TC' ) || die;
+
+/**
+ * Class: Cdnfsd_TotalCdn_Status_Dns
+ *
+ * @since X.X.X
+ */
+class Cdnfsd_TotalCdn_Status_Dns {
+	/**
+	 * Runs the Total CDN dns status test.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array {
+	 *     Test result data.
+	 *
+	 *     @type string $status  Normalized status string (pass|fail|untested).
+	 *     @type string $message Optional message describing the outcome.
+	 *     @type string $log     Optional technical error message.
+	 * }
+	 */
+	public static function test_dns_status() {
+		$config = Dispatcher::config();
+
+		$account_api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
+		$pull_zone_id    = (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+
+		$hostname = Util_Environment::get_site_hostname();
+
+		if ( empty( $hostname ) ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Unable to determine the site hostname.', 'w3-total-cache' ),
+			);
+		}
+
+		$api = new Cdn_TotalCdn_Api(
+			array(
+				'account_api_key' => $account_api_key,
+				'pull_zone_id'    => $pull_zone_id,
+			)
+		);
+
+		try {
+			$response = $api->verify_hostname_cdn( $hostname );
+		} catch ( \Exception $exception ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Failed to verify if the hostname points to a CDN provider.', 'w3-total-cache' ),
+				'log'     => $exception->getMessage(),
+			);
+		}
+
+		$verified = isset( $response['Success'] ) ? (bool) $response['Success'] : false;
+		if ( ! $verified ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \sprintf(
+					// Translators: 1 host name.
+					\__( '%1$s is not pointed to a CDN provider', 'w3-total-cache' ),
+					$hostname
+				),
+			);
+		}
+
+		return array(
+			'status'  => 'pass',
+			'message' => \__( 'The custom hostname is pointed to a CDN provider.', 'w3-total-cache' ),
+		);
+	}
+}

--- a/Cdnfsd_TotalCdn_Status_Ssl.php
+++ b/Cdnfsd_TotalCdn_Status_Ssl.php
@@ -44,7 +44,7 @@ class Cdnfsd_TotalCdn_Status_Ssl {
 		);
 
 		try {
-			$response = $api->get_pull_zone_from_provider( $pull_zone_id );
+			$response = $api->get_pull_zone_from_provider();
 		} catch ( \Exception $exception ) {
 			return array(
 				'status'  => 'fail',
@@ -67,10 +67,10 @@ class Cdnfsd_TotalCdn_Status_Ssl {
 		$hostnames = isset( $response['Hostnames'] ) && is_array( $response['Hostnames'] ) ? $response['Hostnames'] : array();
 
 		foreach ( $hostnames as $entry ) {
-			$value = isset( $entry['Value'] ) ? strtolower( (string) $entry['Value'] ) : '';
-			$cert  = isset( $entry['HasCertificate'] ) ? (bool) $entry['HasCertificate'] : false;
+			$value = isset( $entry['Value'] ) ? strtolower( $entry['Value'] ) : '';
+			$cert  = isset( $entry['HasCertificate'] ) ? $entry['HasCertificate'] : false;
 			// Compare the hostnames in a normalized (case-insensitive) way.
-			if ( $value === $hostname && $cert ) {
+			if ( $value === $hostname && true === $cert ) {
 				$has_ssl = true;
 				break;
 			}

--- a/Cdnfsd_TotalCdn_Status_Ssl.php
+++ b/Cdnfsd_TotalCdn_Status_Ssl.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * File: Cdnfsd_TotalCdn_Status_Ssl.php
+ *
+ * @since X.X.X
+ *
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+defined( 'W3TC' ) || die;
+
+/**
+ * Class: Cdnfsd_TotalCdn_Status_Ssl
+ *
+ * @since X.X.X
+ */
+class Cdnfsd_TotalCdn_Status_Ssl {
+	/**
+	 * Runs the Total CDN SSL status test.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array {
+	 *     Test result data.
+	 *
+	 *     @type string $status  Normalized status string (pass|fail|untested).
+	 *     @type string $message Optional message describing the outcome.
+	 *     @type string $log     Optional technical error message.
+	 * }
+	 */
+	public static function test_ssl_status() {
+		$config = Dispatcher::config();
+
+		$account_api_key = $config->get_string( 'cdn.totalcdn.account_api_key' );
+		$pull_zone_id    = (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+
+		$api = new Cdn_TotalCdn_Api(
+			array(
+				'account_api_key' => $account_api_key,
+				'pull_zone_id'    => $pull_zone_id,
+			)
+		);
+
+		try {
+			$response = $api->get_pull_zone_from_provider( $pull_zone_id );
+		} catch ( \Exception $exception ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Failed to fetch pull zone info from CDN provider.', 'w3-total-cache' ),
+				'log'     => $exception->getMessage(),
+			);
+		}
+
+		$hostname = Util_Environment::get_site_hostname();
+
+		if ( empty( $hostname ) ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Unable to determine the site hostname.', 'w3-total-cache' ),
+			);
+		}
+
+		$has_ssl = false;
+
+		$hostnames = isset( $response['Hostnames'] ) && is_array( $response['Hostnames'] ) ? $response['Hostnames'] : array();
+
+		foreach ( $hostnames as $entry ) {
+			$value = isset( $entry['Value'] ) ? strtolower( (string) $entry['Value'] ) : '';
+			$cert  = isset( $entry['HasCertificate'] ) ? (bool) $entry['HasCertificate'] : false;
+			// Compare the hostnames in a normalized (case-insensitive) way.
+			if ( $value === $hostname && $cert ) {
+				$has_ssl = true;
+				break;
+			}
+		}
+
+		if ( $has_ssl ) {
+			return array(
+				'status'  => 'pass',
+				'message' => __( 'SSL certificate detected for pull zone hostname.', 'w3-total-cache' ),
+			);
+		}
+
+		try {
+			$api->load_free_certificate( $hostname, $pull_zone_id );
+		} catch ( \Exception $exception ) {
+			return array(
+				'status'  => 'fail',
+				'message' => \__( 'Failed to add SSL certificate to pull zone.', 'w3-total-cache' ),
+				'log'     => $exception->getMessage(),
+			);
+		}
+
+		return array(
+			'status'  => 'pass',
+			'message' => \__( 'Successfully added SSL certificate to pull zone.', 'w3-total-cache' ),
+		);
+	}
+}


### PR DESCRIPTION
This PR adds the SSL status test for the CDN FSD status section

To test setup with a pro license with total CDN and enable/configure FSD. This should set the hostname on save. Then you will need your DNS pointed at the CDN

Then go to the CDN settings page and click on the Check Status button within the FSD box. It should pass. To see the failure state modify Cdnfsd_TotalCdn_Status_Ssl.php to manually trigger a failure

If you remove the ssl from the pull zone manually and then perform the check, it should re-add it and pass the test
