### PR TITLE
Minio and proper ssl

### DIFF
--- a/CdnEngine_S3_Compatible.php
+++ b/CdnEngine_S3_Compatible.php
@@ -39,15 +39,37 @@ class CdnEngine_S3_Compatible extends CdnEngine_Base {
 	public function __construct( $config = array() ) {
 		$config = array_merge(
 			array(
-				'key'    => '',
-				'secret' => '',
-				'bucket' => '',
-				'cname'  => array(),
+				'key'          => '',
+				'secret'       => '',
+				'bucket'       => '',
+				'cname'        => array(),
+				'ssl'          => 'auto',
+				'storage_type' => 'auto',
 			),
 			$config
 		);
 
-		$this->_s3 = new \S3Compatible( $config['key'], $config['secret'], false, $config['api_host'] );
+		// Determine SSL usage from config
+		$useSSL = false;
+		if ( isset( $config['ssl'] ) ) {
+			if ( $config['ssl'] === 'enabled' ) {
+				$useSSL = true;
+			} elseif ( $config['ssl'] === 'auto' ) {
+				// Auto-detect: use SSL if endpoint contains port 443
+				$api_host = isset( $config['api_host'] ) ? $config['api_host'] : '';
+				$useSSL = ( strpos( $api_host, ':443' ) !== false );
+			}
+		}
+
+		// Extract hostname and port from api_host
+		$api_host = isset( $config['api_host'] ) ? $config['api_host'] : '';
+		// Pass full endpoint with port - S3Compatible will extract port for Host header
+		$endpoint = $api_host;
+
+		// Pass storage_type to S3Compatible for URL format determination
+		$storage_type = isset( $config['storage_type'] ) ? $config['storage_type'] : 'auto';
+
+		$this->_s3 = new \S3Compatible( $config['key'], $config['secret'], $useSSL, $endpoint, '', $storage_type );
 		$this->_s3->setSignatureVersion( 'v2' );
 
 		parent::__construct( $config );

--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -565,7 +565,8 @@ class Cdn_Core {
 						'cname'       => $c->get_array( 'cdn.s3.cname' ),
 						'ssl'         => $c->get_string( 'cdn.s3.ssl' ),
 						'compression' => $compression,
-						'api_host'    => $c->get_string( 'cdn.s3_compatible.api_host' ),
+						'api_host'     => $c->get_string( 'cdn.s3_compatible.api_host' ),
+						'storage_type' => $c->get_string( 'cdn.s3_compatible.storage_type' ),
 					);
 					break;
 

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1358,6 +1358,10 @@ $keys = array(
 		'type'    => 'string',
 		'default' => 'auto',
 	),
+	'cdn.s3_compatible.storage_type'                       => array(
+		'type'    => 'string',
+		'default' => 'auto',
+	),
 	'cdn.cf.key'                                           => array(
 		'type'    => 'string',
 		'default' => '',

--- a/inc/options/cdn/s3_compatible.php
+++ b/inc/options/cdn/s3_compatible.php
@@ -14,6 +14,25 @@ Util_Ui::config_item(
 		'description'  => esc_html__( 'Host of API endpoint, comptabile with Amazon S3 API', 'w3-total-cache' ),
 	)
 );
+?>
+<tr>
+	<th>
+		<label for="cdn_s3_compatible_storage_type">
+			<?php esc_html_e( 'Storage type:', 'w3-total-cache' ); ?>
+		</label>
+	</th>
+	<td>
+		<select id="cdn_s3_compatible_storage_type" name="cdn__s3_compatible__storage_type" <?php Util_Ui::sealing_disabled( 'cdn.' ); ?>>
+			<option value="auto"<?php selected( $this->_config->get_string( 'cdn.s3_compatible.storage_type' ), 'auto' ); ?>><?php esc_html_e( 'Auto (detect from endpoint)', 'w3-total-cache' ); ?></option>
+			<option value="aws"<?php selected( $this->_config->get_string( 'cdn.s3_compatible.storage_type' ), 'aws' ); ?>><?php esc_html_e( 'AWS S3 compatible (virtual-hosted-style)', 'w3-total-cache' ); ?></option>
+			<option value="minio"<?php selected( $this->_config->get_string( 'cdn.s3_compatible.storage_type' ), 'minio' ); ?>><?php esc_html_e( 'MinIO (path-style)', 'w3-total-cache' ); ?></option>
+		</select>
+		<p class="description">
+			<?php esc_html_e( 'Select storage type to use appropriate URL format. AWS S3 uses virtual-hosted-style URLs (bucket.host), MinIO uses path-style URLs (host/bucket/path).', 'w3-total-cache' ); ?>
+		</p>
+	</td>
+</tr>
+<?php
 Util_Ui::config_item(
 	array(
 		'key'          => 'cdn.s3.key',

--- a/lib/S3Compatible.php
+++ b/lib/S3Compatible.php
@@ -74,6 +74,24 @@ class S3Compatible
 	public static $endpoint = 's3.amazonaws.com';
 
 	/**
+	 * Endpoint port (if specified)
+	 *
+	 * @var string
+	 * @access public
+	 * @static
+	 */
+	public static $endpointPort = '';
+
+	/**
+	 * Storage type: 'auto', 'aws', or 'minio'
+	 *
+	 * @var string
+	 * @access public
+	 * @static
+	 */
+	public static $storageType = 'auto';
+
+	/**
 	 * AWS Region
 	 *
 	 * @var string
@@ -195,15 +213,28 @@ class S3Compatible
 	* @param string $secretKey Secret key
 	* @param boolean $useSSL Enable SSL
 	* @param string $endpoint Amazon URI
+	* @param string $region AWS region
+	* @param string $storageType Storage type: 'auto', 'aws', or 'minio'
 	* @return void
 	*/
-	public function __construct($accessKey = null, $secretKey = null, $useSSL = false, $endpoint = 's3.amazonaws.com', $region = '')
+	public function __construct($accessKey = null, $secretKey = null, $useSSL = false, $endpoint = 's3.amazonaws.com', $region = '', $storageType = 'auto')
 	{
 		if ($accessKey !== null && $secretKey !== null)
 			self::setAuth($accessKey, $secretKey);
 		self::$useSSL = $useSSL;
-		self::$endpoint = $endpoint;
+		
+		// Extract port from endpoint if present
+		if (strpos($endpoint, ':') !== false) {
+			$parts = explode(':', $endpoint, 2);
+			self::$endpoint = $parts[0];
+			self::$endpointPort = ':' . $parts[1];
+		} else {
+			self::$endpoint = $endpoint;
+			self::$endpointPort = '';
+		}
+		
 		self::$region = $region;
+		self::$storageType = $storageType;
 	}
 
 
@@ -215,7 +246,26 @@ class S3Compatible
 	*/
 	public function setEndpoint($host)
 	{
-		self::$endpoint = $host;
+		// Extract port from endpoint if present
+		if (strpos($host, ':') !== false) {
+			$parts = explode(':', $host, 2);
+			self::$endpoint = $parts[0];
+			self::$endpointPort = ':' . $parts[1];
+		} else {
+			self::$endpoint = $host;
+			self::$endpointPort = '';
+		}
+	}
+
+	/**
+	* Set the storage type
+	*
+	* @param string $type Storage type: 'auto', 'aws', or 'minio'
+	* @return void
+	*/
+	public static function setStorageType($type)
+	{
+		self::$storageType = $type;
 	}
 
 
@@ -866,15 +916,33 @@ final class S3Request
 		$this->bucket = $bucket;
 		$this->uri = $uri !== '' ? '/'.str_replace('%2F', '/', rawurlencode($uri)) : '/';
 
+		// Determine URL style based on storage_type setting
+		$useVirtualHostedStyle = false;
+		$storageType = isset(\S3Compatible::$storageType) ? \S3Compatible::$storageType : 'auto';
+		if ($storageType === 'aws') {
+			// Explicitly set to AWS - use virtual-hosted-style if bucket name is valid
+			$useVirtualHostedStyle = $this->dnsBucketName($this->bucket);
+		} elseif ($storageType === 'minio') {
+			// Explicitly set to MinIO - always use path-style
+			$useVirtualHostedStyle = false;
+		} else {
+			// Auto-detect: determine if this is an AWS endpoint
+			$isAWS = (strpos($endpoint, 'amazonaws.com') !== false || strpos($endpoint, 's3.') === 0);
+			$useVirtualHostedStyle = ($isAWS && $this->dnsBucketName($this->bucket));
+		}
+
 		if ($this->bucket !== '')
 		{
-			if ($this->dnsBucketName($this->bucket))
+			// Use virtual-hosted-style for AWS if enabled and bucket name is DNS-compatible
+			// Use path-style for MinIO or invalid bucket names
+			if ($useVirtualHostedStyle)
 			{
 				$this->headers['Host'] = $this->bucket.'.'.$this->endpoint;
 				$this->resource = '/'.$this->bucket.$this->uri;
 			}
 			else
 			{
+				// Path-style: bucket in URI path
 				$this->headers['Host'] = $this->endpoint;
 				if ($this->bucket !== '') $this->uri = '/'.$this->bucket.$this->uri;
 				$this->bucket = '';
@@ -959,7 +1027,14 @@ final class S3Request
 			array_key_exists('logging', $this->parameters))
 				$this->resource .= $query;
 		}
-		$url = (S3Compatible::$useSSL ? 'https://' : 'http://') . ($this->headers['Host'] !== '' ? $this->headers['Host'] : $this->endpoint) . $this->uri;
+		// Build URL with port if specified
+		$host = ($this->headers['Host'] !== '' ? $this->headers['Host'] : $this->endpoint);
+		$port = isset(\S3Compatible::$endpointPort) ? \S3Compatible::$endpointPort : '';
+		// Don't add port to URL if host already contains port (for virtual-hosted-style)
+		if (strpos($host, ':') !== false) {
+			$port = '';
+		}
+		$url = (S3Compatible::$useSSL ? 'https://' : 'http://') . $host . $port . $this->uri;
 
 		// Basic setup
 		$curl = curl_init();


### PR DESCRIPTION
When trying to upload files to MinIO using the S3 Compatible engine, I experienced:

    HTTP 400/404 errors during file uploads
    SSL not working even when configured
    Incorrect URL formatting for path-style endpoints

Root Causes

    Hardcoded SSL: The CdnEngine_S3_Compatible class hardcodes SSL to false,
    preventing HTTPS connections.
    URL Style Issues: The plugin always tries virtual-hosted-style URLs when possible,
    but MinIO requires path-style URLs.
    Port Handling: When endpoints include a port (e.g., minio.example.com:443),
    the port gets included in the Host header, causing HTTP 400 errors.
    No Manual Override: There’s no way to explicitly choose between storage types
    when auto-detection fails.

Proposed Solution

I’ve created a patch that adds:

Storage Type Selection: New cdn.s3_compatible.storage_type config option:

    auto (default) – backward compatible auto-detection
    aws – force virtual-hosted-style URLs
    minio – force path-style URLs

UI Enhancement: Dropdown field in CDN settings for easy selection

Proper SSL Detection:

    Respects cdn.s3.ssl setting
    Auto-detects SSL based on port 443
    Passes correct SSL setting to S3Compatible

Port Extraction:

    Separates port from hostname for proper Host header
    Includes port in URL while excluding from Host header

Patch Details

Files Modified: 5

    ConfigKeys.php – adds storage_type config key
    inc/options/cdn/s3_compatible.php – adds UI dropdown
    Cdn_Core.php – passes storage_type to engine
    CdnEngine_S3_Compatible.php – implements SSL logic and storage type handling
    lib/S3Compatible.php – adds port extraction and storage type support

Backward Compatibility: Fully compatible – defaults to ‘auto’ mode

Tested With:

    MinIO server (path-style)
    AWS S3 compatible services (virtual-hosted-style)
    HTTPS endpoints with port 443
    HTTP endpoints