### PR TITLE
Update origin URL after enabling FSD

### DIFF
--- a/Cdn_TotalCdn_Api.php
+++ b/Cdn_TotalCdn_Api.php
@@ -591,6 +591,27 @@ class Cdn_TotalCdn_Api {
 	}
 
 	/**
+	 * Retrieves the site IP address reported by the CDN API.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string Resolved IP address.
+	 *
+	 * @throws \Exception If the API response does not contain a valid IP.
+	 */
+	public function get_origin_ip_address(): string {
+		$this->api_type = 'account';
+
+		$response = $this->wp_remote_get( $this->api_base_url . '/request/ip' );
+
+		if ( empty( $response['IpAddress'] ) || ! \is_string( $response['IpAddress'] ) ) {
+			throw new \Exception( \esc_html__( 'Unable to determine the site IP address for Full Site Delivery.', 'w3-total-cache' ) );
+		}
+
+		return $response['IpAddress'];
+	}
+
+	/**
 	 * Retrieves the appropriate API key based on the specified type.
 	 *
 	 * @since x.x.x

--- a/Cdn_TotalCdn_Fsd_Origin.php
+++ b/Cdn_TotalCdn_Fsd_Origin.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * File: Cdn_TotalCdn_Fsd_Origin.php
+ *
+ * @since   X.X.X
+ * @package W3TC
+ */
+
+namespace W3TC;
+
+/**
+ * Handles updating the Total CDN origin when Full Site Delivery is enabled.
+ *
+ * @since X.X.X
+ */
+class Cdn_TotalCdn_Fsd_Origin {
+	/**
+	 * Determines whether the origin should be updated when saving settings.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param Config      $new_config New configuration values.
+	 * @param Config|null $old_config Previous configuration values.
+	 *
+	 * @return bool True when the origin requires an update.
+	 */
+	public static function should_update_on_save( Config $new_config, ?Config $old_config = null ): bool {
+		if ( ! self::is_applicable( $new_config ) ) {
+			return false;
+		}
+
+		if ( ! $old_config || ! self::is_applicable( $old_config ) ) {
+			return true;
+		}
+
+		if ( ! $old_config->get_boolean( 'cdnfsd.enabled' ) && $new_config->get_boolean( 'cdnfsd.enabled' ) ) {
+			return true;
+		}
+
+		if ( 'totalcdn' !== $old_config->get_string( 'cdnfsd.engine' ) ) {
+			return true;
+		}
+
+		$new_zone_id = (int) $new_config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+		$old_zone_id = (int) $old_config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+
+		if ( $new_zone_id > 0 && $new_zone_id !== $old_zone_id ) {
+			return true;
+		}
+
+		$new_origin = $new_config->get_string( 'cdn.totalcdn.origin_url' );
+
+		if ( ! self::origin_uses_ip( $new_origin ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Updates the origin URL and host header for the configured pull zone.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param Config $config Configuration instance.
+	 * @param array  $args   {
+	 *     Optional arguments.
+	 *
+	 *     @type \W3TC\Cdn_TotalCdn_Api $api Preconfigured API instance (primarily for testing).
+	 * }
+	 *
+	 * @return array {
+	 *     Result details.
+	 *
+	 *     @type bool        $success     True when the origin was updated.
+	 *     @type bool        $skipped     True when no update was required.
+	 *     @type string|null $ip_address  Resolved IP address.
+	 *     @type string|null $origin_url  Origin URL applied to the pull zone.
+	 *     @type string|null $host_header Host header applied to the pull zone.
+	 *     @type string|null $error       Error message when unsuccessful.
+	 * }
+	 */
+	public static function ensure( Config $config, array $args = array() ): array {
+		$result = array(
+			'success'     => false,
+			'skipped'     => false,
+			'ip_address'  => null,
+			'origin_url'  => null,
+			'host_header' => null,
+			'error'       => null,
+		);
+
+		if ( ! self::is_applicable( $config ) ) {
+			$result['success'] = true;
+			$result['skipped'] = true;
+			return $result;
+		}
+
+		$host_header = Util_Environment::get_site_hostname();
+
+		if ( empty( $host_header ) ) {
+			$result['error'] = \__( 'Unable to determine the site hostname required for Full Site Delivery.', 'w3-total-cache' );
+			return $result;
+		}
+
+		$pull_zone_id = (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' );
+
+		try {
+			$api = isset( $args['api'] ) && $args['api'] instanceof Cdn_TotalCdn_Api
+				? $args['api']
+				: new Cdn_TotalCdn_Api(
+					array(
+						'account_api_key' => $config->get_string( 'cdn.totalcdn.account_api_key' ),
+						'pull_zone_id'    => $pull_zone_id,
+					)
+				);
+		} catch ( \Exception $exception ) {
+			$result['error'] = $exception->getMessage();
+			return $result;
+		}
+
+		try {
+			$ip_address = $api->get_origin_ip_address();
+		} catch ( \Exception $exception ) {
+			$result['error'] = $exception->getMessage();
+			return $result;
+		}
+
+		if ( empty( $ip_address ) || false === \filter_var( $ip_address, FILTER_VALIDATE_IP ) ) {
+			$result['error'] = \__( 'The CDN API did not return a valid IP address for Full Site Delivery.', 'w3-total-cache' );
+			return $result;
+		}
+
+		$site_url = \get_option( 'siteurl' );
+		if ( ! \is_string( $site_url ) || '' === $site_url ) {
+			$site_url = \home_url();
+		}
+
+		$scheme = \wp_parse_url( $site_url, PHP_URL_SCHEME );
+		if ( empty( $scheme ) ) {
+			$scheme = \is_ssl() ? 'https' : 'http';
+		}
+
+		$origin_url = $scheme . '://' . $ip_address;
+
+		try {
+			$api->update_pull_zone(
+				$pull_zone_id,
+				array(
+					'OriginUrl'        => $origin_url,
+					'OriginHostHeader' => $host_header,
+				)
+			);
+		} catch ( \Exception $exception ) {
+			$result['error'] = $exception->getMessage();
+			return $result;
+		}
+
+		$config->set( 'cdn.totalcdn.origin_url', $origin_url );
+		$config->set( 'cdnfsd.totalcdn.origin_url', $origin_url );
+
+		$result['success']     = true;
+		$result['ip_address']  = $ip_address;
+		$result['origin_url']  = $origin_url;
+		$result['host_header'] = $host_header;
+
+		return $result;
+	}
+
+	/**
+	 * Determines if the configuration meets the requirements for an origin update.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param Config $config Configuration instance.
+	 *
+	 * @return bool True when the configuration is applicable.
+	 */
+	private static function is_applicable( Config $config ): bool {
+		if ( ! $config->get_boolean( 'cdnfsd.enabled' ) ) {
+			return false;
+		}
+
+		if ( 'totalcdn' !== $config->get_string( 'cdnfsd.engine' ) ) {
+			return false;
+		}
+
+		if ( empty( $config->get_string( 'cdn.totalcdn.account_api_key' ) ) ) {
+			return false;
+		}
+
+		if ( (int) $config->get_integer( 'cdn.totalcdn.pull_zone_id' ) <= 0 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determines whether the supplied origin URL contains a valid IP host.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $origin_url Origin URL to evaluate.
+	 *
+	 * @return bool True when the origin host is an IP address.
+	 */
+	private static function origin_uses_ip( string $origin_url ): bool {
+		if ( empty( $origin_url ) ) {
+			return false;
+		}
+
+		$host = \wp_parse_url( $origin_url, PHP_URL_HOST );
+
+		return ! empty( $host ) && false !== \filter_var( $host, FILTER_VALIDATE_IP );
+	}
+}

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -204,6 +204,14 @@ class Generic_Plugin_Admin {
 			}
 		}
 
+		if ( Cdn_TotalCdn_Fsd_Origin::should_update_on_save( $new_config, $old_config ) ) {
+			$result = Cdn_TotalCdn_Fsd_Origin::ensure( $new_config );
+
+			if ( empty( $result['success'] ) && empty( $result['skipped'] ) ) {
+				$data['response_errors'][] = 'cdn_totalcdn_fsd_origin_update_failed';
+			}
+		}
+
 		return $data;
 	}
 
@@ -1146,6 +1154,7 @@ class Generic_Plugin_Admin {
 				'<acronym title="' . esc_attr__( 'Content Delivery Network', 'w3-total-cache' ) . '">' . esc_html__( 'CDN', 'w3-total-cache' ) . '</acronym>'
 			),
 			'updated_pullzone_url'                    => __( 'Pull Zone URL could not be automatically updated. Please contact support for assistance.', 'w3-total-cache' ),
+			'cdn_totalcdn_fsd_origin_update_failed'  => __( 'Unable to update the Total CDN origin for Full Site Delivery. Please contact support for assistance.', 'w3-total-cache' ),
 			'cdn_totalcdn_fsd_custom_hostname_failed' => Cdn_TotalCdn_CustomHostname::failure_message(),
 		);
 

--- a/tests/admin/class-w3tc-cdn-totalcdn-fsd-origin-test.php
+++ b/tests/admin/class-w3tc-cdn-totalcdn-fsd-origin-test.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * File: class-w3tc-cdn-totalcdn-fsd-origin-test.php
+ *
+ * @package    W3TC
+ * @subpackage W3TC/tests/admin
+ * @since      X.X.X
+ */
+
+declare( strict_types = 1 );
+
+use W3TC\Cdn_TotalCdn_Api;
+use W3TC\Cdn_TotalCdn_Fsd_Origin;
+use W3TC\Config;
+
+/**
+ * Class: W3tc_Cdn_TotalCdn_Fsd_Origin_Test
+ *
+ * @since X.X.X
+ */
+class W3tc_Cdn_TotalCdn_Fsd_Origin_Test extends WP_UnitTestCase {
+	/**
+	 * Stored config data keyed by mock object id.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var array
+	 */
+	private $config_storage = array();
+
+	/**
+	 * Callback used to override the site URL for predictable host headers.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var callable|null
+	 */
+	private $site_filter = null;
+
+	/**
+	 * Sets up default configuration storage and site filters.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config_storage = array();
+
+		$this->site_filter = function() {
+			return 'https://example.com';
+		};
+
+		add_filter( 'pre_option_siteurl', $this->site_filter );
+		add_filter( 'pre_option_home', $this->site_filter );
+	}
+
+	/**
+	 * Tears down stored configuration and removes filters.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		if ( $this->site_filter ) {
+			remove_filter( 'pre_option_siteurl', $this->site_filter );
+			remove_filter( 'pre_option_home', $this->site_filter );
+		}
+
+		$this->site_filter    = null;
+		$this->config_storage = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensures should_update_on_save() returns false when FSD is not applicable.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_should_update_on_save_returns_false_when_not_applicable(): void {
+		$config = $this->create_config_mock(
+			array(
+				'cdnfsd.enabled' => false,
+			)
+		);
+
+		$this->assertFalse( Cdn_TotalCdn_Fsd_Origin::should_update_on_save( $config ) );
+	}
+
+	/**
+	 * Confirms should_update_on_save() triggers when enabling FSD.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_should_update_on_save_returns_true_when_enabling_fsd(): void {
+		$new_config = $this->create_config_mock(
+			array(
+				'cdnfsd.enabled' => true,
+			)
+		);
+		$old_config = $this->create_config_mock(
+			array(
+				'cdnfsd.enabled' => false,
+			)
+		);
+
+		$this->assertTrue( Cdn_TotalCdn_Fsd_Origin::should_update_on_save( $new_config, $old_config ) );
+	}
+
+	/**
+	 * Verifies should_update_on_save() executes when the origin is not an IP.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_should_update_on_save_returns_true_when_origin_not_ip(): void {
+		$new_config = $this->create_config_mock(
+			array(
+				'cdn.totalcdn.origin_url' => 'https://example.com',
+			)
+		);
+		$old_config = $this->create_config_mock(
+			array(
+				'cdn.totalcdn.origin_url' => 'https://example.com',
+			)
+		);
+
+		$this->assertTrue( Cdn_TotalCdn_Fsd_Origin::should_update_on_save( $new_config, $old_config ) );
+	}
+
+	/**
+	 * Ensures should_update_on_save() skips when the origin already uses an IP address.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_should_update_on_save_returns_false_when_origin_uses_ip(): void {
+		$origin_url = 'https://203.0.113.1';
+
+		$new_config = $this->create_config_mock(
+			array(
+				'cdn.totalcdn.origin_url' => $origin_url,
+			)
+		);
+		$old_config = $this->create_config_mock(
+			array(
+				'cdn.totalcdn.origin_url' => $origin_url,
+			)
+		);
+
+		$this->assertFalse( Cdn_TotalCdn_Fsd_Origin::should_update_on_save( $new_config, $old_config ) );
+	}
+
+	/**
+	 * Confirms ensure() bails with a skipped result when not applicable.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ensure_skips_when_not_applicable(): void {
+		$config = $this->create_config_mock(
+			array(
+				'cdnfsd.enabled' => false,
+			)
+		);
+
+		$result = Cdn_TotalCdn_Fsd_Origin::ensure( $config );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['skipped'] );
+	}
+
+	/**
+	 * Verifies ensure() updates the origin and records configuration values.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ensure_updates_origin_and_config(): void {
+		$config = $this->create_config_mock();
+
+		$api = $this->getMockBuilder( Cdn_TotalCdn_Api::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_origin_ip_address', 'update_pull_zone' ) )
+			->getMock();
+
+		$api->expects( $this->once() )
+			->method( 'get_origin_ip_address' )
+			->willReturn( '198.51.100.10' );
+
+		$api->expects( $this->once() )
+			->method( 'update_pull_zone' )
+			->with(
+				$this->equalTo( 1 ),
+				$this->callback(
+					function( $payload ) {
+						$this->assertSame( 'https://198.51.100.10', $payload['OriginUrl'] );
+						$this->assertSame( 'example.com', $payload['OriginHostHeader'] );
+						return true;
+					}
+				)
+			)
+			->willReturn( array( 'success' => true ) );
+
+		$result = Cdn_TotalCdn_Fsd_Origin::ensure(
+			$config,
+			array(
+				'api' => $api,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['skipped'] );
+		$this->assertSame( '198.51.100.10', $result['ip_address'] );
+		$this->assertSame( 'https://198.51.100.10', $result['origin_url'] );
+		$this->assertSame( 'example.com', $result['host_header'] );
+		$this->assertSame( 'https://198.51.100.10', $this->get_config_storage_value( $config, 'cdn.totalcdn.origin_url' ) );
+		$this->assertSame( 'https://198.51.100.10', $this->get_config_storage_value( $config, 'cdnfsd.totalcdn.origin_url' ) );
+	}
+
+	/**
+	 * Ensures ensure() reports an error when the API does not provide a valid IP.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ensure_returns_error_when_api_returns_invalid_ip(): void {
+		$config = $this->create_config_mock();
+
+		$api = $this->getMockBuilder( Cdn_TotalCdn_Api::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_origin_ip_address', 'update_pull_zone' ) )
+			->getMock();
+
+		$api->expects( $this->once() )
+			->method( 'get_origin_ip_address' )
+			->willReturn( 'not-an-ip' );
+
+		$api->expects( $this->never() )
+			->method( 'update_pull_zone' );
+
+		$result = Cdn_TotalCdn_Fsd_Origin::ensure(
+			$config,
+			array(
+				'api' => $api,
+			)
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame(
+			__( 'The CDN API did not return a valid IP address for Full Site Delivery.', 'w3-total-cache' ),
+			$result['error']
+		);
+	}
+
+	/**
+	 * Creates a configuration mock with default values and overridable storage.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $values Optional values to override.
+	 *
+	 * @return Config
+	 */
+	private function create_config_mock( array $values = array() ): Config {
+		$defaults = array(
+			'cdnfsd.enabled'               => true,
+			'cdnfsd.engine'                => 'totalcdn',
+			'cdn.totalcdn.account_api_key' => 'account-key',
+			'cdn.totalcdn.pull_zone_id'    => 1,
+			'cdn.totalcdn.origin_url'      => 'https://example.com',
+			'cdnfsd.totalcdn.origin_url'   => '',
+		);
+
+		$storage = array_merge( $defaults, $values );
+
+		$config = $this->getMockBuilder( Config::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_boolean', 'get_string', 'get_integer', 'set', 'save' ) )
+			->getMock();
+
+		$config->method( 'get_boolean' )->willReturnCallback(
+			function( $key ) use ( &$storage ) {
+				return ! empty( $storage[ $key ] );
+			}
+		);
+
+		$config->method( 'get_string' )->willReturnCallback(
+			function( $key ) use ( &$storage ) {
+				return isset( $storage[ $key ] ) ? (string) $storage[ $key ] : '';
+			}
+		);
+
+		$config->method( 'get_integer' )->willReturnCallback(
+			function( $key ) use ( &$storage ) {
+				return isset( $storage[ $key ] ) ? (int) $storage[ $key ] : 0;
+			}
+		);
+
+		$config->method( 'set' )->willReturnCallback(
+			function( $key, $value ) use ( &$storage ) {
+				$storage[ $key ] = $value;
+			}
+		);
+
+		$this->config_storage[ spl_object_id( $config ) ] = &$storage;
+
+		return $config;
+	}
+
+	/**
+	 * Retrieves a stored configuration value for assertions.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param Config $config Config mock reference.
+	 * @param string $key    Config key to fetch.
+	 *
+	 * @return mixed|null
+	 */
+	private function get_config_storage_value( Config $config, string $key ) {
+		$object_id = spl_object_id( $config );
+
+		if ( ! isset( $this->config_storage[ $object_id ] ) ) {
+			return null;
+		}
+
+		return isset( $this->config_storage[ $object_id ][ $key ] ) ? $this->config_storage[ $object_id ][ $key ] : null;
+	}
+}


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG5-451

To test:
1. Have a license with Pro and TCDN
1. Enable FSD
1. See that your origin URL has been configured to use your site's IP on the protocol that matches your siteurl
1. The host header on the pull zone matches your siteurl hostname
1. Disable FSD and enable CDN
1. An admin notice is raised to ask to update the origin URL back to the hostname (not part of this PR)