### PR TITLE
Fixed issues with output buffering

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1086,6 +1086,8 @@ class Generic_Plugin {
 	 * open output buffers after every shutdown function has run, which keeps
 	 * response headers open for any remaining shutdown handlers (e.g. late
 	 * setcookie() or header() calls from other plugins or session libraries).
+	 * The same removal runs on the early-return path when our buffer was
+	 * already closed, so Core does not flush at priority 1 before those hooks.
 	 *
 	 * @since X.X.X
 	 *
@@ -1123,7 +1125,15 @@ class Generic_Plugin {
 		}
 
 		if ( ob_get_level() < $this->_ob_level ) {
-			// Our buffer was already closed (e.g. by a redirect or wp_die).
+			/*
+			 * Our buffer was already closed (e.g. by a redirect or wp_die). Still
+			 * remove wp_ob_end_flush_all so shutdown priority 1 does not flush
+			 * remaining buffers before later hooks (e.g. setcookie at priority 999).
+			 * When headers are already committed, late header() calls still fail
+			 * harmlessly; when output remains buffered elsewhere, this preserves
+			 * compatibility with session/cookie finalization on shutdown.
+			 */
+			remove_action( 'shutdown', 'wp_ob_end_flush_all', 1 );
 			return;
 		}
 

--- a/tests/test-generic-plugin.php
+++ b/tests/test-generic-plugin.php
@@ -546,6 +546,43 @@ class Generic_Plugin_ObShutdown_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the W3TC buffer was already closed, ob_shutdown() must still remove
+	 * wp_ob_end_flush_all so Core does not flush at shutdown priority 1 before
+	 * late handlers (e.g. setcookie at priority 999).
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ob_shutdown_early_return_still_removes_wp_ob_end_flush_all() {
+		$original_priority = has_action( 'shutdown', 'wp_ob_end_flush_all' );
+
+		try {
+			add_action( 'shutdown', 'wp_ob_end_flush_all', 1 );
+			$this->assertNotFalse(
+				has_action( 'shutdown', 'wp_ob_end_flush_all' ),
+				'wp_ob_end_flush_all must be registered on shutdown before ob_shutdown() runs.'
+			);
+
+			ob_start();
+			$this->set_private_property( '_ob_level', ob_get_level() );
+			ob_end_clean();
+
+			$this->plugin->ob_shutdown();
+
+			$this->assertFalse(
+				has_action( 'shutdown', 'wp_ob_end_flush_all' ),
+				'ob_shutdown() must remove wp_ob_end_flush_all even when its buffer was already closed.'
+			);
+		} finally {
+			remove_action( 'shutdown', 'wp_ob_end_flush_all' );
+			if ( false !== $original_priority ) {
+				add_action( 'shutdown', 'wp_ob_end_flush_all', $original_priority );
+			}
+		}
+	}
+
+	/**
 	 * Second call to ob_shutdown() is a no-op (double-invocation guard).
 	 *
 	 * ob_shutdown() is registered both as a WP shutdown action and as a PHP


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-1658

Manual Testing Instructions: Output Buffer Shutdown Fix

  Branch: ENG7-1659-ouput-buf
  Affects: W3TC 2.9.2 — Generic_Plugin.php

  ---
  Setup

  Requirements: WordPress with W3 Total Cache active, page caching enabled (any backend).

  Create both test plugins and activate them alongside W3TC:

  wp-content/plugins/w3tc-json-test/w3tc-json-test.php
  ```
<?php
  /**
   * Plugin Name: W3TC JSON Test
   * Description: Simulates FacetWP-style JSON output with a nested OB left open.
   */
  add_action( 'wp', function () {
      if ( empty( $_GET['w3tc_json_test'] ) ) return;

      // JSON goes into W3TC's main buffer.
      header( 'Content-Type: application/json; charset=utf-8' );
      echo wp_json_encode( array( 'status' => 'ok', 'results' => array( 'item1', 'item2' ) ) );

      // A nested OB is opened with stray HTML and left open (simulates a theme
      // or plugin that does this during the same request).
      ob_start();
      echo '<html><body><p>Stray HTML from a nested OB opened after JSON output</p></body></html>';

      exit;
  }, 5 );
```

  wp-content/plugins/w3tc-cookie-test/w3tc-cookie-test.php
 ```
 <?php
  /**
   * Plugin Name: W3TC Cookie Test
   * Description: Sets a cookie during WordPress shutdown (simulates session libs).
   */
  add_action( 'shutdown', function () {
      setcookie( 'w3tc_shutdown_test', '1', time() + 3600, '/', '', false, true );
  }, 999 );
```

  ---
  Bug 1 — FacetWP / JSON Response Contamination

  Replicating on unpatched master (2.9.2)

  git checkout master
  wp w3-total-cache flush all --path=/path/to/wordpress
  curl -s "https://your-site.com/?w3tc_json_test=1"

  Expected (broken) output:
  {"status":"ok","results":["item1","item2"]}<html><body><p>Stray HTML from a nested OB opened after JSON
  output</p></body></html>

  The response is not valid JSON — the HTML from the open nested OB was flushed into and appended to the JSON body.

  Validate:
  curl -s "https://your-site.com/?w3tc_json_test=1" | python3 -m json.tool
  
  Exits non-zero — parse error

  Confirming the fix

  git checkout ENG7-1659-ouput-buf
  curl -s "https://your-site.com/?w3tc_json_test=1"

  Expected (fixed) output:
  {"status":"ok","results":["item1","item2"]}

  Validate:
  curl -s "https://your-site.com/?w3tc_json_test=1" | python3 -m json.tool
  
  Exits 0 — valid JSON, no HTML present

  ---
  Bug 2 — Late Shutdown Cookie / Headers Already Sent

  Replicating on unpatched master (2.9.2)

  With master checked out, make a dynamic (uncached) request using a unique query parameter to bypass the page cache:

  curl -s -D - "https://your-site.com/?t=$(date +%s)" -o /dev/null | grep -i "set-cookie"

  Expected (broken) output: nothing — the w3tc_shutdown_test cookie is absent because echo $buffer at shutdown priority 0 sent
  response headers before the priority-999 callback could call setcookie().

  Confirming the fix

  git checkout ENG7-1659-ouput-buf
  curl -s -D - "https://your-site.com/?t=$(date +%s)" -o /dev/null | grep -i "w3tc_shutdown_test"

  Expected (fixed) output:
  Set-Cookie: w3tc_shutdown_test=1; expires=...; Max-Age=3600; path=/; HttpOnly

  The cookie is present — response headers remain open through all shutdown callbacks.

  ---
  Cleanup

  wp plugin deactivate w3tc-json-test w3tc-cookie-test --path=/path/to/wordpress
  rm -rf wp-content/plugins/w3tc-json-test wp-content/plugins/w3tc-cookie-test