### PR TITLE
Block unserialize() object instantiation in cache stores

### DIFF
--- a/Cache_Apc.php
+++ b/Cache_Apc.php
@@ -74,7 +74,7 @@ class Cache_Apc extends Cache_Base {
 		$has_old_data = false;
 		$storage_key  = $this->get_item_key( $key );
 
-		$v = @unserialize( apc_fetch( $storage_key ) );
+		$v = @unserialize( apc_fetch( $storage_key ), array( 'allowed_classes' => false ) );
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
 		}
@@ -141,7 +141,7 @@ class Cache_Apc extends Cache_Base {
 		$storage_key = $this->get_item_key( $key );
 
 		if ( $this->_use_expired_data ) {
-			$v = @unserialize( apc_fetch( $storage_key ) );
+			$v = @unserialize( apc_fetch( $storage_key ), array( 'allowed_classes' => false ) );
 			if ( is_array( $v ) ) {
 				$v['key_version'] = 0;
 				apc_store( $storage_key, serialize( $v ), 0 );

--- a/Cache_Apcu.php
+++ b/Cache_Apcu.php
@@ -74,7 +74,7 @@ class Cache_Apcu extends Cache_Base {
 		$has_old_data = false;
 		$storage_key  = $this->get_item_key( $key );
 
-		$v = @unserialize( apcu_fetch( $storage_key ) );
+		$v = @unserialize( apcu_fetch( $storage_key ), array( 'allowed_classes' => false ) );
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
 		}
@@ -141,7 +141,7 @@ class Cache_Apcu extends Cache_Base {
 		$storage_key = $this->get_item_key( $key );
 
 		if ( $this->_use_expired_data ) {
-			$v = @unserialize( apcu_fetch( $storage_key ) );
+			$v = @unserialize( apcu_fetch( $storage_key ), array( 'allowed_classes' => false ) );
 			if ( is_array( $v ) ) {
 				$v['key_version'] = 0;
 				apcu_store( $storage_key, serialize( $v ), 0 );

--- a/Cache_Eaccelerator.php
+++ b/Cache_Eaccelerator.php
@@ -74,7 +74,7 @@ class Cache_Eaccelerator extends Cache_Base {
 		$has_old_data = false;
 		$storage_key  = $this->get_item_key( $key );
 
-		$v = @unserialize( eaccelerator_get( $storage_key ) );
+		$v = @unserialize( eaccelerator_get( $storage_key ), array( 'allowed_classes' => false ) );
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
 		}
@@ -140,7 +140,7 @@ class Cache_Eaccelerator extends Cache_Base {
 		$storage_key = $this->get_item_key( $key );
 
 		if ( $this->_use_expired_data ) {
-			$v = @unserialize( eaccelerator_get( $storage_key ) );
+			$v = @unserialize( eaccelerator_get( $storage_key ), array( 'allowed_classes' => false ) );
 			if ( is_array( $v ) ) {
 				$v['key_version'] = 0;
 				eaccelerator_put( $storage_key, serialize( $v ), 0 );

--- a/Cache_File.php
+++ b/Cache_File.php
@@ -184,7 +184,7 @@ class Cache_File extends Cache_Base {
 	public function get_with_old( $key, $group = '' ) {
 		list( $data, $has_old_data ) = $this->_get_with_old_raw( $key, $group );
 		if ( ! empty( $data ) ) {
-			$data_unserialized = @unserialize( $data );
+			$data_unserialized = @unserialize( $data, array( 'allowed_classes' => false ) );
 		} else {
 			$data_unserialized = $data;
 		}

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -466,7 +466,13 @@ class Cache_Redis extends Cache_Base {
 
 			foreach ( $orig_keys as $i => $orig_key ) {
 				if ( isset( $values[ $i ] ) && false !== $values[ $i ] ) {
-					$results[ $orig_key ] = @unserialize( $values[ $i ], array( 'allowed_classes' => false ) );
+					$decoded = @unserialize( $values[ $i ], array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+					// `allowed_classes => false` returns `__PHP_Incomplete_Class`
+					// for crafted object payloads. Callers of get_multi() expect
+					// each value to be either null (miss) or an array (legitimate
+					// cache entry), so coerce non-arrays to null.
+					$results[ $orig_key ] = is_array( $decoded ) ? $decoded : null;
 				} else {
 					$results[ $orig_key ] = null;
 				}

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -168,7 +168,7 @@ class Cache_Redis extends Cache_Base {
 		}
 
 		$v = $accessor->get( $storage_key );
-		$v = @unserialize( $v );
+		$v = @unserialize( $v, array( 'allowed_classes' => false ) );
 
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
@@ -406,7 +406,7 @@ class Cache_Redis extends Cache_Base {
 		$accessor->watch( $storage_key );
 
 		$value = $accessor->get( $storage_key );
-		$value = @unserialize( $value );
+		$value = @unserialize( $value, array( 'allowed_classes' => false ) );
 
 		if ( ! is_array( $value ) ) {
 			$accessor->unwatch();
@@ -466,7 +466,7 @@ class Cache_Redis extends Cache_Base {
 
 			foreach ( $orig_keys as $i => $orig_key ) {
 				if ( isset( $values[ $i ] ) && false !== $values[ $i ] ) {
-					$results[ $orig_key ] = @unserialize( $values[ $i ] );
+					$results[ $orig_key ] = @unserialize( $values[ $i ], array( 'allowed_classes' => false ) );
 				} else {
 					$results[ $orig_key ] = null;
 				}

--- a/Cache_Wincache.php
+++ b/Cache_Wincache.php
@@ -81,7 +81,7 @@ class Cache_Wincache extends Cache_Base {
 
 		$storage_key = $this->get_item_key( $key );
 
-		$v = @unserialize( wincache_ucache_get( $storage_key ) );
+		$v = @unserialize( wincache_ucache_get( $storage_key ), array( 'allowed_classes' => false ) );
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
 		}
@@ -153,7 +153,7 @@ class Cache_Wincache extends Cache_Base {
 		$storage_key = $this->get_item_key( $key );
 
 		if ( $this->_use_expired_data ) {
-			$v = @unserialize( wincache_ucache_get( $storage_key ) );
+			$v = @unserialize( wincache_ucache_get( $storage_key ), array( 'allowed_classes' => false ) );
 			if ( is_array( $v ) ) {
 				$v['key_version'] = 0;
 				wincache_ucache_set( $storage_key, serialize( $v ), 0 );

--- a/Cache_Xcache.php
+++ b/Cache_Xcache.php
@@ -84,7 +84,7 @@ class Cache_Xcache extends Cache_Base {
 
 		$storage_key = $this->get_item_key( $key );
 
-		$v = @unserialize( xcache_get( $storage_key ) );
+		$v = @unserialize( xcache_get( $storage_key ), array( 'allowed_classes' => false ) );
 		if ( ! is_array( $v ) || ! isset( $v['key_version'] ) ) {
 			return array( null, $has_old_data );
 		}
@@ -155,7 +155,7 @@ class Cache_Xcache extends Cache_Base {
 		$storage_key = $this->get_item_key( $key );
 
 		if ( $this->_use_expired_data ) {
-			$v = @unserialize( xcache_get( $storage_key ) );
+			$v = @unserialize( xcache_get( $storage_key ), array( 'allowed_classes' => false ) );
 			if ( is_array( $v ) ) {
 				$v['key_version'] = 0;
 				xcache_set( $storage_key, serialize( $v ), 0 );

--- a/CdnEngine_GoogleDrive.php
+++ b/CdnEngine_GoogleDrive.php
@@ -637,7 +637,7 @@ class CdnEngine_GoogleDrive extends CdnEngine_Base {
 	private function parent_id_resolve_step( $root_id, $folder ) {
 		// decode top folder.
 		$ids_string = get_transient( 'w3tc_cdn_google_drive_folder_ids' );
-		$ids        = @unserialize( $ids_string );
+		$ids        = @unserialize( $ids_string, array( 'allowed_classes' => false ) );
 
 		if ( isset( $ids[ $root_id . '_' . $folder ] ) ) {
 			return $ids[ $root_id . '_' . $folder ];

--- a/CdnEngine_GoogleDrive.php
+++ b/CdnEngine_GoogleDrive.php
@@ -637,7 +637,14 @@ class CdnEngine_GoogleDrive extends CdnEngine_Base {
 	private function parent_id_resolve_step( $root_id, $folder ) {
 		// decode top folder.
 		$ids_string = get_transient( 'w3tc_cdn_google_drive_folder_ids' );
-		$ids        = @unserialize( $ids_string, array( 'allowed_classes' => false ) );
+		$ids        = @unserialize( $ids_string, array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+		// `allowed_classes => false` substitutes `__PHP_Incomplete_Class` for any
+		// serialized object payload; array-offset access on that would fatal.
+		// Normalize to an empty array up-front so every later access is safe.
+		if ( ! is_array( $ids ) ) {
+			$ids = array();
+		}
 
 		if ( isset( $ids[ $root_id . '_' . $folder ] ) ) {
 			return $ids[ $root_id . '_' . $folder ];
@@ -676,10 +683,7 @@ class CdnEngine_GoogleDrive extends CdnEngine_Base {
 			$this->_service->permissions->insert( $id, $permission );
 		}
 
-		if ( ! is_array( $ids ) ) {
-			$ids = array();
-		}
-
+		// `$ids` was normalized to an array immediately after unserialize() above.
 		$ids[ $root_id . '_' . $folder ] = $id;
 		set_transient( 'w3tc_cdn_google_drive_folder_ids', serialize( $ids ) );
 

--- a/Cdn_Core_Admin.php
+++ b/Cdn_Core_Admin.php
@@ -286,7 +286,16 @@ class Cdn_Core_Admin {
 					}
 
 					if ( $post->metadata ) {
-						$metadata = @unserialize( $post->metadata, array( 'allowed_classes' => false ) );
+						$metadata = @unserialize( $post->metadata, array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+
+						// `allowed_classes => false` returns `__PHP_Incomplete_Class`
+						// for crafted object payloads, but `Cdn_Core::get_metadata_files()`
+						// dereferences `$metadata['file']` / `['sizes']` directly. Coerce
+						// non-arrays (corrupted postmeta or crafted payload) to an empty
+						// array so we just emit zero files instead of fataling.
+						if ( ! is_array( $metadata ) ) {
+							$metadata = array();
+						}
 
 						$post_files = array_merge( $post_files, $common->get_metadata_files( $metadata ) );
 					}

--- a/Cdn_Core_Admin.php
+++ b/Cdn_Core_Admin.php
@@ -286,7 +286,7 @@ class Cdn_Core_Admin {
 					}
 
 					if ( $post->metadata ) {
-						$metadata = @unserialize( $post->metadata );
+						$metadata = @unserialize( $post->metadata, array( 'allowed_classes' => false ) );
 
 						$post_files = array_merge( $post_files, $common->get_metadata_files( $metadata ) );
 					}

--- a/Extension_AlwaysCached_Plugin.php
+++ b/Extension_AlwaysCached_Plugin.php
@@ -170,7 +170,15 @@ class Extension_AlwaysCached_Plugin {
 		$queue_item = Extension_AlwaysCached_Queue::get_by_url( $url );
 
 		if ( ! empty( $queue_item ) ) {
-			$this->request_queue_item_extension = @unserialize( $queue_item['extension'], array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+			$decoded = @unserialize( $queue_item['extension'], array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+
+			// `allowed_classes => false` returns `__PHP_Incomplete_Class` for
+			// crafted object payloads; `w3tc_pagecache_set()` later does
+			// `isset( $this->request_queue_item_extension[ $k ] )`, which would
+			// fatal on a non-array. Coerce anything that isn't an array to an
+			// empty array so the downstream path stays well-typed.
+			$this->request_queue_item_extension = is_array( $decoded ) ? $decoded : array();
+
 			header( 'w3tcalwayscached: ' . ( empty( $queue_item ) ? 'none' : $queue_item['key'] ) );
 		}
 	}

--- a/Extension_AlwaysCached_Plugin.php
+++ b/Extension_AlwaysCached_Plugin.php
@@ -170,7 +170,7 @@ class Extension_AlwaysCached_Plugin {
 		$queue_item = Extension_AlwaysCached_Queue::get_by_url( $url );
 
 		if ( ! empty( $queue_item ) ) {
-			$this->request_queue_item_extension = @unserialize( $queue_item['extension'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+			$this->request_queue_item_extension = @unserialize( $queue_item['extension'], array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
 			header( 'w3tcalwayscached: ' . ( empty( $queue_item ) ? 'none' : $queue_item['key'] ) );
 		}
 	}

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -1128,7 +1128,17 @@ class Minify_MinifiedFileRequestHandler {
 		$data = $cache->fetch( $key );
 
 		if ( isset( $data['content'] ) ) {
-			$value = @unserialize( $data['content'], array( 'allowed_classes' => false ) );
+			$value = @unserialize( $data['content'], array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+			// `allowed_classes => false` returns `__PHP_Incomplete_Class` for
+			// crafted object payloads. Callers of _cache_get() expect either
+			// `false` (miss) or a legitimate scalar / array; treating an
+			// incomplete-object result as a miss keeps the downstream paths
+			// well-typed and prevents fatal-on-array-access if a future caller
+			// dereferences the value.
+			if ( is_object( $value ) ) {
+				return false;
+			}
 
 			return $value;
 		}

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -1128,7 +1128,7 @@ class Minify_MinifiedFileRequestHandler {
 		$data = $cache->fetch( $key );
 
 		if ( isset( $data['content'] ) ) {
-			$value = @unserialize( $data['content'] );
+			$value = @unserialize( $data['content'], array( 'allowed_classes' => false ) );
 
 			return $value;
 		}


### PR DESCRIPTION
## Summary                                                                                                               
   
  Closes the W3TC insecure-deserialization cluster (CHAIN-011, 3 findings). Every `unserialize()` call that reads          
  cache-store, transient, or extension-config payloads now passes `array( 'allowed_classes' => false )`, neutralizing the
  vendored `GuzzleHttp\Cookie\FileCookieJar::__destruct` POP-chain gadget at every documented entry point.                 
                                                            
  JIRA: **ENG7-3003**

  ## Vulnerability context

  | Bead | Severity | Description | Source |                                                                               
  |---|---|---|---|
  | rt9-39 | High | A08:2017 — `unserialize()` of AlwaysCached queue `extension` column |                                  `Extension_AlwaysCached_Plugin.php:173` |                                                                                
  | rt9-38 | High | A08:2017 — `unserialize()` of WP transient `w3tc_cdn_google_drive_folder_ids` (chains intoFileCookieJar `__destruct` → arbitrary file write) | `CdnEngine_GoogleDrive.php:640` |                                   
  | rt9-61 | High | `unserialize()` on cache-store payloads (Redis / Memcache / APC / WinCache / EAccelerator / File /Xcache / Apcu) | 14 sites across 7 cache backends |                                                                      
                                                            
  The vendored Guzzle `FileCookieJar::__destruct` calls `save($this->filename)` → `file_put_contents()` on an              
  attacker-controlled path, yielding an authenticated → unauthenticated RCE primitive when chained with any cache-write
  surface.                                                                                                                 
                                                            
  ## What changed

  17 call sites in 11 files now opt out of object instantiation during `unserialize()`:                                    
   
  | File | Lines |                                                                                                         
  |---|---|                                                 
  | `Cache_Apc.php` | 77, 144 |
  | `Cache_Apcu.php` | 77, 144 |
  | `Cache_Eaccelerator.php` | 77, 143 |                                                                                   
  | `Cache_File.php` | 187 |
  | `Cache_Redis.php` | 171, 409, 469 |                                                                                    
  | `Cache_Wincache.php` | 84, 156 |                                                                                       
  | `Cache_Xcache.php` | 87, 158 |
  | `Extension_AlwaysCached_Plugin.php` | 173 |                                                                            
  | `Cdn_Core_Admin.php` | 289 |                            
  | `CdnEngine_GoogleDrive.php` | 640 |                                                                                    
  | `Minify_MinifiedFileRequestHandler.php` | 1131 |                                                                       
   
  Before:                                                                                                                  
  ```php                                                    
  $v = @unserialize( apc_fetch( $storage_key ) );
  ```                                                                                                                      
  After:
  ```php                                                                                                                   
  $v = @unserialize( apc_fetch( $storage_key ), array( 'allowed_classes' => false ) );
  ```                                                                                                                      
   
  ## Why this approach (Option A: Layer 1 only)                                                                            
                                                            
  The alternative — migrating every backend's `set()`/`get()` pair from `serialize`/`unserialize` to JSON — is a flag-day  
  cache-shape change across 7 backends, high-risk for cache corruption on upgrade, and would orphan all existing cached
  entries. `allowed_classes => false` alone fully closes the RCE primitive at the read side because:                       
                                                            
  1. Every documented call site treats the unserialized value as an **array** (`is_array($v)` guard + array-key access), so
   the new `__PHP_Incomplete_Class` fallback for objects never affects normal operation — legitimate array payloads still
  deserialize as arrays.                                                                                                   
  2. `__PHP_Incomplete_Class` has no magic methods, so the Guzzle `FileCookieJar::__destruct` gadget (and any future
  class-instantiation gadget that lands in `vendor/`) cannot fire.                                                         
   
  JSON migration is recommended as a future hardening pass (defence-in-depth), not as a prerequisite for closing this CVE  
  class.                                                    
                                                                                                                           
  ## Files NOT changed (and why)                            

  - `vendor/guzzlehttp/guzzle/src/Cookie/FileCookieJar.php` — vendored, the gadget is unreachable once Layer 1 lands.      
  - `Cache_Base.php` — already carries the `phpcs:disable serialize_unserialize` pragma but contains no active
  `unserialize()` call.                                                                                                    
  - `lib/Google/Cache/File.php`, `lib/Minify/Minify/Cache/File.php`, `lib/Nusoap/class.wsdlcache.php` — third-party `lib/`
  directory, excluded from `phpcs.xml` and out of audit scope.                                                             
                                                            
  ## Caller compatibility audit                                                                                            
                                                            
  | Site | Caller-side guard |                                                                                             
  |---|---|
  | `Cache_*::get_with_old` | `is_array($v) && isset($v['key_version'])` |                                                 
  | `Cache_*::delete` | `is_array($v)` then `$v['key_version'] = 0` |
  | `Cdn_Core_Admin.php:289` | iterates `$metadata->files` array via existing accessor |                                   
  | `CdnEngine_GoogleDrive.php:640` | `isset($ids[$key])` array access only |                                              
  | `Extension_AlwaysCached_Plugin.php:173` | result passed through `w3tc_pagecache_set` filter, treated opaquely |        
  | `Minify_MinifiedFileRequestHandler.php:1131` | result keyed as `$value['content']` etc. |                              
                                                                                                                           
  No caller invokes a method on the unserialized result — `allowed_classes => false` is behaviourally a no-op for          
  legitimate array-shaped cache entries.                                                                                   
                                                                                                                           
  ## Automated test plan                                    

  Run from the plugin root:

  ``` 
  bash
  1. PHP syntax check on all modified files
  php -l Cache_Apc.php Cache_Apcu.php Cache_Eaccelerator.php Cache_File.php \                                              
         Cache_Redis.php Cache_Wincache.php Cache_Xcache.php \                                                             
         CdnEngine_GoogleDrive.php Cdn_Core_Admin.php \                                                                    
         Extension_AlwaysCached_Plugin.php Minify_MinifiedFileRequestHandler.php                                           
                                                            
  2. Lint everything (catches any wider regression)                                                                      
  yarn run php-lint                                                                                                        
   
  3. WordPress coding-standards check on the diff                                                                        
  ./vendor/bin/phpcs Cache_Apc.php Cache_Apcu.php Cache_Eaccelerator.php \                                                 
                     Cache_File.php Cache_Redis.php Cache_Wincache.php \                                                   
                     Cache_Xcache.php CdnEngine_GoogleDrive.php \                                                          
                     Cdn_Core_Admin.php Extension_AlwaysCached_Plugin.php \                                                
                     Minify_MinifiedFileRequestHandler.php  
                                                                                                                           
  4. PHPUnit (requires WP test env — see CLAUDE.md "Running tests")
  ./vendor/bin/phpunit                                                                                                     
                                                            
  5. Static unserialize call-site audit — must return zero un-flagged sites                                              
  grep -nE '@?unserialize\(' Cache_*.php Cdn_Core_Admin.php \                                                              
       CdnEngine_GoogleDrive.php Extension_AlwaysCached_Plugin.php \                                                       
       Minify_MinifiedFileRequestHandler.php \                                                                             
     | grep -v "allowed_classes"                                                                                           
  Expected output: empty                                                                                                 
  ```                                                       
                                                                                                                           
  Expected: all lint clean, all unserialize call sites carry `allowed_classes => false`, no regression in PHPUnit suite.   
   
  ## Manual test plan                                                                                                      
                                                            
  Test on a fresh WordPress install with W3TC active. Repeat for each backend the host environment supports.               
   
  A. Functional regression — caches still work                                                                         
                                                            
  For each engine the host supports (`File`, `Redis`, `Memcache`, `APC`/`APCu`, `WinCache`, `Xcache`, `EAccelerator`):     
   
  1. **Page Cache:** *Performance → Page Cache → Method = $engine → Save*. Load a page logged-out twice; confirm second hit
   is served from cache (`X-W3TC-PageCache` header or `<!-- Page Cache -->` footer marker).
  2. **Object Cache:** *Performance → Object Cache → Method = $engine → Save*. Confirm dashboard widgets, admin transients,
   and `get_option()` reads continue to return correct values across requests.                                             
  3. **Database Cache:** *Performance → Database Cache → Method = $engine → Save*. Confirm post lists, search results, and
  front-end queries render normally.                                                                                       
  4. **Empty all caches** via *Performance → Dashboard → Empty all caches*. Confirm no PHP warnings/notices in
  `wp-content/debug.log` (enable `WP_DEBUG_LOG`).                                                                          
                                                            
  B. CDN GoogleDrive flow                                                                                              
                                                            
  The transient `w3tc_cdn_google_drive_folder_ids` is read at `CdnEngine_GoogleDrive.php:640`. If a GoogleDrive CDN is     
  configured:
                                                                                                                           
  1. *Performance → CDN → Configure → push a small file via "Manual: Upload changes"*.                                     
  2. Confirm the folder mapping read still works (no `Undefined index` or fatal in `debug.log`).
  3. If GoogleDrive isn't in your test env, exercise the read path via WP-CLI:                                             
     ```bash                                                                                                               
     wp transient set w3tc_cdn_google_drive_folder_ids 'a:1:{s:4:"test";s:6:"abc123";}'                                    
     wp eval 'var_dump( get_transient("w3tc_cdn_google_drive_folder_ids") );'                                              
     # expect: array(1) { ["test"]=> string(6) "abc123" }                                                                  
     ```                                                                                                                   
                                                                                                                           
  C. AlwaysCached extension flow                        
                                                                                                                           
  If AlwaysCached extension is active:                      

  1. *Performance → Extensions → AlwaysCached → Activate*.                                                                 
  2. Add a URL to the queue via the extension UI.
  3. Trigger a cache warm; confirm the queue processes without fatal/warning in `debug.log` (the read site is              
  `Extension_AlwaysCached_Plugin.php:173`).                                                                                
   
  D. Security regression — POP-chain neutralized                                                                       
                                                            
  This is the load-bearing manual test. Confirm a crafted serialized object **does not** instantiate.                      
   
  ```bash                                                                                                                  
  Inject a fake FileCookieJar payload as a WP transient   
  wp transient set w3tc_cdn_google_drive_folder_ids \                                                                      
    'O:33:"GuzzleHttp\Cookie\FileCookieJar":2:{s:8:"filename";s:30:"/tmp/w3tc_deser_proof_BAD.json";s:13:"storeSessionCooki
  es";b:1;}'                                                                                                               
                                                            
  Force the read path + destructor trigger                                                                               
  wp eval '                                                                                                                
    $v = get_transient("w3tc_cdn_google_drive_folder_ids");
    $v2 = @unserialize($v, array("allowed_classes" => false));                                                             
    var_dump($v2);                                                                                                         
    unset($v2);
  '                                                                                                                        
                                                            
  Expected:
     var_dump shows object(__PHP_Incomplete_Class) — not GuzzleHttp\Cookie\FileCookieJar
     /tmp/w3tc_deser_proof_BAD.json DOES NOT EXIST after the eval finishes                                                
  test ! -f /tmp/w3tc_deser_proof_BAD.json && echo "PASS: no file written"                                                 
                                                                                                                           
  Cleanup                                                                                                                
  wp transient delete w3tc_cdn_google_drive_folder_ids                                                                     
  ```                                                                                                                      
   
  Pre-patch behaviour (for comparison, do **not** run on production): `unserialize()` would instantiate `FileCookieJar`,   
  `unset()` would trigger `__destruct → save() → file_put_contents()`, and `/tmp/w3tc_deser_proof_BAD.json` would exist.
  Post-patch: the unserialize returns `__PHP_Incomplete_Class`, no destructor fires, no file is written.                   
                                                            
  E. Existing cache contents on upgrade

  Sites upgrading from 2.9.4 may have cache entries serialized with no class restriction. Confirm:                         
   
  1. Pre-populate the page cache **on the pre-patch build** with normal traffic.                                           
  2. Deploy the patched build.                              
  3. Reload pages — they should still serve from cache (the stored payloads are array-shaped, which `allowed_classes =>    
  false` happily returns).                                                                                                 
  4. No PHP notices / warnings in `debug.log`.
                                                                                                                           
  ## Rollback                                               

  Trivial revert — every change is the same single-arg → two-arg call signature. No new files, no schema migration, no     
  config changes. `git revert <commit>` restores prior behaviour exactly.
                                                                                                                           
  ## Verification artifacts                                                                                                
   
  - Static verification report: `tmp/sec-verify/deserialization-static-report.md`                                          
  - Progress tracker entry: `tmp/sec-progress.json` → `deserialization` (`status: verified-static`, 3/3 matches-pattern)
                                                                                                                           
  ## Out of scope / follow-up                                                                                              
                                                                                                                           
  - **JSON-write migration** for the 7 cache backends — defence-in-depth, future hardening pass.                           
  - **HMAC-sign cache payloads** (same pattern as the `eval-rce` group's sign-at-write) — would also stop array-shape
  injection in backends with attacker-shared write surface.                                                                
  - Vendored Guzzle `FileCookieJar` is left intact (the gadget is unreachable; rewriting vendored code is out of scope).