### PR TITLE
mfunc fix

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -226,9 +226,11 @@ class Generic_Plugin {
 			$value = $original;
 		}
 
+		// The W3TC_DYNAMIC_SECURITY constant should be a unique string and not an int or boolean.
 		if ( 1 === (int) W3TC_DYNAMIC_SECURITY ) {
 			return $value;
 		}
+
 		return str_replace( W3TC_DYNAMIC_SECURITY, '', $value );
 	}
 

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -2084,6 +2084,7 @@ class PgCache_ContentGrabber {
 	 * @return string The buffer with parsed dynamic content.
 	 */
 	public function _parse_dynamic( $buffer ) {
+		// The W3TC_DYNAMIC_SECURITY constant should be a unique string and not an int or boolean.
 		if ( ! defined( 'W3TC_DYNAMIC_SECURITY' ) || empty( W3TC_DYNAMIC_SECURITY ) || 1 === (int) W3TC_DYNAMIC_SECURITY ) {
 			return $buffer;
 		}


### PR DESCRIPTION
This PR addresses an issue with the "1" character being stripped from REST API responses if the W3TC_DYNAMIC_SECURITY is set as 1 or true. This also prevents mfunc from executing if the constant is set to 1 or true

W3TC_DYNAMIC_SECURITY should be a unique string and NOT an int or boolean value