### PR TITLE
Rackspace Cloud Files API - Fix 404 Bug

### DIFF
--- a/Cdn_RackSpace_Api_CloudFiles.php
+++ b/Cdn_RackSpace_Api_CloudFiles.php
@@ -199,7 +199,7 @@ class Cdn_RackSpace_Api_CloudFiles {
 				)
 			);
 
-			if ( '404' === $result['response']['code'] ) {
+			if ( 404 === (int) $result['response']['code'] ) {
 				return null;
 			}
 


### PR DESCRIPTION
This simple PR addresses a potential bug where the API response returns an int, but the 404 check is a string comparison. The fix simply casts the response code to an int and does an int comparison to eliminate any potential data type mismatches.