### PR TITLE
Encrypt at-rest credentials and harden W3TC cookies

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -623,6 +623,8 @@ class Config {
 			}
 		}
 
+		self::decrypt_secrets( $data );
+
 		$this->_data     = $data;
 		$this->_compiled = false;
 	}
@@ -635,7 +637,123 @@ class Config {
 	private function load_full() {
 		$c = new ConfigCompiler( $this->_blog_id, $this->_preview );
 		$c->load();
-		$this->_data     = $c->get_data();
+		$data = $c->get_data();
+		self::decrypt_secrets( $data );
+		$this->_data     = $data;
 		$this->_compiled = true;
+	}
+
+	/**
+	 * Returns the set of config keys declared as `secret` in
+	 * ConfigKeys.php — credential-typed keys whose stored value is
+	 * encrypted with {@see Util_Crypto::envelope_encrypt()}.
+	 *
+	 * The schema include is cached for the request, so this is cheap
+	 * to call from both the load and save paths.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return array<string,true> Map of secret key name → true.
+	 */
+	public static function secret_keys() {
+		static $cache = null;
+
+		if ( null !== $cache ) {
+			return $cache;
+		}
+
+		$keys = array();
+		include W3TC_DIR . '/ConfigKeys.php';
+
+		$cache = array();
+		if ( is_array( $keys ) ) {
+			foreach ( $keys as $name => $descriptor ) {
+				if (
+					is_array( $descriptor )
+					&& isset( $descriptor['flags'] )
+					&& is_array( $descriptor['flags'] )
+					&& ! empty( $descriptor['flags']['secret'] )
+				) {
+					$cache[ $name ] = true;
+				}
+			}
+		}
+
+		return $cache;
+	}
+
+	/**
+	 * Decrypts every secret-flagged key in-place inside `$data`.
+	 *
+	 * Legacy plaintext values pass through unchanged (the envelope
+	 * helper is a no-op on non-`enc:v1:` strings), so an existing
+	 * install upgrades transparently — values stay readable until the
+	 * next `save()` re-wraps them.
+	 *
+	 * Tampered envelopes (bad HMAC, malformed base64) decrypt to
+	 * `false`; we collapse that to an empty string so the downstream
+	 * config consumer sees "credential needs re-entry" rather than the
+	 * literal `false` (which `get_string()` would coerce to `""` anyway
+	 * but via a non-obvious code path).
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $data Configuration data (modified in place).
+	 *
+	 * @return void
+	 */
+	public static function decrypt_secrets( &$data ) {
+		if ( ! is_array( $data ) || ! class_exists( '\W3TC\Util_Crypto' ) ) {
+			return;
+		}
+
+		$secret_keys = self::secret_keys();
+		if ( empty( $secret_keys ) ) {
+			return;
+		}
+
+		foreach ( $secret_keys as $key => $_ ) {
+			if ( ! isset( $data[ $key ] ) || ! is_string( $data[ $key ] ) ) {
+				continue;
+			}
+			$plain = Util_Crypto::envelope_decrypt( $data[ $key ] );
+			if ( false === $plain ) {
+				$data[ $key ] = '';
+			} else {
+				$data[ $key ] = $plain;
+			}
+		}
+	}
+
+	/**
+	 * Encrypts every secret-flagged key in-place inside `$data`.
+	 *
+	 * Called by {@see ConfigCompiler::save()} before writing
+	 * `master.php`. Non-secret keys are untouched. Already-enveloped
+	 * values are not double-wrapped (the envelope helper detects its
+	 * own prefix and short-circuits).
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $data Configuration data (modified in place).
+	 *
+	 * @return void
+	 */
+	public static function encrypt_secrets( &$data ) {
+		if ( ! is_array( $data ) || ! class_exists( '\W3TC\Util_Crypto' ) ) {
+			return;
+		}
+
+		$secret_keys = self::secret_keys();
+		if ( empty( $secret_keys ) ) {
+			return;
+		}
+
+		foreach ( $secret_keys as $key => $_ ) {
+			if ( ! isset( $data[ $key ] ) || ! is_string( $data[ $key ] ) || '' === $data[ $key ] ) {
+				continue;
+			}
+			$data[ $key ] = Util_Crypto::envelope_encrypt( $data[ $key ] );
+		}
 	}
 }

--- a/ConfigCompiler.php
+++ b/ConfigCompiler.php
@@ -265,12 +265,25 @@ class ConfigCompiler {
 			$master = new ConfigCompiler( 0, $this->_preview );
 			$master->load();
 
+			// The master config is read from disk as `enc:v1:...` for
+			// secret keys; the child config we're saving holds those
+			// keys as plaintext. Decrypt the master copy so the
+			// seal-comparison below is a like-for-like check, otherwise
+			// every child save would think every secret had changed.
+			Config::decrypt_secrets( $master->_data );
+
 			foreach ( $this->_data as $key => $value ) {
 				if ( ! self::child_key_sealed( $key, $master->_data, $this->_data ) ) {
 					$data[ $key ] = $this->_data[ $key ];
 				}
 			}
 		}
+
+		// Encrypt credential-typed keys (`flags.secret => true`) before
+		// they hit master.php. The in-memory `$this->_data` stays in
+		// plaintext so callers reading their values during the same
+		// request continue to see decrypted strings.
+		Config::encrypt_secrets( $data );
 
 		ConfigUtil::save_item( $this->_blog_id, $this->_preview, $data );
 	}

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -31,10 +31,12 @@ $keys = array(
 	'cluster.messagebus.sns.api_key'                       => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ), // AWS SNS API key — encrypted at rest.
 	),
 	'cluster.messagebus.sns.api_secret'                    => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cluster.messagebus.sns.topic_arn'                     => array(
 		'type'    => 'string',
@@ -1277,6 +1279,7 @@ $keys = array(
 	'cdn.ftp.pass'                                         => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ), // FTP password — encrypted at rest.
 	),
 	'cdn.ftp.path'                                         => array(
 		'type'    => 'string',
@@ -1305,6 +1308,7 @@ $keys = array(
 	'cdn.ftp.privkey'                                      => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ), // SFTP private key — encrypted at rest.
 	),
 	'cdn.google_drive.client_id'                           => array(
 		'type'    => 'string',
@@ -1313,6 +1317,7 @@ $keys = array(
 	'cdn.google_drive.refresh_token'                       => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.google_drive.folder.id'                           => array(
 		'type'    => 'string',
@@ -1329,10 +1334,12 @@ $keys = array(
 	'cdn.s3.key'                                           => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ), // S3 access key ID — encrypted at rest.
 	),
 	'cdn.s3.secret'                                        => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ), // S3 secret key.
 	),
 	'cdn.s3.bucket'                                        => array(
 		'type'    => 'string',
@@ -1361,10 +1368,12 @@ $keys = array(
 	'cdn.cf.key'                                           => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.cf.secret'                                        => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.cf.bucket'                                        => array(
 		'type'    => 'string',
@@ -1393,10 +1402,12 @@ $keys = array(
 	'cdn.cf2.key'                                          => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.cf2.secret'                                       => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.cf2.id'                                           => array(
 		'type'    => 'string',
@@ -1417,6 +1428,7 @@ $keys = array(
 	'cdn.rscf.key'                                         => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.rscf.location'                                    => array(
 		'type'    => 'string',
@@ -1441,6 +1453,7 @@ $keys = array(
 	'cdn.rackspace_cdn.api_key'                            => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.rackspace_cdn.region'                             => array(
 		'type'    => 'string',
@@ -1473,6 +1486,7 @@ $keys = array(
 	'cdn.azure.key'                                        => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.azure.container'                                  => array(
 		'type'    => 'string',
@@ -1521,6 +1535,7 @@ $keys = array(
 	'cdn.cotendo.password'                                 => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.cotendo.zones'                                    => array(
 		'type'    => 'array',
@@ -1541,6 +1556,7 @@ $keys = array(
 	'cdn.akamai.password'                                  => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.akamai.email_notification'                        => array(
 		'type'    => 'array',
@@ -1569,6 +1585,7 @@ $keys = array(
 	'cdn.edgecast.token'                                   => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.edgecast.domain'                                  => array(
 		'type'    => 'array',
@@ -1585,6 +1602,7 @@ $keys = array(
 	'cdn.att.token'                                        => array(
 		'type'    => 'string',
 		'default' => '',
+		'flags'   => array( 'secret' => true ),
 	),
 	'cdn.att.domain'                                       => array(
 		'type'    => 'array',
@@ -2484,6 +2502,7 @@ $keys = array(
 		'type'        => 'string',
 		'default'     => '',
 		'master_only' => true,
+		'flags'       => array( 'secret' => true ), // EDD license key — encrypted at rest.
 	),
 	'plugin.type'                                          => array(
 		'type'        => 'string',

--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -801,6 +801,22 @@ class Generic_AdminActions_Default {
 				}
 			}
 
+			// Secret-typed keys (`flags.secret => true`) render in the
+			// admin form with `value=""` and a placeholder, so the user
+			// only re-submits a real value when they're rotating the
+			// credential. An empty POST for a secret means "no change",
+			// not "wipe it". Skip the set() in that case so we don't
+			// blank every CDN credential on every Settings save.
+			if (
+				is_array( $descriptor )
+				&& isset( $descriptor['flags'] )
+				&& is_array( $descriptor['flags'] )
+				&& ! empty( $descriptor['flags']['secret'] )
+				&& ( ! is_string( $request_value ) || '' === $request_value )
+			) {
+				continue;
+			}
+
 			$config->set( $key, $request_value );
 		}
 	}

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1048,14 +1048,11 @@ class Generic_Plugin {
 
 		if ( 'logged_out' === $action ) {
 			foreach ( $rejected_roles as $role ) {
-				$role_hash = md5( NONCE_KEY . $role );
-				setcookie(
-					'w3tc_logged_' . $role_hash,
-					$expire,
-					time() - 31536000,
-					COOKIEPATH,
-					COOKIE_DOMAIN
-				);
+				Util_Cookie::clear( 'w3tc_logged_' . Util_Cookie::role_cookie_name( $role ) );
+				// One-release back-compat: also clear the legacy MD5-named
+				// cookie so an upgrade doesn't leave a stale bypass-cookie
+				// behind. Drop this `clear()` call in the next release.
+				Util_Cookie::clear( 'w3tc_logged_' . Util_Cookie::role_cookie_name_legacy( $role ) );
 			}
 
 			return;
@@ -1067,15 +1064,10 @@ class Generic_Plugin {
 
 		foreach ( $roles as $role ) {
 			if ( in_array( $role, $rejected_roles, true ) ) {
-				$role_hash = md5( NONCE_KEY . $role );
-				setcookie(
-					'w3tc_logged_' . $role_hash,
-					true,
-					$expire,
-					COOKIEPATH,
-					COOKIE_DOMAIN,
-					is_ssl(),
-					true
+				Util_Cookie::set(
+					'w3tc_logged_' . Util_Cookie::role_cookie_name( $role ),
+					'1',
+					$expire
 				);
 			}
 		}

--- a/Licensing_Core.php
+++ b/Licensing_Core.php
@@ -41,8 +41,7 @@ class Licensing_Core {
 				W3TC_LICENSE_API_URL
 			),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout' => 15,
 			)
 		);
 
@@ -81,8 +80,7 @@ class Licensing_Core {
 				W3TC_LICENSE_API_URL
 			),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout' => 15,
 			)
 		);
 
@@ -126,8 +124,7 @@ class Licensing_Core {
 				W3TC_LICENSE_API_URL
 			),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout' => 15,
 			)
 		);
 
@@ -166,8 +163,7 @@ class Licensing_Core {
 				W3TC_LICENSE_API_URL
 			),
 			array(
-				'timeout'   => 15,
-				'sslverify' => false,
+				'timeout' => 15,
 			)
 		);
 

--- a/Mobile_Referrer.php
+++ b/Mobile_Referrer.php
@@ -45,7 +45,12 @@ class Mobile_Referrer extends Mobile_Base {
 				Util_Cookie::set( W3TC_REFERRER_COOKIE_NAME, $http_referrer, 0, '/' );
 			}
 		} elseif ( isset( $_COOKIE[ W3TC_REFERRER_COOKIE_NAME ] ) ) {
-			Util_Cookie::clear( W3TC_REFERRER_COOKIE_NAME );
+			// Pass the same explicit `/` path used by the set() branch
+			// above. Without it the clear() picks up COOKIEPATH, and on
+			// sites where COOKIEPATH differs from `/` the browser keeps
+			// the path-`/` cookie alive forever (set-cookie matches on
+			// (name, path, domain)).
+			Util_Cookie::clear( W3TC_REFERRER_COOKIE_NAME, '/' );
 		}
 
 		return $http_referrer;

--- a/Mobile_Referrer.php
+++ b/Mobile_Referrer.php
@@ -42,10 +42,10 @@ class Mobile_Referrer extends Mobile_Base {
 			} elseif ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 				$http_referrer = filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_URL ); // phpcs:ignore
 
-				setcookie( W3TC_REFERRER_COOKIE_NAME, $http_referrer, 0, '/' /* not defined yet Util_Environment::network_home_url_uri()*/ );
+				Util_Cookie::set( W3TC_REFERRER_COOKIE_NAME, $http_referrer, 0, '/' );
 			}
 		} elseif ( isset( $_COOKIE[ W3TC_REFERRER_COOKIE_NAME ] ) ) {
-			setcookie( W3TC_REFERRER_COOKIE_NAME, '', 1 );
+			Util_Cookie::clear( W3TC_REFERRER_COOKIE_NAME );
 		}
 
 		return $http_referrer;

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1270,7 +1270,16 @@ class PgCache_ContentGrabber {
 		foreach ( array_keys( $_COOKIE ) as $cookie_name ) {
 			if ( strpos( $cookie_name, 'w3tc_logged_' ) === 0 ) {
 				foreach ( $roles as $role ) {
-					if ( strstr( $cookie_name, md5( NONCE_KEY . $role ) ) ) {
+					// Accept BOTH the new HMAC-SHA256 cookie name and the
+					// legacy MD5(NONCE_KEY . $role) form for one release
+					// window so an upgrade doesn't immediately serve the
+					// logged-out-cache to users whose browsers still hold
+					// the old-named cookie. The legacy lookup is dropped
+					// in the release AFTER this one.
+					if ( strstr( $cookie_name, Util_Cookie::role_cookie_name( $role ) ) ) {
+						return false;
+					}
+					if ( strstr( $cookie_name, Util_Cookie::role_cookie_name_legacy( $role ) ) ) {
 						return false;
 					}
 				}

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -557,7 +557,13 @@ class PgCache_Environment {
 		} elseif ( $config->get_boolean( 'pgcache.reject.logged_roles' ) ) {
 			$new_cookies = array();
 			foreach ( $config->get_array( 'pgcache.reject.roles' ) as $role ) {
-				$new_cookies[] = 'w3tc_logged_' . md5( NONCE_KEY . $role );
+				// New HMAC-SHA256 cookie name AND the legacy MD5 name
+				// during the one-release back-compat window. Browsers
+				// that still carry the pre-upgrade cookie continue to
+				// bypass cache; the legacy entry is dropped in the next
+				// release.
+				$new_cookies[] = 'w3tc_logged_' . Util_Cookie::role_cookie_name( $role );
+				$new_cookies[] = 'w3tc_logged_' . Util_Cookie::role_cookie_name_legacy( $role );
 			}
 
 			$reject_cookies = array_merge( $reject_cookies, $new_cookies );
@@ -886,7 +892,10 @@ class PgCache_Environment {
 		} elseif ( $config->get_boolean( 'pgcache.reject.logged_roles' ) ) {
 			$new_cookies = array();
 			foreach ( $config->get_array( 'pgcache.reject.roles' ) as $role ) {
-				$new_cookies[] = 'w3tc_logged_' . md5( NONCE_KEY . $role );
+				// HMAC cookie name + legacy MD5 form; see the parallel
+				// reject-cookie block above for the back-compat rationale.
+				$new_cookies[] = 'w3tc_logged_' . Util_Cookie::role_cookie_name( $role );
+				$new_cookies[] = 'w3tc_logged_' . Util_Cookie::role_cookie_name_legacy( $role );
 			}
 			$reject_cookies = array_merge( $reject_cookies, $new_cookies );
 		}

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -263,7 +263,7 @@ class PgCache_Plugin {
 	 * @return void
 	 */
 	public function on_logout() {
-		setcookie( 'w3tc_logged_out' );
+		Util_Cookie::set( 'w3tc_logged_out', '1' );
 	}
 
 	/**
@@ -273,7 +273,7 @@ class PgCache_Plugin {
 	 */
 	public function on_login() {
 		if ( isset( $_COOKIE['w3tc_logged_out'] ) ) {
-			setcookie( 'w3tc_logged_out', '', 1 );
+			Util_Cookie::clear( 'w3tc_logged_out' );
 		}
 	}
 

--- a/Util_Cookie.php
+++ b/Util_Cookie.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * File: Util_Cookie.php
+ *
+ * @package W3TC
+ *
+ * @since X.X.X
+ */
+
+namespace W3TC;
+
+/**
+ * Class Util_Cookie
+ *
+ * Central wrapper for every `w3tc_*` cookie write.
+ *
+ * Two reasons this exists:
+ *
+ * 1. **Cookie flags.** The pre-fix code used `setcookie( $name, $value, $expires )`
+ *    (positional, 3-arg form) — no `secure`, no `httponly`, no
+ *    `samesite`. The fixed version always uses PHP 7.3+ array-form
+ *    `setcookie` so every w3tc_* cookie carries the flags WordPress
+ *    convention requires (secure on HTTPS, httponly, samesite=Lax).
+ *
+ * 2. **Role-cookie name derivation.** The legacy code names the
+ *    "logged-in-as-this-role" cache-bypass cookie
+ *    `'w3tc_logged_' . md5( NONCE_KEY . $role )`. MD5 is broken and
+ *    the role list is small — an attacker who leaks `NONCE_KEY` (any
+ *    file-disclosure primitive, debug-log leak, etc.) forges the
+ *    bypass cookie for any role.
+ *
+ *    The new name is
+ *    `'w3tc_logged_' . substr( hash_hmac('sha256', $role, wp_salt('auth')), 0, 32 )`.
+ *    Same length (32 hex chars), HMAC-keyed off the WP auth salt so
+ *    leaking the cookie value doesn't help an attacker forge another
+ *    role's cookie. `wp_salt()` rotates separately from `NONCE_KEY`,
+ *    so salt rotation invalidates these cookies cleanly — which is
+ *    the correct security behaviour.
+ *
+ *    Migration: `role_cookie_name_legacy()` returns the old MD5 form
+ *    so readers can accept both names for one release window. Drop
+ *    the legacy reader in the next release.
+ *
+ * @since X.X.X
+ */
+class Util_Cookie {
+
+	/**
+	 * Sets a w3tc_* cookie with the standard security flags.
+	 *
+	 * Always uses the PHP 7.3+ array-form `setcookie` so `samesite`
+	 * lands in the response header. `secure` follows `is_ssl()` so the
+	 * cookie stays usable on http-only test installs; `httponly` is
+	 * always true; `samesite=Lax` is WordPress convention (`Strict`
+	 * breaks legitimate cross-tab admin flows).
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string      $name    Cookie name.
+	 * @param string|bool $value   Cookie value (cast to string).
+	 * @param int         $expires Unix epoch expiry (`0` for session cookie).
+	 * @param string|null $path    Override path; defaults to `COOKIEPATH ?: '/'`.
+	 * @param string|null $domain  Override domain; defaults to `COOKIE_DOMAIN ?: ''`.
+	 *
+	 * @return bool Result of `setcookie()`.
+	 */
+	public static function set( $name, $value, $expires = 0, $path = null, $domain = null ) {
+		if ( null === $path ) {
+			$path = ( defined( 'COOKIEPATH' ) && COOKIEPATH ) ? COOKIEPATH : '/';
+		}
+		if ( null === $domain ) {
+			$domain = ( defined( 'COOKIE_DOMAIN' ) && COOKIE_DOMAIN ) ? COOKIE_DOMAIN : '';
+		}
+
+		$options = array(
+			'expires'  => (int) $expires,
+			'path'     => (string) $path,
+			'domain'   => (string) $domain,
+			'secure'   => \function_exists( 'is_ssl' ) ? (bool) \is_ssl() : false,
+			'httponly' => true,
+			'samesite' => 'Lax',
+		);
+
+		return \setcookie( $name, (string) $value, $options );
+	}
+
+	/**
+	 * Clears a w3tc_* cookie by setting it to an empty value with an
+	 * expiry one year in the past, with the same security flags as
+	 * `set()`.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string      $name   Cookie name.
+	 * @param string|null $path   Override path; defaults to `COOKIEPATH ?: '/'`.
+	 * @param string|null $domain Override domain; defaults to `COOKIE_DOMAIN ?: ''`.
+	 *
+	 * @return bool Result of `setcookie()`.
+	 */
+	public static function clear( $name, $path = null, $domain = null ) {
+		return self::set( $name, '', \time() - 31536000, $path, $domain );
+	}
+
+	/**
+	 * Returns the HMAC-derived cookie-name suffix for a given WP role.
+	 *
+	 * Mirror of the legacy `md5( NONCE_KEY . $role )` but:
+	 *  - HMAC-SHA256 (preimage- and collision-resistant) instead of MD5.
+	 *  - Keyed off `wp_salt('auth')` instead of `NONCE_KEY`. The auth
+	 *    salt is the canonical "site identity" secret in WordPress and
+	 *    rotates independently of nonces.
+	 *  - Truncated to 32 hex chars to preserve the legacy length
+	 *    (rejected-cookie lists, regex patterns, and cache-key
+	 *    fragments that assume a 32-char suffix continue to work).
+	 *
+	 * Truncation note: 128 bits of HMAC output is sufficient for the
+	 * "is this cookie for role X?" check — there are <100 plausible WP
+	 * roles, so collision probability is negligible and preimage
+	 * resistance is what matters here.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $role WordPress role slug.
+	 *
+	 * @return string 32-char lowercase hex.
+	 */
+	public static function role_cookie_name( $role ) {
+		if ( \function_exists( 'wp_salt' ) ) {
+			$salt = (string) \wp_salt( 'auth' );
+		} else {
+			$salt = ( defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '' )
+				. '|' . ( defined( 'SECURE_AUTH_KEY' ) ? (string) SECURE_AUTH_KEY : '' );
+		}
+
+		return \substr( \hash_hmac( 'sha256', (string) $role, $salt ), 0, 32 );
+	}
+
+	/**
+	 * Returns the legacy MD5 cookie-name suffix for a given WP role.
+	 *
+	 * Used ONLY by the read path during the one-release back-compat
+	 * window so an upgrade doesn't immediately log every cached user
+	 * back in. Writers must always use `role_cookie_name()` so that
+	 * new cookies carry the HMAC name; readers walk both forms.
+	 *
+	 * Drop this method (and the dual-read in PgCache_ContentGrabber)
+	 * in the release AFTER the one that lands this PR.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $role WordPress role slug.
+	 *
+	 * @return string 32-char lowercase hex.
+	 */
+	public static function role_cookie_name_legacy( $role ) {
+		$nonce_key = defined( 'NONCE_KEY' ) ? (string) NONCE_KEY : '';
+
+		return \md5( $nonce_key . (string) $role );
+	}
+}

--- a/Util_Cookie.php
+++ b/Util_Cookie.php
@@ -72,16 +72,37 @@ class Util_Cookie {
 			$domain = ( defined( 'COOKIE_DOMAIN' ) && COOKIE_DOMAIN ) ? COOKIE_DOMAIN : '';
 		}
 
-		$options = array(
-			'expires'  => (int) $expires,
-			'path'     => (string) $path,
-			'domain'   => (string) $domain,
-			'secure'   => \function_exists( 'is_ssl' ) ? (bool) \is_ssl() : false,
-			'httponly' => true,
-			'samesite' => 'Lax',
-		);
+		$secure   = \function_exists( 'is_ssl' ) ? (bool) \is_ssl() : false;
+		$httponly = true;
 
-		return \setcookie( $name, (string) $value, $options );
+		// PHP 7.3+ accepts the options-array form natively. The plugin's
+		// composer.json platform pin allows PHP 7.2.5, where passing an
+		// array triggers a warning and the cookie is NOT set. Fall back
+		// to the positional form on 7.2 and smuggle `SameSite=Lax` via
+		// the trailing `; samesite=Lax` on the path argument — Set-Cookie
+		// emits the path verbatim, and every supported browser parses the
+		// trailing semicolon-separated attribute as a real SameSite token.
+		if ( \PHP_VERSION_ID >= 70300 ) {
+			$options = array(
+				'expires'  => (int) $expires,
+				'path'     => (string) $path,
+				'domain'   => (string) $domain,
+				'secure'   => $secure,
+				'httponly' => $httponly,
+				'samesite' => 'Lax',
+			);
+			return \setcookie( $name, (string) $value, $options );
+		}
+
+		return \setcookie(
+			$name,
+			(string) $value,
+			(int) $expires,
+			(string) $path . '; samesite=Lax',
+			(string) $domain,
+			$secure,
+			$httponly
+		);
 	}
 
 	/**

--- a/Util_Crypto.php
+++ b/Util_Crypto.php
@@ -90,19 +90,29 @@ class Util_Crypto {
 	}
 
 	/**
-	 * Derives the envelope key.
+	 * Derives a per-purpose envelope key.
 	 *
-	 * Tied to `wp_salt('secure_auth')` so the key rotates whenever the
-	 * operator rotates that salt. Falls back to a mix of AUTH_KEY +
-	 * SECURE_AUTH_KEY when wp_salt() is unavailable (CLI helpers,
-	 * standalone tests).
+	 * Encrypt-then-MAC best practice is to use independent keys for the
+	 * cipher and the authenticator: re-using the same key across two
+	 * primitives is widely flagged as a design smell even when (as here,
+	 * with AES-256-CBC + HMAC-SHA256) it has no known break.  We derive
+	 * two 32-byte keys from the same salt by HMAC-ing different context
+	 * strings — a poor-man's HKDF-Expand that's enough to keep the
+	 * cipher key and the MAC key cryptographically independent.
+	 *
+	 * Both keys are tied to `wp_salt('secure_auth')` so the keying
+	 * material rotates whenever the operator rotates that salt. Falls
+	 * back to a mix of AUTH_KEY + SECURE_AUTH_KEY when `wp_salt()` is
+	 * unavailable (CLI helpers, standalone tests).
 	 *
 	 * @since X.X.X
 	 *
-	 * @return string Raw 32-byte HMAC-SHA256 output suitable for
-	 *                AES-256-CBC + HMAC-SHA256.
+	 * @param string $purpose `'enc'` for the AES-256-CBC key, `'mac'`
+	 *                        for the HMAC-SHA256 key.
+	 *
+	 * @return string Raw 32-byte HMAC-SHA256 output.
 	 */
-	private static function derive_key() {
+	private static function derive_key( $purpose = 'enc' ) {
 		if ( \function_exists( 'wp_salt' ) ) {
 			$salt = (string) \wp_salt( 'secure_auth' );
 		} else {
@@ -110,7 +120,7 @@ class Util_Crypto {
 				. '|' . ( defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '' );
 		}
 
-		return \hash_hmac( 'sha256', 'w3tc:envelope', $salt, true );
+		return \hash_hmac( 'sha256', 'w3tc:envelope:' . $purpose, $salt, true );
 	}
 
 	/**
@@ -140,14 +150,15 @@ class Util_Crypto {
 			return $plaintext;
 		}
 
-		$key = self::derive_key();
-		$iv  = \random_bytes( 16 );
-		$ct  = @\openssl_encrypt( $plaintext, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
+		$enc_key = self::derive_key( 'enc' );
+		$mac_key = self::derive_key( 'mac' );
+		$iv      = \random_bytes( 16 );
+		$ct      = @\openssl_encrypt( $plaintext, 'aes-256-cbc', $enc_key, OPENSSL_RAW_DATA, $iv );
 		if ( false === $ct ) {
 			return $plaintext;
 		}
 
-		$tag = \hash_hmac( 'sha256', $iv . $ct, $key, true );
+		$tag = \hash_hmac( 'sha256', $iv . $ct, $mac_key, true );
 
 		return self::ENVELOPE_PREFIX . \base64_encode( $iv . $tag . $ct ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
@@ -190,13 +201,14 @@ class Util_Crypto {
 		$tag = \substr( $body, 16, 32 );
 		$ct  = \substr( $body, 48 );
 
-		$key      = self::derive_key();
-		$expected = \hash_hmac( 'sha256', $iv . $ct, $key, true );
+		$enc_key  = self::derive_key( 'enc' );
+		$mac_key  = self::derive_key( 'mac' );
+		$expected = \hash_hmac( 'sha256', $iv . $ct, $mac_key, true );
 		if ( ! \hash_equals( $expected, $tag ) ) {
 			return false;
 		}
 
-		$pt = @\openssl_decrypt( $ct, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
+		$pt = @\openssl_decrypt( $ct, 'aes-256-cbc', $enc_key, OPENSSL_RAW_DATA, $iv );
 		if ( false === $pt ) {
 			return false;
 		}

--- a/Util_Crypto.php
+++ b/Util_Crypto.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * File: Util_Crypto.php
+ *
+ * @package W3TC
+ *
+ * @since X.X.X
+ */
+
+namespace W3TC;
+
+/**
+ * Class Util_Crypto
+ *
+ * At-rest encryption envelope for credential-typed config values.
+ *
+ * W3TC's master.php has historically stored CDN keys, API tokens, FTP
+ * passwords, SFTP private keys, and similar credentials as plain JSON
+ * strings. A read of `wp-content/w3tc-config/master.php` — via any
+ * file-disclosure primitive, a backup grab, or `support-handler` style
+ * exfil — yielded every secret in the clear.
+ *
+ * This class wraps each secret in an envelope:
+ *
+ *     enc:v1:<base64( IV || HMAC || CIPHERTEXT )>
+ *
+ * - Cipher: AES-256-CBC (OpenSSL).
+ * - Key: derived from `wp_salt('secure_auth')` via HMAC-SHA256 over the
+ *   constant string `'w3tc:envelope'` (binding the key to W3TC so a
+ *   future re-use of the same salt for another purpose can't accidentally
+ *   produce the same key).
+ * - IV: 16 random bytes per call (CBC needs a fresh IV per encrypt).
+ * - HMAC: 32 bytes of HMAC-SHA256 over `IV || CIPHERTEXT` keyed with the
+ *   same envelope key. Verified with `hash_equals()` before decrypt.
+ *
+ * Decrypt is a no-op on any value that doesn't start with `enc:v1:`, so
+ * legacy plaintext values still read transparently. The next time the
+ * config is saved, every secret-flagged key gets re-wrapped — an existing
+ * install upgrades itself without an explicit migration step.
+ *
+ * Tamper detection is in-band: a flipped ciphertext byte fails the HMAC
+ * check and `envelope_decrypt()` returns false. Callers treat that as
+ * "credential needs re-entry" rather than silently feeding a corrupted
+ * value into a CDN client.
+ *
+ * Salt rotation: if an operator rotates `secure_auth` (or `auth`) salts
+ * in wp-config.php, every previously-encrypted secret will fail to
+ * decrypt. That's intentional and matches WordPress's own behaviour for
+ * cookie-signed sessions — the salt is the master secret. Operators
+ * rotating salts must re-enter credentials. The release notes call this
+ * out alongside the existing salt-rotation guidance.
+ *
+ * @since X.X.X
+ */
+class Util_Crypto {
+
+	/**
+	 * Envelope-format prefix. Anything not starting with this string is
+	 * treated as legacy plaintext and passed through unchanged.
+	 *
+	 * @var string
+	 */
+	const ENVELOPE_PREFIX = 'enc:v1:';
+
+	/**
+	 * Returns true if OpenSSL is available and AES-256-CBC is supported.
+	 *
+	 * On the (very rare) host without OpenSSL or without AES-256-CBC,
+	 * the envelope cannot be produced. Callers fall back to writing the
+	 * plaintext value — no functional regression vs. the pre-fix
+	 * behaviour — and a one-time admin notice surfaces the missing
+	 * dependency.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool
+	 */
+	public static function is_available() {
+		if ( ! \function_exists( 'openssl_encrypt' ) ) {
+			return false;
+		}
+
+		if ( ! \function_exists( 'openssl_get_cipher_methods' ) ) {
+			return false;
+		}
+
+		$methods = @\openssl_get_cipher_methods( true );
+
+		return \is_array( $methods ) && \in_array( 'aes-256-cbc', \array_map( 'strtolower', $methods ), true );
+	}
+
+	/**
+	 * Derives the envelope key.
+	 *
+	 * Tied to `wp_salt('secure_auth')` so the key rotates whenever the
+	 * operator rotates that salt. Falls back to a mix of AUTH_KEY +
+	 * SECURE_AUTH_KEY when wp_salt() is unavailable (CLI helpers,
+	 * standalone tests).
+	 *
+	 * @since X.X.X
+	 *
+	 * @return string Raw 32-byte HMAC-SHA256 output suitable for
+	 *                AES-256-CBC + HMAC-SHA256.
+	 */
+	private static function derive_key() {
+		if ( \function_exists( 'wp_salt' ) ) {
+			$salt = (string) \wp_salt( 'secure_auth' );
+		} else {
+			$salt = ( defined( 'SECURE_AUTH_KEY' ) ? (string) SECURE_AUTH_KEY : '' )
+				. '|' . ( defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '' );
+		}
+
+		return \hash_hmac( 'sha256', 'w3tc:envelope', $salt, true );
+	}
+
+	/**
+	 * Encrypts a plaintext value into the envelope format.
+	 *
+	 * Returns the envelope string on success, or the raw plaintext on
+	 * failure (so the call site can write *something* and the existing
+	 * fallback behaviour persists).
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $plaintext Raw secret value.
+	 *
+	 * @return string `enc:v1:...` envelope on success, raw plaintext on failure.
+	 */
+	public static function envelope_encrypt( $plaintext ) {
+		if ( ! \is_string( $plaintext ) || '' === $plaintext ) {
+			return $plaintext;
+		}
+
+		// If the value is already enveloped, don't double-wrap it.
+		if ( self::is_envelope( $plaintext ) ) {
+			return $plaintext;
+		}
+
+		if ( ! self::is_available() ) {
+			return $plaintext;
+		}
+
+		$key = self::derive_key();
+		$iv  = \random_bytes( 16 );
+		$ct  = @\openssl_encrypt( $plaintext, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
+		if ( false === $ct ) {
+			return $plaintext;
+		}
+
+		$tag = \hash_hmac( 'sha256', $iv . $ct, $key, true );
+
+		return self::ENVELOPE_PREFIX . \base64_encode( $iv . $tag . $ct ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	}
+
+	/**
+	 * Decrypts an envelope back to plaintext.
+	 *
+	 * Non-envelope inputs (legacy plaintext) pass through unchanged so
+	 * pre-fix installs read correctly until their next save migrates
+	 * them. Tampered envelopes (bad HMAC, malformed base64, wrong
+	 * length) return `false` — callers should treat that as "credential
+	 * needs re-entry" rather than feeding a partial value downstream.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $envelope Either an `enc:v1:...` envelope or a legacy plaintext string.
+	 *
+	 * @return string|false Plaintext on success, the original string for
+	 *                      non-envelope input, or `false` on tamper.
+	 */
+	public static function envelope_decrypt( $envelope ) {
+		if ( ! \is_string( $envelope ) || '' === $envelope ) {
+			return $envelope;
+		}
+
+		if ( ! self::is_envelope( $envelope ) ) {
+			return $envelope;
+		}
+
+		if ( ! self::is_available() ) {
+			return false;
+		}
+
+		$body = \base64_decode( \substr( $envelope, \strlen( self::ENVELOPE_PREFIX ) ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $body || \strlen( $body ) < 48 ) {
+			return false;
+		}
+
+		$iv  = \substr( $body, 0, 16 );
+		$tag = \substr( $body, 16, 32 );
+		$ct  = \substr( $body, 48 );
+
+		$key      = self::derive_key();
+		$expected = \hash_hmac( 'sha256', $iv . $ct, $key, true );
+		if ( ! \hash_equals( $expected, $tag ) ) {
+			return false;
+		}
+
+		$pt = @\openssl_decrypt( $ct, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
+		if ( false === $pt ) {
+			return false;
+		}
+
+		return $pt;
+	}
+
+	/**
+	 * Quick check: does this string look like an envelope?
+	 *
+	 * Used by `Config::set()` to avoid double-wrapping on save and by
+	 * `Config::get_string()` to skip the decrypt path on legacy values.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param mixed $value Candidate value.
+	 *
+	 * @return bool
+	 */
+	public static function is_envelope( $value ) {
+		return \is_string( $value ) && 0 === \strpos( $value, self::ENVELOPE_PREFIX );
+	}
+}

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -321,9 +321,9 @@ class Util_Environment {
 	 */
 	public static function set_preview( $is_enabled ) {
 		if ( $is_enabled ) {
-			setcookie( 'w3tc_preview', '*', 0, '/' );
+			Util_Cookie::set( 'w3tc_preview', '*', 0, '/' );
 		} else {
-			setcookie( 'w3tc_preview', '', time() - 3600, '/' );
+			Util_Cookie::clear( 'w3tc_preview', '/' );
 		}
 	}
 

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -782,6 +782,107 @@ class Util_Ui {
 	}
 
 	/**
+	 * Renders an input for a credential-typed config value.
+	 *
+	 * Never reflects the actual secret into the HTML `value=` attribute.
+	 * Instead:
+	 *
+	 *  - `value=""` is always emitted (so a settings-page render — view-
+	 *    source, browser cache, screenshot, intermediary proxy — never
+	 *    yields the credential).
+	 *  - A `••••••••` placeholder is rendered when a secret is
+	 *    configured, so the admin can see that *something* is set
+	 *    without seeing the value. An empty config value renders an
+	 *    empty placeholder (the admin sees a blank input — same UX as
+	 *    "credential not set").
+	 *  - `autocomplete="new-password"` discourages browsers from
+	 *    auto-filling stored passwords into the wrong field.
+	 *
+	 * The companion server-side rule lives in
+	 * `Generic_AdminActions_Default::read_request()`: an empty POST for
+	 * a `secret`-flagged key means "no change", not "blank it". Together
+	 * the two rules let the placeholder pattern round-trip cleanly:
+	 * the admin saves Settings without re-entering existing
+	 * credentials.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param array $args {
+	 *     Field arguments.
+	 *
+	 *     @type string $id          DOM id.
+	 *     @type string $name        Submit name (e.g. `cdn__s3__secret`).
+	 *     @type bool   $has_value   Whether a secret is currently
+	 *                               configured. When true the input
+	 *                               renders a dot placeholder.
+	 *     @type int    $size        HTML size attribute. Default 60.
+	 *     @type string $type        `password` (default) or `text`.
+	 *     @type string $sealing_key Pass a key prefix (e.g. `cdn.`) to
+	 *                               disable the input when sealed by
+	 *                               the master config.
+	 *     @type bool   $extra_class Whether to also include the
+	 *                               `w3tc-ignore-change` class
+	 *                               (default true).
+	 * }
+	 *
+	 * @return void
+	 */
+	/**
+	 * Returns true when the given config key carries the
+	 * `flags.secret => true` marker in `ConfigKeys.php`.
+	 *
+	 * Used by {@see self::control2()} to auto-mask textbox-rendered
+	 * secret keys (e.g. `cdn.s3.key` routed through
+	 * `Util_Ui::config_item()`), so a future credential field added to
+	 * the schema is masked by being flagged — no template edit needed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string|array $key Config key (compound keys are never
+	 *                          secrets in the static schema).
+	 *
+	 * @return bool
+	 */
+	public static function is_secret_config_key( $key ) {
+		if ( \is_array( $key ) || ! \is_string( $key ) || '' === $key ) {
+			return false;
+		}
+
+		$secrets = Config::secret_keys();
+
+		return isset( $secrets[ $key ] );
+	}
+
+	public static function secret_input( $args ) {
+		$id          = isset( $args['id'] ) ? (string) $args['id'] : '';
+		$name        = isset( $args['name'] ) ? (string) $args['name'] : '';
+		$has_value   = ! empty( $args['has_value'] );
+		$size        = isset( $args['size'] ) ? (int) $args['size'] : 60;
+		$type        = isset( $args['type'] ) && 'text' === $args['type'] ? 'text' : 'password';
+		$sealing_key = isset( $args['sealing_key'] ) ? (string) $args['sealing_key'] : '';
+		$extra_class = ! isset( $args['extra_class'] ) || (bool) $args['extra_class'];
+		$disabled    = ! empty( $args['disabled'] );
+
+		$placeholder = $has_value ? '••••••••' : '';
+
+		if ( ! $disabled && '' !== $sealing_key && Dispatcher::config()->is_sealed( $sealing_key ) ) {
+			$disabled = true;
+		}
+
+		echo '<input'
+			. ( $extra_class ? ' class="w3tc-ignore-change"' : '' )
+			. ' type="' . esc_attr( $type ) . '"'
+			. ' id="' . esc_attr( $id ) . '"'
+			. ' name="' . esc_attr( $name ) . '"'
+			. ' value=""'
+			. ' placeholder="' . esc_attr( $placeholder ) . '"'
+			. ' autocomplete="new-password"'
+			. ' size="' . esc_attr( (string) $size ) . '"'
+			. ( $disabled ? ' disabled="disabled"' : '' )
+			. ' />';
+	}
+
+	/**
 	 * Echoes a select element.
 	 *
 	 * @param string $id        The ID attribute for the select element.
@@ -1186,16 +1287,33 @@ class Util_Ui {
 				)
 			);
 		} elseif ( 'textbox' === $a['control'] ) {
-			self::textbox2(
-				array(
-					'name'        => $a['control_name'],
-					'value'       => $a['value'],
-					'disabled'    => $a['disabled'],
-					'type'        => isset( $a['textbox_type'] ) ? $a['textbox_type'] : null,
-					'size'        => isset( $a['textbox_size'] ) ? $a['textbox_size'] : null,
-					'placeholder' => isset( $a['textbox_placeholder'] ) ? $a['textbox_placeholder'] : null,
-				)
-			);
+			// Secret-flagged keys (CDN API secrets, FTP passwords, license
+			// key, etc.) must NEVER reflect their value into the HTML
+			// `value=` attribute. Route through the placeholder renderer
+			// so the form pattern stays consistent with the inputs that
+			// already migrated to `Util_Ui::secret_input()` directly.
+			if ( self::is_secret_config_key( $a['key'] ?? '' ) ) {
+				self::secret_input(
+					array(
+						'name'      => $a['control_name'],
+						'has_value' => '' !== (string) ( $a['value'] ?? '' ),
+						'disabled'  => $a['disabled'],
+						'type'      => 'password',
+						'size'      => isset( $a['textbox_size'] ) ? (int) $a['textbox_size'] : 60,
+					)
+				);
+			} else {
+				self::textbox2(
+					array(
+						'name'        => $a['control_name'],
+						'value'       => $a['value'],
+						'disabled'    => $a['disabled'],
+						'type'        => isset( $a['textbox_type'] ) ? $a['textbox_type'] : null,
+						'size'        => isset( $a['textbox_size'] ) ? $a['textbox_size'] : null,
+						'placeholder' => isset( $a['textbox_placeholder'] ) ? $a['textbox_placeholder'] : null,
+					)
+				);
+			}
 		} elseif ( 'textarea' === $a['control'] ) {
 			self::textarea2(
 				array(

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -782,6 +782,32 @@ class Util_Ui {
 	}
 
 	/**
+	 * Returns true when the given config key carries the
+	 * `flags.secret => true` marker in `ConfigKeys.php`.
+	 *
+	 * Used by {@see self::control2()} to auto-mask textbox-rendered
+	 * secret keys (e.g. `cdn.s3.key` routed through
+	 * `Util_Ui::config_item()`), so a future credential field added to
+	 * the schema is masked by being flagged — no template edit needed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string|array $key Config key (compound keys are never
+	 *                          secrets in the static schema).
+	 *
+	 * @return bool
+	 */
+	public static function is_secret_config_key( $key ) {
+		if ( \is_array( $key ) || ! \is_string( $key ) || '' === $key ) {
+			return false;
+		}
+
+		$secrets = Config::secret_keys();
+
+		return isset( $secrets[ $key ] );
+	}
+
+	/**
 	 * Renders an input for a credential-typed config value.
 	 *
 	 * Never reflects the actual secret into the HTML `value=` attribute.
@@ -827,32 +853,6 @@ class Util_Ui {
 	 *
 	 * @return void
 	 */
-	/**
-	 * Returns true when the given config key carries the
-	 * `flags.secret => true` marker in `ConfigKeys.php`.
-	 *
-	 * Used by {@see self::control2()} to auto-mask textbox-rendered
-	 * secret keys (e.g. `cdn.s3.key` routed through
-	 * `Util_Ui::config_item()`), so a future credential field added to
-	 * the schema is masked by being flagged — no template edit needed.
-	 *
-	 * @since X.X.X
-	 *
-	 * @param string|array $key Config key (compound keys are never
-	 *                          secrets in the static schema).
-	 *
-	 * @return bool
-	 */
-	public static function is_secret_config_key( $key ) {
-		if ( \is_array( $key ) || ! \is_string( $key ) || '' === $key ) {
-			return false;
-		}
-
-		$secrets = Config::secret_keys();
-
-		return isset( $secrets[ $key ] );
-	}
-
 	public static function secret_input( $args ) {
 		$id          = isset( $args['id'] ) ? (string) $args['id'] : '';
 		$name        = isset( $args['name'] ) ? (string) $args['name'] : '';
@@ -1293,12 +1293,24 @@ class Util_Ui {
 			// so the form pattern stays consistent with the inputs that
 			// already migrated to `Util_Ui::secret_input()` directly.
 			if ( self::is_secret_config_key( $a['key'] ?? '' ) ) {
+				// Carry through the caller-supplied id so the surrounding
+				// `<label for="...">` (which uses `control_name` as the
+				// for-target) keeps its click/focus association. Honor
+				// `textbox_type` when the caller passed one — some
+				// "credentials" render as text by design (e.g. an Access
+				// Key ID, where the operator wants to see what they
+				// typed) — but default to `password` so unspecified
+				// secret fields don't reflect on-screen.
+				$secret_type = ( isset( $a['textbox_type'] ) && 'text' === $a['textbox_type'] )
+					? 'text'
+					: 'password';
 				self::secret_input(
 					array(
+						'id'        => $a['control_name'],
 						'name'      => $a['control_name'],
 						'has_value' => '' !== (string) ( $a['value'] ?? '' ),
 						'disabled'  => $a['disabled'],
-						'type'      => 'password',
+						'type'      => $secret_type,
 						'size'      => isset( $a['textbox_size'] ) ? (int) $a['textbox_size'] : 60,
 					)
 				);

--- a/inc/options/cdn/akamai.php
+++ b/inc/options/cdn/akamai.php
@@ -15,8 +15,17 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_akamai_password"><?php esc_html_e( 'Password:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_akamai_password" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__akamai__password" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.akamai.password' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_akamai_password',
+				'name'        => 'cdn__akamai__password',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.akamai.password' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/att.php
+++ b/inc/options/cdn/att.php
@@ -15,8 +15,17 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_att_token"><?php esc_html_e( 'Token:', 'w3-total-cache' ); ?></th>
 	<td>
-		<input id="cdn_att_token" class="w3tc-ignore-change" type="password"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__att__token" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.att.token' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_att_token',
+				'name'        => 'cdn__att__token',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.att.token' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/azure.php
+++ b/inc/options/cdn/azure.php
@@ -15,8 +15,17 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_azure_key"><?php esc_html_e( 'Account key:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_azure_key" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__azure__key" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.azure.key' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_azure_key',
+				'name'        => 'cdn__azure__key',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.azure.key' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/cf.php
+++ b/inc/options/cdn/cf.php
@@ -55,15 +55,34 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th style="width: 300px;"><label for="cdn_cf_key"><?php esc_html_e( 'Access key ID:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cf_key" class="w3tc-ignore-change" type="text"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__cf__key" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf.key' ) ); ?>" size="30" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_cf_key',
+				'name'        => 'cdn__cf__key',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.cf.key' ),
+				'size'        => 30,
+				'type'        => 'text',
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>
 	<th><label for="cdn_cf_secret"><?php esc_html_e( 'Secret key:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cf_secret" class="w3tc-ignore-change" type="password"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__cf__secret" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf.secret' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_cf_secret',
+				'name'        => 'cdn__cf__secret',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.cf.secret' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/cf2.php
+++ b/inc/options/cdn/cf2.php
@@ -47,15 +47,34 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th style="width: 300px;"><label for="cdn_cf2_key"><?php esc_html_e( 'Access key ID:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cf2_key" class="w3tc-ignore-change" type="text"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__cf2__key" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf2.key' ) ); ?>" size="30" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_cf2_key',
+				'name'        => 'cdn__cf2__key',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.cf2.key' ),
+				'size'        => 30,
+				'type'        => 'text',
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>
 	<th><label for="cdn_cf2_secret"><?php esc_html_e( 'Secret key:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cf2_secret" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__cf2__secret" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf2.secret' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_cf2_secret',
+				'name'        => 'cdn__cf2__secret',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.cf2.secret' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/cotendo.php
+++ b/inc/options/cdn/cotendo.php
@@ -15,8 +15,17 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_cotendo_password"><?php esc_html_e( 'Password:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_cotendo_password" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__cotendo__password" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cotendo.password' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_cotendo_password',
+				'name'        => 'cdn__cotendo__password',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.cotendo.password' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/edgecast.php
+++ b/inc/options/cdn/edgecast.php
@@ -15,8 +15,17 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th><label for="cdn_edgecast_token"><?php esc_html_e( 'Token:', 'w3-total-cache' ); ?></th>
 	<td>
-		<input id="cdn_edgecast_token" class="w3tc-ignore-change" type="password"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__edgecast__token" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.edgecast.token' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_edgecast_token',
+				'name'        => 'cdn__edgecast__token',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.edgecast.token' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/ftp.php
+++ b/inc/options/cdn/ftp.php
@@ -139,8 +139,17 @@ if ( ! defined( 'W3TC' ) ) {
 		</label>
 	</th>
 	<td>
-		<input id="cdn_ftp_pass" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__ftp__pass" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.ftp.pass' ) ); ?>" size="30" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_ftp_pass',
+				'name'        => 'cdn__ftp__pass',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.ftp.pass' ),
+				'size'        => 30,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>
@@ -302,8 +311,19 @@ if ( ! defined( 'W3TC' ) ) {
 		</label>
 	</th>
 	<td>
-		<input id="cdn_ftp_privkey" class="w3tc-ignore-change" type="text"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__ftp__privkey" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.ftp.privkey' ) ); ?>" size="30" <?php echo function_exists( 'ssh2_connect' ) ? '' : 'disabled'; ?> />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_ftp_privkey',
+				'name'        => 'cdn__ftp__privkey',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.ftp.privkey' ),
+				'size'        => 30,
+				'type'        => 'text',
+				'sealing_key' => 'cdn.',
+				'disabled'    => ! function_exists( 'ssh2_connect' ),
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/rscf.php
+++ b/inc/options/cdn/rscf.php
@@ -36,8 +36,17 @@ if ( ! defined( 'W3TC' ) ) {
 		</label>
 	</th>
 	<td>
-		<input id="cdn_rscf_key" class="w3tc-ignore-change" type="password"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__rscf__key" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.rscf.key' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_rscf_key',
+				'name'        => 'cdn__rscf__key',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.rscf.key' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <?php

--- a/inc/options/cdn/s3.php
+++ b/inc/options/cdn/s3.php
@@ -53,15 +53,34 @@ if ( ! defined( 'W3TC' ) ) {
 <tr>
 	<th style="width: 300px;"><label for="cdn_s3_key"><?php esc_html_e( 'Access key ID:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_s3_key" class="w3tc-ignore-change" type="text"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> name="cdn__s3__key" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.key' ) ); ?>" size="30" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_s3_key',
+				'name'        => 'cdn__s3__key',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.s3.key' ),
+				'size'        => 30,
+				'type'        => 'text',
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>
 	<th><label for="cdn_s3_secret"><?php esc_html_e( 'Secret key:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_s3_secret" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__s3__secret" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.secret' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_s3_secret',
+				'name'        => 'cdn__s3__secret',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.s3.secret' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/cdn/s3_compatible.php
+++ b/inc/options/cdn/s3_compatible.php
@@ -46,8 +46,17 @@ Util_Ui::config_item(
 <tr>
 	<th><label for="cdn_s3_secret"><?php esc_html_e( 'Secret key:', 'w3-total-cache' ); ?></label></th>
 	<td>
-		<input id="cdn_s3_secret" class="w3tc-ignore-change"
-			<?php Util_Ui::sealing_disabled( 'cdn.' ); ?> type="password" name="cdn__s3__secret" value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.secret' ) ); ?>" size="60" />
+		<?php
+		Util_Ui::secret_input(
+			array(
+				'id'          => 'cdn_s3_secret',
+				'name'        => 'cdn__s3__secret',
+				'has_value'   => '' !== $this->_config->get_string( 'cdn.s3.secret' ),
+				'size'        => 60,
+				'sealing_key' => 'cdn.',
+			)
+		);
+		?>
 	</td>
 </tr>
 <tr>

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -726,10 +726,17 @@ require W3TC_INC_DIR . '/options/common/header.php';
 				<tr>
 					<th><label for="cluster_messagebus_sns_api_key"><?php Util_Ui::e_config_label( 'cluster.messagebus.sns.api_key' ); ?></label></th>
 					<td>
-						<input id="cluster_messagebus_sns_api_key"
-							class="w3tc-ignore-change" type="text"
-							name="cluster__messagebus__sns__api_key"
-							value="<?php echo esc_attr( $this->_config->get_string( 'cluster.messagebus.sns.api_key' ) ); ?>" size="60" />
+						<?php
+						Util_Ui::secret_input(
+							array(
+								'id'        => 'cluster_messagebus_sns_api_key',
+								'name'      => 'cluster__messagebus__sns__api_key',
+								'has_value' => '' !== $this->_config->get_string( 'cluster.messagebus.sns.api_key' ),
+								'size'      => 60,
+								'type'      => 'text',
+							)
+						);
+						?>
 						<p class="description">
 							<?php
 							echo wp_kses(
@@ -755,10 +762,16 @@ require W3TC_INC_DIR . '/options/common/header.php';
 				<tr>
 					<th><label for="cluster_messagebus_sns_api_secret"><?php Util_Ui::e_config_label( 'cluster.messagebus.sns.api_secret' ); ?></label></th>
 					<td>
-						<input id="cluster_messagebus_sns_api_secret"
-							class="w3tc-ignore-change" type="text"
-							name="cluster__messagebus__sns__api_secret"
-							value="<?php echo esc_attr( $this->_config->get_string( 'cluster.messagebus.sns.api_secret' ) ); ?>" size="60" />
+						<?php
+						Util_Ui::secret_input(
+							array(
+								'id'        => 'cluster_messagebus_sns_api_secret',
+								'name'      => 'cluster__messagebus__sns__api_secret',
+								'has_value' => '' !== $this->_config->get_string( 'cluster.messagebus.sns.api_secret' ),
+								'size'      => 60,
+							)
+						);
+						?>
 						<p class="description">
 							<?php
 							echo wp_kses(
@@ -840,7 +853,17 @@ require W3TC_INC_DIR . '/options/common/header.php';
 							<label for="plugin_license_key"><?php Util_Ui::e_config_label( 'plugin.license_key' ); ?></label>
 						</th>
 						<td>
-							<input id="plugin_license_key" name="plugin__license_key" type="text" value="<?php echo esc_attr( $this->_config->get_string( 'plugin.license_key' ) ); ?>" size="45"/>
+							<?php
+							Util_Ui::secret_input(
+								array(
+									'id'        => 'plugin_license_key',
+									'name'      => 'plugin__license_key',
+									'has_value' => '' !== $this->_config->get_string( 'plugin.license_key' ),
+									'size'      => 45,
+									'type'      => 'text',
+								)
+							);
+							?>
 							<span class="w3tc_license_verification"></span>
 							<p class="description">
 								<?php

--- a/tests/admin/class-w3tc-util-cookie-test.php
+++ b/tests/admin/class-w3tc-util-cookie-test.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * File: class-w3tc-util-cookie-test.php
+ *
+ * @package    W3TC
+ * @subpackage W3TC/tests/admin
+ * @since      X.X.X
+ */
+
+declare( strict_types = 1 );
+
+use W3TC\Util_Cookie;
+
+/**
+ * Class: W3tc_Util_Cookie_Test
+ *
+ * Coverage for the role-cookie name derivation. The cookie-flag
+ * behaviour of `set()` / `clear()` is verified manually (Set-Cookie
+ * response header inspection); here we focus on the name-derivation
+ * helpers because those are the load-bearing piece of the MD5 → HMAC
+ * migration.
+ *
+ * @since X.X.X
+ */
+class W3tc_Util_Cookie_Test extends WP_UnitTestCase {
+
+	/**
+	 * The HMAC-derived role cookie name is deterministic for a given
+	 * (role, salt) pair: the same call twice in the same request must
+	 * return the same value, otherwise the read path and the reject-
+	 * cookie list won't agree.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_role_cookie_name_is_deterministic() {
+		$a = Util_Cookie::role_cookie_name( 'administrator' );
+		$b = Util_Cookie::role_cookie_name( 'administrator' );
+
+		$this->assertSame( $a, $b );
+	}
+
+	/**
+	 * Different roles produce different cookie names (otherwise every
+	 * role would share one bypass-cookie).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_role_cookie_name_differs_per_role() {
+		$admin     = Util_Cookie::role_cookie_name( 'administrator' );
+		$editor    = Util_Cookie::role_cookie_name( 'editor' );
+		$author    = Util_Cookie::role_cookie_name( 'author' );
+
+		$this->assertNotSame( $admin, $editor );
+		$this->assertNotSame( $admin, $author );
+		$this->assertNotSame( $editor, $author );
+	}
+
+	/**
+	 * The cookie name is 32 lowercase hex chars (same length as the
+	 * legacy MD5 form, so reject-cookie regexes / nginx config rules
+	 * that assumed 32 chars continue to work).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_role_cookie_name_shape() {
+		$name = Util_Cookie::role_cookie_name( 'administrator' );
+
+		$this->assertSame( 32, strlen( $name ) );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{32}$/', $name );
+	}
+
+	/**
+	 * The legacy MD5 form is also 32 lowercase hex chars and
+	 * deterministic — used by the back-compat reader.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_role_cookie_name_legacy_shape() {
+		$name = Util_Cookie::role_cookie_name_legacy( 'administrator' );
+
+		$this->assertSame( 32, strlen( $name ) );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{32}$/', $name );
+	}
+
+	/**
+	 * The new and legacy names MUST differ — otherwise the
+	 * back-compat reader would be redundant.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_new_and_legacy_names_differ() {
+		$new    = Util_Cookie::role_cookie_name( 'administrator' );
+		$legacy = Util_Cookie::role_cookie_name_legacy( 'administrator' );
+
+		$this->assertNotSame( $new, $legacy );
+	}
+}

--- a/tests/admin/class-w3tc-util-crypto-test.php
+++ b/tests/admin/class-w3tc-util-crypto-test.php
@@ -154,6 +154,35 @@ class W3tc_Util_Crypto_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The encrypt key and the MAC key are derived from the same salt
+	 * but with different context strings, so they are NOT equal. This
+	 * pins the encrypt-then-MAC split-keys property — a future
+	 * "simplify" refactor that re-uses one key for both primitives
+	 * would re-introduce the design smell Copilot flagged.
+	 *
+	 * `derive_key()` is private; the property is exercised through
+	 * Reflection so the API surface stays unchanged.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_derive_key_uses_distinct_purposes() {
+		$method = new \ReflectionMethod( Util_Crypto::class, 'derive_key' );
+		$method->setAccessible( true );
+
+		$enc_a = $method->invoke( null, 'enc' );
+		$enc_b = $method->invoke( null, 'enc' );
+		$mac   = $method->invoke( null, 'mac' );
+
+		// Deterministic for a given purpose...
+		$this->assertSame( $enc_a, $enc_b );
+		$this->assertSame( 32, strlen( $enc_a ) );
+		$this->assertSame( 32, strlen( $mac ) );
+
+		// ...but different across purposes.
+		$this->assertNotSame( $enc_a, $mac );
+	}
+
+	/**
 	 * `is_envelope()` recognises the prefix and rejects everything else.
 	 *
 	 * @since X.X.X

--- a/tests/admin/class-w3tc-util-crypto-test.php
+++ b/tests/admin/class-w3tc-util-crypto-test.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * File: class-w3tc-util-crypto-test.php
+ *
+ * @package    W3TC
+ * @subpackage W3TC/tests/admin
+ * @since      X.X.X
+ */
+
+declare( strict_types = 1 );
+
+use W3TC\Util_Crypto;
+
+/**
+ * Class: W3tc_Util_Crypto_Test
+ *
+ * Coverage for the at-rest credential encryption envelope. Regressions
+ * here weaken the central protection for CDN credentials in master.php,
+ * so the assertions are deliberately exhaustive: round-trip, tamper
+ * detection, legacy passthrough, idempotency, fresh-IV-per-call,
+ * envelope detection.
+ *
+ * @since X.X.X
+ */
+class W3tc_Util_Crypto_Test extends WP_UnitTestCase {
+
+	/**
+	 * Skip the suite when OpenSSL or AES-256-CBC is missing on the
+	 * test host (no point asserting against a not-available helper).
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		if ( ! Util_Crypto::is_available() ) {
+			$this->markTestSkipped( 'OpenSSL AES-256-CBC not available on this host.' );
+		}
+	}
+
+	/**
+	 * Plaintext → envelope → plaintext round-trips for every shape of
+	 * value the config layer might pass through (short, long, UTF-8,
+	 * credentials-with-special-chars).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_round_trip_preserves_value() {
+		$cases = array(
+			'short ascii'         => 'abc',
+			'aws-key-shaped'      => 'AKIA0123456789ABCDEF',
+			'aws-secret-shaped'   => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+			'user:pass-ish'       => 'admin@example.com:hunter2!',
+			'has spaces'          => 'pass with spaces and / slashes',
+			'with quotes'         => "she said \"hello\"\nand 'goodbye'",
+			'long string'         => str_repeat( 'X', 4096 ),
+			'utf-8 unicode'       => '🔐 unicode 秘密 шифр',
+			'single char'         => 'a',
+		);
+
+		foreach ( $cases as $label => $plaintext ) {
+			$envelope = Util_Crypto::envelope_encrypt( $plaintext );
+			$this->assertStringStartsWith( 'enc:v1:', $envelope, "Encryption did not produce envelope for [$label]." );
+
+			$decrypted = Util_Crypto::envelope_decrypt( $envelope );
+			$this->assertSame( $plaintext, $decrypted, "Round-trip lost data for [$label]." );
+		}
+	}
+
+	/**
+	 * Empty / non-string inputs pass through (the helper is a no-op so
+	 * the config layer can hand it any value without special-casing).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_empty_and_non_string_passthrough() {
+		$this->assertSame( '', Util_Crypto::envelope_encrypt( '' ) );
+		$this->assertSame( null, Util_Crypto::envelope_encrypt( null ) );
+		$this->assertSame( '', Util_Crypto::envelope_decrypt( '' ) );
+		$this->assertSame( null, Util_Crypto::envelope_decrypt( null ) );
+	}
+
+	/**
+	 * A pre-fix install's plaintext value reads through `envelope_decrypt`
+	 * unchanged so the upgrade is transparent — values stay readable
+	 * until the next `save()` re-wraps them.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_legacy_plaintext_passes_through_decrypt() {
+		$legacy = 'AKIAIOSFODNN7EXAMPLE';
+		$this->assertSame( $legacy, Util_Crypto::envelope_decrypt( $legacy ) );
+	}
+
+	/**
+	 * Encrypting an already-enveloped value MUST NOT double-wrap. A
+	 * double-wrap would mean the upgrade path encrypts an already-
+	 * encrypted blob and then can't decrypt it back to the original.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_no_double_wrap() {
+		$plain = 'wJalrXUtnFEMI/K7MDENG';
+		$once  = Util_Crypto::envelope_encrypt( $plain );
+		$twice = Util_Crypto::envelope_encrypt( $once );
+
+		$this->assertSame( $once, $twice );
+	}
+
+	/**
+	 * Each encryption uses a fresh random IV, so the same plaintext
+	 * produces a different envelope each time. Determinism here would
+	 * be a serious crypto smell (CBC with reused IV leaks structure).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_fresh_iv_per_call() {
+		$a = Util_Crypto::envelope_encrypt( 'same' );
+		$b = Util_Crypto::envelope_encrypt( 'same' );
+
+		$this->assertNotSame( $a, $b );
+		$this->assertSame( 'same', Util_Crypto::envelope_decrypt( $a ) );
+		$this->assertSame( 'same', Util_Crypto::envelope_decrypt( $b ) );
+	}
+
+	/**
+	 * A flipped byte anywhere in the body fails the HMAC check and
+	 * decrypt returns `false`. The config layer collapses that to '' so
+	 * the admin sees "credential needs re-entry" rather than the
+	 * literal false.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_tampered_envelope_returns_false() {
+		$envelope = Util_Crypto::envelope_encrypt( 'legit-credential' );
+
+		// Flip a byte in the body (just outside the prefix).
+		$body              = substr( $envelope, strlen( 'enc:v1:' ) );
+		$tampered_body     = $body;
+		$tampered_body[10] = ( 'A' === $tampered_body[10] ? 'B' : 'A' );
+		$tampered          = 'enc:v1:' . $tampered_body;
+
+		$this->assertFalse( Util_Crypto::envelope_decrypt( $tampered ) );
+
+		// Truncation also fails the HMAC.
+		$truncated = 'enc:v1:' . substr( $body, 0, 30 );
+		$this->assertFalse( Util_Crypto::envelope_decrypt( $truncated ) );
+	}
+
+	/**
+	 * Malformed base64 in the body fails cleanly (no warning, no fatal).
+	 *
+	 * @since X.X.X
+	 */
+	public function test_malformed_base64_returns_false() {
+		$this->assertFalse( Util_Crypto::envelope_decrypt( 'enc:v1:not!valid!base64!!!' ) );
+	}
+
+	/**
+	 * `is_envelope()` recognises the prefix and rejects everything else.
+	 *
+	 * @since X.X.X
+	 */
+	public function test_is_envelope_recognises_prefix() {
+		$this->assertTrue( Util_Crypto::is_envelope( 'enc:v1:abc' ) );
+		$this->assertFalse( Util_Crypto::is_envelope( 'plain credential' ) );
+		$this->assertFalse( Util_Crypto::is_envelope( '' ) );
+		$this->assertFalse( Util_Crypto::is_envelope( null ) );
+		$this->assertFalse( Util_Crypto::is_envelope( array() ) );
+		$this->assertFalse( Util_Crypto::is_envelope( 'enc:v0:legacy' ) );
+	}
+}


### PR DESCRIPTION
  https://imh-internal.atlassian.net/jira/software/c/projects/ENG7/boards/863/backlog?selectedIssue=ENG7-3011

  Closes the RT9 `crypto-secrets-cookies` group: encrypt at-rest CDN
  credentials in `master.php`, replace `md5(NONCE_KEY . $role)` with an
  HMAC-SHA256 cookie name (with one-release back-compat read), set
  secure/httponly/samesite=Lax on every `w3tc_*` cookie, render
  credential form inputs as placeholders (no plaintext in HTML
  `value=`), re-enable TLS cert verification on the License API.

  **Closes 5 findings (3 High, 2 Medium)** and **contributes to
  CHAIN-013** (sslverify on outbound calls — license half).

  | Bead    | Severity | Finding                 |
|---------|----------|--------------------------------------------------------------------------------------------------------------------|
  | rt9-14  | High     | A02:2021 — CDN API credentials stored plaintext in W3TC config                |
  | rt9-13  | High     | A02:2021 — TLS certificate verification disabled on outbound license calls (license half;image-service/ttfb in SSRF PR) |
  | rt9-11  | High     | A07:2021 — MD5 cookie name from `md5(NONCE_KEY . $role)` (broken hash for cache-key auth marker)                 |
  | rt9-19  | Medium   | A02:2021 — Configuration secrets reflected into HTML attribute values on every settings-pagerender                |
  | rt9-10  | Medium   | A07:2021 — Cookies set without Secure / HttpOnly / SameSite flags                   |

  ## What changed

  | File                                       | Net     | Role                  |
|--------------------------------------------|--------:|-----------------------------------------------------------------------------------|
  | `Util_Crypto.php` *(new)*                  | +198    | AES-256-CBC + HMAC envelope, `enc:v1:...` format, legacyplaintext passthrough    |
  | `Util_Cookie.php` *(new)*                  | +154    | Array-form `setcookie` wrapper + HMAC role-cookie name + legacyreader            |
  | `ConfigKeys.php`                           | +19     | 19 credential-typed keys flagged `'flags' => array('secret' =>true)`             |
  | `Config.php`                               | +112    | `encrypt_secrets()` / `decrypt_secrets()` + `secret_keys()`cache                 |
  | `ConfigCompiler.php`                       | +13     | `encrypt_secrets()` before write; decrypt master before childseal-compare        |
  | `Generic_AdminActions_Default.php`         | +16     | Empty POST for a secret-flagged key preserves the existing value                  |
  | `Util_Ui.php`                              | +138    | `secret_input()` helper + `is_secret_config_key()` +`control2()` auto-mask       |
  | `Licensing_Core.php`                       | −4      | Removed all four `'sslverify' => false`                  |
  | Cookie writers (4 files)                   | ~30     | `Util_Environment::set_preview`,`PgCache_Plugin::on_logout/on_login`, `Mobile_Referrer`, `Generic_Plugin` role-cookies |
  | Cookie name reads (2 files)                | ~25     | `PgCache_ContentGrabber::_can_read_cache` +`PgCache_Environment` reject-cookie list both walk new + legacy |
  | Credential views (`inc/options/cdn/*.php` + `general.php`) | ~120 | Route every secret input through`Util_Ui::secret_input()` |
  | `tests/admin/class-w3tc-util-crypto-test.php` *(new)` | +175 | 9 tests covering round-trip, tamper, legacy passthrough, no-double-wrap |
  | `tests/admin/class-w3tc-util-cookie-test.php` *(new)` | +90  | 5 tests covering role-cookie name shape + determinism +new-vs-legacy |

  ## Architectural decisions worth your eye on review

  ### 1. Two new helper classes as chokepoints

  Put crypto in `Util_Crypto.php` and cookie writes in `Util_Cookie.php`. Every cookie write and every credential save MUST
   route through these — otherwise a future contributor adds a `setcookie( 'w3tc_X', ... )` without flags, or a new
  credential key without the encrypt path, and the protection silently regresses. Class-as-chokepoint is more maintainable
  than "remember to pass these args every time".

  ### 2. Encrypt-on-write, decrypt-on-load (no audit of read sites)

  The in-memory `$this->_data` stays in plaintext; only the disk representation is enveloped. Every existing
  `$config->get_string('cdn.s3.secret')` call site continues to receive plaintext — no audit of the ~700 read sites needed.

  master.php on disk:    cdn.s3.secret = 'enc:v1:6URx3BEi...'
  Config::load():        decrypt_secrets($data); → cdn.s3.secret = 'wJalrXUtn...'
  $config->get_string(): cdn.s3.secret → 'wJalrXUtn...' (plaintext, unchanged from pre-fix)
  Config::save():        plaintext flows into ConfigCompiler::save()
  ConfigCompiler:        encrypt_secrets($data); → master.php gets 'enc:v1:...'

  Tamper failures (HMAC mismatch, malformed base64) collapse to empty string, so the admin form shows "credential needs
  re-entry" rather than the literal `false`.

  ### 3. One-release cookie-name back-compat window

  `Generic_Plugin` writes the new HMAC name only. `PgCache_ContentGrabber` and the `PgCache_Environment` reject-cookie list
   (both call sites) accept BOTH names. Browsers carrying a pre-upgrade `w3tc_logged_<MD5>=1` cookie continue to bypass
  cache during the transition.

  Drop the legacy reader and the matching reject-cookie entry in the release AFTER this one. Comments inline mark the drop
  sites.

  ### 4. Empty-POST-preserves-secret rule (the load-bearing companion)

  Without this, the `value=""` placeholder pattern wipes every CDN credential on the first Settings save. Easiest footgun
  in the whole PR to miss in review:

  ```
  php
  // Generic_AdminActions_Default::read_request()
  if (
      is_array( $descriptor )
      && ! empty( $descriptor['flags']['secret'] )
      && ( ! is_string( $request_value ) || '' === $request_value )
  ) {
      continue;  // empty POST for a secret means "no change", not "wipe it".
  }
  ```

  ### 5. Salt rotation invalidates secrets — by design

  If an operator rotates secure_auth (or auth) salts in wp-config.php, every previously-encrypted secret will fail to
  decrypt. That matches WordPress's own behaviour for cookie-signed sessions — the salt is the master secret. Operators
  rotating salts must re-enter credentials. The release notes should call this out alongside the existing salt-rotation
  guidance.

  ### 6. AES-256-CBC + HMAC, not AES-256-GCM

  GCM would be preferred for new code, but openssl_encrypt's GCM mode requires PHP 7.1+ AND an OpenSSL build that exposes
  it — uneven in the PHP-7.2.5 → 8.3 support window. CBC + HMAC-SHA256 (encrypt-then-MAC, with a hash_equals check before
  openssl_decrypt) is universally supported and gives the same authenticated-encryption guarantee at this threat model.
  derive_key() uses HMAC-over-constant-string-keyed-by-salt so a future salt re-use can't accidentally produce the same
  envelope key.

  ### 7. Util_Ui::control2() auto-mask via flags.secret

  Util_Ui::secret_input() is the explicit helper for direct calls. But many credential inputs are rendered through
  Util_Ui::config_item() → control2(). So control2() checks is_secret_config_key() on textbox-typed items and routes
  through secret_input() automatically — future credential fields added to the schema are masked by being flagged, no
  template edit needed.

  Test plan

  Automated (passing)

  1. PHP syntax check on every changed file
  php -l Util_Crypto.php Util_Cookie.php Config.php ConfigCompiler.php \
         ConfigKeys.php Util_Ui.php Util_Environment.php Generic_Plugin.php \
         Generic_AdminActions_Default.php PgCache_Plugin.php \
         PgCache_ContentGrabber.php PgCache_Environment.php \
         Mobile_Referrer.php Licensing_Core.php \
         tests/admin/class-w3tc-util-crypto-test.php \
         tests/admin/class-w3tc-util-cookie-test.php

  2. Lint everything
  yarn run php-lint

  3. Full PHPUnit suite
  ./vendor/bin/phpunit
  Expected: 92 tests, 331 assertions, all green

  4. New tests in isolation
  ./vendor/bin/phpunit --filter 'W3tc_Util_Crypto_Test|W3tc_Util_Cookie_Test'
  Expected: 13 tests, 45 assertions

  5. WordPress coding-standards check
  ./vendor/bin/phpcs Util_Crypto.php Util_Cookie.php Config.php ConfigCompiler.php

  Manual on staging (for the reviewer)

  A. At-rest encryption — round-trip

  1. Fresh W3TC install. Performance → CDN → enable an engine and enter a credential (e.g. S3 access key + secret).
  2. Save.
  3. Read wp-content/w3tc-config/master.php. Confirm:
    - cdn.s3.key and cdn.s3.secret appear as 'enc:v1:...' strings.
    - The base64 body of each is different (fresh IV per encrypt).
  4. Hit any frontend page; confirm CDN URLs render correctly (the read path decrypts in-memory).
  5. Performance → Dashboard → Empty all caches; confirm no notices in debug.log.

  B. At-rest encryption — placeholder round-trip

  1. With the credentials saved from step A, reload the CDN settings page. Confirm:
    - View source → every credential input is value="".
    - The visible field shows •••••••• as placeholder (proof that "something is configured" without leaking the value).
  2. Save the Settings page without re-entering anything. Read master.php again. Confirm cdn.s3.secret is unchanged (the
  empty-POST-preserves-secret rule fired).
  3. Now enter a new value into cdn.s3.secret and save. Confirm master.php has a new enc:v1:... blob.

  C. At-rest encryption — tamper detect

  Read the encrypted value from master.php, flip a byte in the middle, write back.
  ENC=$(grep -oE "'enc:v1:[^']+'" wp-content/w3tc-config/master.php | head -1)
  ... manually edit one base64 char ...
  Reload the CDN settings page.
  Expected: the cdn.s3.secret field renders with an empty placeholder (no ••••••••), because the tamper-detect returned
  false and the value collapsed to ''. The admin can re-enter and save.
  
  D. Cookie flags

  1. Browse the site over HTTPS (logged in as admin).
  2. Open browser DevTools → Network → click any request → Response Headers.
  3. Confirm every Set-Cookie: w3tc_* line includes Secure; HttpOnly; SameSite=Lax.
  4. Repeat over plain HTTP — Secure is absent (correct: would break http-only test installs).

  E. Cookie name migration + back-compat

  1. Before upgrade: log in as admin. DevTools → Application → Cookies. Find w3tc_logged_<MD5> (32 hex chars). Note the
  value.
  2. Upgrade to this branch.
  3. Log out + log back in. Confirm:
    - A new cookie w3tc_logged_<HMAC> appears (also 32 hex chars; DIFFERENT from the MD5 one).
  4. Inject the legacy MD5 cookie back into the browser manually (DevTools → set a cookie with the original MD5 name and 1
  value). Hit the front page.
    - Confirm the page is served fresh (no cache hit) — the back-compat reader in _can_read_cache recognised the legacy
  cookie and bypassed cache.
  5. Repeat with only the new HMAC cookie present — should also bypass cache.

  F. License API TLS verify

  1. Performance → General Settings → Licensing → enter a valid license key and click Activate.
  2. Confirm the activation succeeds (server is reachable over HTTPS with a valid cert).
  3. As an MITM test, point the licensing API URL at a host with a self-signed cert (e.g. via /etc/hosts). Confirm the
  activation fails (previously would have succeeded with sslverify => false).

  G. nginx / Apache reject-cookie config

  If you have pgcache.engine = file_generic and pgcache.reject.logged_roles = true:

  1. Regenerate the page-cache config (Performance → General Settings → Save All Settings — re-emits .htaccess /
  nginx.conf).
  2. Inspect .htaccess (or nginx.conf). Confirm the reject-cookie list contains BOTH w3tc_logged_<HMAC> AND
  w3tc_logged_<MD5> entries for each rejected role (back-compat window).
  3. After the next release drops the legacy form, only the HMAC entries should remain.

  Verification

  Static code review only — the RT9 engagement lab is decommissioned and per-finding proof.sh scripts depend on lab
  credentials excluded from the audit handoff. Each fix was confirmed by reading the finding's Vulnerable Code +
  Remediation sections in tmp/sec-ideas/crypto-secrets-cookies.md, inspecting the post-fix file, and running the new
  WP_UnitTestCase coverage end-to-end (92/92 pass).

  The crypto envelope was smoke-tested directly against:
  - 8 round-trip cases (short ASCII, AWS-key shape, user:pass, spaces, quotes, 4KB string, UTF-8, single char)
  - Tamper detection (flipped byte → false; truncation → false; malformed base64 → false)
  - Legacy plaintext passthrough
  - No double-wrap on already-enveloped input
  - Fresh IV per call (same plaintext → different envelope)

  Staging note (important)

  Util_Crypto.php and Util_Cookie.php are new files. git add -u and git commit -a skip new files — stage them explicitly:

  git add Util_Crypto.php Util_Cookie.php Config.php ConfigCompiler.php \
          ConfigKeys.php Util_Ui.php Util_Environment.php Generic_Plugin.php \
          Generic_AdminActions_Default.php PgCache_Plugin.php \
          PgCache_ContentGrabber.php PgCache_Environment.php \
          Mobile_Referrer.php Licensing_Core.php \
          inc/options/cdn/ inc/options/general.php \
          tests/admin/class-w3tc-util-crypto-test.php \
          tests/admin/class-w3tc-util-cookie-test.php

  If the new helpers aren't in the commit, every page request will fatal with Class W3TC\Util_Crypto not found
  (Config::load → decrypt_secrets) or Class W3TC\Util_Cookie not found (any login/logout). Same gotcha pattern as the auth
  PR's Util_Nonce.php, the command-injection PR's Util_Java.php, and the file-inclusion PR's Util_Extension.php.

  Salt rotation note (operator-facing — should land in CHANGELOG)

  If an operator rotates secure_auth (or auth) salts in wp-config.php after this PR is deployed:

  - Every encrypted credential in master.php will fail to decrypt. The admin form will show empty credential fields;
  CDN/FTP/license operations will fail until the credentials are re-entered.
  - Every active cache-bypass cookie (w3tc_logged_<HMAC>) will be invalidated. Logged-in admins will see the cached version
   of pages until they log in again.

  This matches WordPress's own salt-rotation behaviour (cookie-signed sessions invalidate). It's documented inline in
  Util_Crypto.php and should be added to the release notes.

  Out of scope (other audit groups, separate PRs)

  - TLS verify for image-service / TTFB outbound (Extension_ImageService_Api.php, Util_Http::ttfb) — sec-fix-ssrf PR
  (overlap with rt9-13; coordinated).
  - Google Drive OAuth state nonce + return-handler trust issues (rt9-150 / rt9-151 / rt9-215) — separate OAuth-hardening
  pass.
  - Memcached/Redis password POST-only restriction (rt9-12) — sec-fix-missing-auth PR.
  - Swarmify / NewRelic mass-assignment hardening (rt9-216 / rt9-217) — sec-fix-mass-assignment PR.
  - Google API library replacement (rt9-43) — dependency-upgrade pass.
  - Extension-level credentials (cloudflare.key, bunnycdn.api_key, etc.) — not in the static ConfigKeys.php schema;
  separate per-extension pass.