### PR TITLE
Fix Redis/Memcached/CDN credential regressions

### DIFF
--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -611,13 +611,26 @@ class Cdn_AdminActions {
 					'privkey' => 'cdn.ftp.privkey',
 				);
 			case 's3':
-				return array( 'secret' => 'cdn.s3.secret' );
+				return array(
+					'key'    => 'cdn.s3.key',
+					'secret' => 'cdn.s3.secret',
+				);
 			case 's3_compatible':
-				return array( 'secret' => 'cdn.s3_compatible.secret' );
+				// s3_compatible reuses the shared cdn.s3.* config keys (see Cdn_Core::get_cdn()).
+				return array(
+					'key'    => 'cdn.s3.key',
+					'secret' => 'cdn.s3.secret',
+				);
 			case 'cf':
-				return array( 'secret' => 'cdn.cf.secret' );
+				return array(
+					'key'    => 'cdn.cf.key',
+					'secret' => 'cdn.cf.secret',
+				);
 			case 'cf2':
-				return array( 'secret' => 'cdn.cf2.secret' );
+				return array(
+					'key'    => 'cdn.cf2.key',
+					'secret' => 'cdn.cf2.secret',
+				);
 			case 'rscf':
 				return array( 'key' => 'cdn.rscf.key' );
 			case 'azure':

--- a/Config.php
+++ b/Config.php
@@ -263,18 +263,27 @@ class Config {
 	 * `load()` while `wp_salt()` is still undefined. We skip the eager
 	 * decrypt in that window so {@see Util_Crypto::derive_key()} doesn't
 	 * take its `SECURE_AUTH_KEY|AUTH_KEY` fallback branch — which derives a
-	 * different key than `wp_salt('secure_auth')` and would HMAC-fail every
-	 * secret, collapsing each one to `''` for the rest of the request.
+	 * different key than `wp_salt('secure_auth')` and would fail to verify
+	 * every value, collapsing each one to `''` for the rest of the request.
 	 *
 	 * By the time admin / settings / CDN code calls `$w3tc_config->get_string()`,
 	 * `wp_salt()` has loaded, so we decrypt then and cache the plaintext
 	 * back into `$_data` so subsequent reads are plain hash lookups.
 	 *
+	 * The runtime cache engines (Redis / Memcached page, object, db and minify
+	 * caches) are different: they read their stored connection values during the
+	 * same pre-pluggable window, and unlike the license/CDN consumers they have
+	 * no later post-pluggable read to fall back on. {@see Util_Crypto::key_salt()}
+	 * reproduces `wp_salt('secure_auth')` from the wp-config salt constants so we
+	 * can resolve those early when the constants are present; otherwise the
+	 * engine would receive the raw `enc:v1:...` envelope instead of the stored
+	 * value.
+	 *
 	 * @since 2.10.0
 	 *
 	 * @param mixed $w3tc_value Value to inspect; mutated in place when an
-	 *                     envelope is successfully decrypted (or collapsed
-	 *                     to '' on HMAC tamper).
+	 *                     envelope is successfully decrypted (or collapsed to ''
+	 *                     when it cannot be verified in the post-pluggable window).
 	 *
 	 * @return void
 	 */
@@ -282,11 +291,37 @@ class Config {
 		if ( ! is_string( $w3tc_value ) || 0 !== strncmp( $w3tc_value, 'enc:v1:', 7 ) ) {
 			return;
 		}
-		if ( ! \function_exists( 'wp_salt' ) || ! class_exists( '\W3TC\Util_Crypto' ) ) {
+		if ( ! class_exists( '\W3TC\Util_Crypto' ) ) {
 			return;
 		}
-		$plain      = Util_Crypto::envelope_decrypt( $w3tc_value );
-		$w3tc_value = ( false === $plain ) ? '' : $plain;
+
+		$wp_salt_ready = \function_exists( 'wp_salt' );
+
+		/*
+		 * Before pluggable.php defines wp_salt(), only attempt a decrypt when
+		 * the wp-config salt constants are available — Util_Crypto::key_salt()
+		 * reproduces wp_salt('secure_auth') from them, so the derived key
+		 * matches encrypt time. Without those constants we cannot derive the
+		 * right key this early; leave the envelope intact so a later save()
+		 * does not persist an unverified collapse over a recoverable value.
+		 */
+		if ( ! $wp_salt_ready && ! Util_Crypto::salt_constants_available() ) {
+			return;
+		}
+
+		$plain = Util_Crypto::envelope_decrypt( $w3tc_value );
+
+		if ( false !== $plain ) {
+			$w3tc_value = $plain;
+		} elseif ( $wp_salt_ready ) {
+			/*
+			 * Rotated salt (or otherwise unrecoverable) in the post-pluggable
+			 * window: collapse so the consumer treats it as needing re-entry.
+			 * Pre-pluggable we deliberately leave the envelope in place
+			 * (non-destructive) — see the guard above.
+			 */
+			$w3tc_value = '';
+		}
 	}
 
 	/**

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -61,6 +61,33 @@ class Generic_AdminActions_Test {
 	}
 
 	/**
+	 * Resolves the saved cache auth value for the module under test.
+	 *
+	 * Masked {@see Util_Ui::secret_input()} fields submit an empty value once a
+	 * value is stored, so the "Test" button would otherwise connect with an
+	 * empty value and fail after every save. The settings page posts the module
+	 * that owns the field (the `{module}__{engine}__password` field-name prefix)
+	 * so we can read the stored value back from config here — it resolves
+	 * transparently because this admin request runs after `pluggable.php`.
+	 *
+	 * @since 2.10.0
+	 *
+	 * @param string $engine Cache engine identifier: 'redis' or 'memcached'.
+	 *
+	 * @return string Stored value, or '' when the module is unknown / unset.
+	 */
+	private function stored_cache_password( $engine ) {
+		$module  = Util_Request::get_string( 'module', '' );
+		$allowed = array( 'pgcache', 'dbcache', 'objectcache', 'minify' );
+
+		if ( ! in_array( $module, $allowed, true ) ) {
+			return '';
+		}
+
+		return $this->_config->get_string( $module . '.' . $engine . '.password' );
+	}
+
+	/**
 	 * Test memcached
 	 *
 	 * @return void
@@ -80,6 +107,11 @@ class Generic_AdminActions_Test {
 		$password = isset( $_POST['password'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified upstream by the admin-action dispatcher.
 			? (string) wp_unslash( $_POST['password'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- password is opaque secret used only as the auth credential to memcached; nonce verified upstream by the admin-action dispatcher.
 			: '';
+
+		// A masked field submits empty once stored — fall back to the saved value.
+		if ( '' === $password ) {
+			$password = $this->stored_cache_password( 'memcached' );
+		}
 
 		$this->respond_test_result( $this->is_memcache_available( $servers, $binary_protocol, $username, $password ) );
 	}
@@ -101,6 +133,11 @@ class Generic_AdminActions_Test {
 		$password = isset( $_POST['password'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified upstream by the admin-action dispatcher.
 			? (string) wp_unslash( $_POST['password'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- password is opaque secret used only as the auth credential to redis; nonce verified upstream by the admin-action dispatcher.
 			: '';
+
+		// A masked field submits empty once stored — fall back to the saved value.
+		if ( '' === $password ) {
+			$password = $this->stored_cache_password( 'redis' );
+		}
 
 		if ( empty( $servers ) ) {
 			$success = false;

--- a/Util_Crypto.php
+++ b/Util_Crypto.php
@@ -101,9 +101,9 @@ class Util_Crypto {
 	 * cipher key and the MAC key cryptographically independent.
 	 *
 	 * Both keys are tied to `wp_salt('secure_auth')` so the keying
-	 * material rotates whenever the operator rotates that salt. Falls
-	 * back to a mix of AUTH_KEY + SECURE_AUTH_KEY when `wp_salt()` is
-	 * unavailable (CLI helpers, standalone tests).
+	 * material rotates whenever the operator rotates that salt. The
+	 * salt itself is resolved by {@see self::key_salt()}, which keeps the
+	 * derived key identical whether or not `wp_salt()` has loaded yet.
 	 *
 	 * @since 2.10.0
 	 *
@@ -113,14 +113,68 @@ class Util_Crypto {
 	 * @return string Raw 32-byte HMAC-SHA256 output.
 	 */
 	private static function derive_key( $purpose = 'enc' ) {
+		return \hash_hmac( 'sha256', 'w3tc:envelope:' . $purpose, self::key_salt(), true );
+	}
+
+	/**
+	 * Resolves the salt the envelope key is derived from.
+	 *
+	 * The salt must be identical at encrypt time (admin context, `wp_salt()`
+	 * available) and at decrypt time — including the early-bootstrap window
+	 * where `advanced-cache.php` and the object-cache drop-ins read stored
+	 * values before `wp-includes/pluggable.php` defines `wp_salt()`. If the two
+	 * differ, the derived key differs and the stored value cannot be recovered.
+	 *
+	 * Resolution order:
+	 *
+	 * 1. `wp_salt('secure_auth')` when available — authoritative; honours a
+	 *    `salt` filter and DB-stored salts.
+	 * 2. Otherwise reproduce what `wp_salt('secure_auth')` returns from the
+	 *    wp-config.php constants `SECURE_AUTH_KEY . SECURE_AUTH_SALT`. For the
+	 *    common case (all eight keys/salts defined in wp-config.php, no `salt`
+	 *    filter) this is byte-identical to (1), so a value stored in admin can
+	 *    be read back during the pre-pluggable bootstrap.
+	 * 3. Last-resort fallback for standalone CLI helpers / unit tests with no
+	 *    salts defined at all. Values keyed here cannot be read back in any
+	 *    other context, but nothing in a real install relies on it.
+	 *
+	 * Installs relying on auto-generated (DB-stored) salts or a `salt` filter —
+	 * where (2) cannot reproduce (1) — cannot resolve stored values
+	 * pre-pluggable; the caller leaves the envelope intact rather than
+	 * discarding it (see {@see \W3TC\Config::_maybe_lazy_decrypt()}).
+	 *
+	 * @since 2.10.0
+	 *
+	 * @return string Salt string fed to {@see self::derive_key()}.
+	 */
+	private static function key_salt() {
 		if ( \function_exists( 'wp_salt' ) ) {
-			$salt = (string) \wp_salt( 'secure_auth' );
-		} else {
-			$salt = ( defined( 'SECURE_AUTH_KEY' ) ? (string) SECURE_AUTH_KEY : '' )
-				. '|' . ( defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '' );
+			return (string) \wp_salt( 'secure_auth' );
 		}
 
-		return \hash_hmac( 'sha256', 'w3tc:envelope:' . $purpose, $salt, true );
+		if ( self::salt_constants_available() ) {
+			return (string) SECURE_AUTH_KEY . (string) SECURE_AUTH_SALT;
+		}
+
+		return ( defined( 'SECURE_AUTH_KEY' ) ? (string) SECURE_AUTH_KEY : '' )
+			. '|' . ( defined( 'AUTH_KEY' ) ? (string) AUTH_KEY : '' );
+	}
+
+	/**
+	 * True when the wp-config.php salt constants needed to reproduce
+	 * `wp_salt('secure_auth')` without `wp_salt()` are defined and non-empty.
+	 *
+	 * Used both by {@see self::key_salt()} (to pick the early-bootstrap branch)
+	 * and by {@see \W3TC\Config::_maybe_lazy_decrypt()} (to decide whether a
+	 * pre-pluggable decrypt can be trusted to use the right key).
+	 *
+	 * @since 2.10.0
+	 *
+	 * @return bool
+	 */
+	public static function salt_constants_available() {
+		return defined( 'SECURE_AUTH_KEY' ) && SECURE_AUTH_KEY
+			&& defined( 'SECURE_AUTH_SALT' ) && SECURE_AUTH_SALT;
 	}
 
 	/**

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -1466,6 +1466,10 @@ jQuery(function () {
           ),
           username: jQuery("#memcached_username").val(),
           password: jQuery("#memcached_password").val(),
+          // Masked field submits empty once stored; send the owning module so the server can fall back to the saved value.
+          module: (jQuery("#memcached_password").attr("name") || "").split(
+            "__",
+          )[0],
           _wpnonce: jQuery(this).metadata().nonce,
         },
         function (data) {
@@ -1499,6 +1503,8 @@ jQuery(function () {
           ).is(":checked"),
           dbid: jQuery("#redis_dbid").val(),
           password: jQuery("#redis_password").val(),
+          // Masked field submits empty once stored; send the owning module so the server can fall back to the saved value.
+          module: (jQuery("#redis_password").attr("name") || "").split("__")[0],
           _wpnonce: jQuery(this).metadata().nonce,
         },
         function (data) {

--- a/tests/test-crypto-early-bootstrap.php
+++ b/tests/test-crypto-early-bootstrap.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Standalone regression test for Util_Crypto early-bootstrap key derivation.
+ *
+ * Pins the 2.10.0 fix for stored values not resolving at runtime: the
+ * page-cache (`advanced-cache.php`) and object-cache drop-ins read stored
+ * `enc:v1:...` values BEFORE `wp-includes/pluggable.php` defines `wp_salt()`.
+ * The envelope key must be derivable in that pre-pluggable window with the SAME
+ * bytes used at encrypt time (admin context, `wp_salt()` available) — otherwise
+ * the derived key differs and the stored value cannot be recovered.
+ *
+ * This test verifies:
+ *   1. A value enveloped while `wp_salt()` is UNAVAILABLE (constants branch)
+ *      round-trips immediately (early-bootstrap self-consistency).
+ *   2. That same envelope still decrypts once `wp_salt()` IS defined to the
+ *      value it returns in the common case (`SECURE_AUTH_KEY . SECURE_AUTH_SALT`).
+ *      Because the derivation is deterministic in the salt string, identical
+ *      salts ⇒ identical keys ⇒ envelopes cross-decrypt in BOTH directions —
+ *      i.e. a value stored in admin resolves at cache bootstrap.
+ *   3. `salt_constants_available()` reflects the wp-config salt constants.
+ *   4. Legacy plaintext passes through unchanged; a bad-MAC envelope is rejected.
+ *
+ * Run with: php tests/test-crypto-early-bootstrap.php
+ *
+ * Exit code 0 = all pass, non-zero = failures.
+ *
+ * @package W3TC\Tests
+ * @since   2.10.0
+ */
+
+if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+	return;
+}
+
+// Salt constants that stand in for wp-config.php. Defined BEFORE wp_salt() so
+// the encrypt below exercises the pre-pluggable constants branch.
+define( 'SECURE_AUTH_KEY', 'ceb-unit-secure-auth-key-0123456789abcdef' );
+define( 'SECURE_AUTH_SALT', 'ceb-unit-secure-auth-salt-fedcba9876543210' );
+define( 'AUTH_KEY', 'ceb-unit-auth-key-should-not-be-used-here' );
+
+require_once __DIR__ . '/../Util_Crypto.php';
+
+use W3TC\Util_Crypto;
+
+$ceb_pass = 0;
+$ceb_fail = 0;
+
+/**
+ * Minimal assert helper (file-unique name per the standalone-test convention).
+ *
+ * @param bool   $cond  Condition that must hold.
+ * @param string $label Human-readable description.
+ *
+ * @return void
+ */
+function ceb_assert( $cond, $label ) {
+	global $ceb_pass, $ceb_fail;
+	if ( $cond ) {
+		$ceb_pass++;
+		echo "  PASS: $label\n";
+	} else {
+		$ceb_fail++;
+		echo "  FAIL: $label\n";
+	}
+}
+
+if ( ! Util_Crypto::is_available() ) {
+	echo "SKIP: OpenSSL AES-256-CBC not available in this PHP build.\n";
+	return;
+}
+
+echo "Util_Crypto early-bootstrap key derivation\n";
+
+// 1. Constants branch is active (wp_salt not yet defined) and reports ready.
+ceb_assert( ! function_exists( 'wp_salt' ), 'precondition: wp_salt() is undefined (early-bootstrap window)' );
+ceb_assert( Util_Crypto::salt_constants_available(), 'salt_constants_available() is true with the constants defined' );
+
+// 1. Envelope a value in the pre-pluggable window, then decrypt it there.
+$plaintext     = 'round-trip-sample-value';
+$envelope_boot = Util_Crypto::envelope_encrypt( $plaintext );
+
+ceb_assert( Util_Crypto::is_envelope( $envelope_boot ), 'envelope_encrypt() produced an enc:v1: envelope pre-pluggable' );
+ceb_assert( $plaintext === Util_Crypto::envelope_decrypt( $envelope_boot ), 'pre-pluggable envelope round-trips (early-bootstrap self-consistency)' );
+
+// 4. Legacy plaintext and bad-MAC behaviour (independent of the salt branch).
+ceb_assert( 'legacy-plain' === Util_Crypto::envelope_decrypt( 'legacy-plain' ), 'legacy plaintext passes through unchanged' );
+ceb_assert( false === Util_Crypto::envelope_decrypt( 'enc:v1:' . base64_encode( 'too-short' ) ), 'malformed/short envelope returns false' );
+
+$bad_mac = 'enc:v1:' . base64_encode( str_repeat( "\x00", 64 ) ); // valid length, invalid MAC
+ceb_assert( false === Util_Crypto::envelope_decrypt( $bad_mac ), 'bad-MAC envelope is rejected' );
+
+// 2. Now simulate pluggable.php loading: define wp_salt() to the value it
+// returns in the common case. The envelope made via the constants branch must
+// still decrypt via the wp_salt branch — proving both derive an identical key.
+if ( ! function_exists( 'wp_salt' ) ) {
+	/**
+	 * Stub of WordPress's wp_salt() for the 'secure_auth' scheme.
+	 *
+	 * @param string $scheme Salt scheme.
+	 *
+	 * @return string
+	 */
+	function wp_salt( $scheme = 'auth' ) {
+		return SECURE_AUTH_KEY . SECURE_AUTH_SALT;
+	}
+}
+
+ceb_assert( function_exists( 'wp_salt' ), 'post-condition: wp_salt() now defined (post-pluggable window)' );
+ceb_assert(
+	$plaintext === Util_Crypto::envelope_decrypt( $envelope_boot ),
+	'constants-branch envelope decrypts under wp_salt() — key match across the pluggable boundary (THE fix)'
+);
+
+// 5. Encrypt under the wp_salt branch and confirm it round-trips too.
+$envelope_admin = Util_Crypto::envelope_encrypt( $plaintext );
+ceb_assert( $plaintext === Util_Crypto::envelope_decrypt( $envelope_admin ), 'wp_salt-branch envelope round-trips' );
+
+echo "\n$ceb_pass passed, $ceb_fail failed\n";
+exit( $ceb_fail > 0 ? 1 : 0 );


### PR DESCRIPTION
## ENG7-3960: Restore Redis/Memcached/CDN connection handling after 2.10.0 at-rest value wrapping

### Summary

W3TC 2.10.0 began wrapping stored config values at rest (`enc:v1:…` envelopes in `master.php`) and masking the connection input fields. Three follow-on issues surfaced on the .org support forums; this PR addresses all three.

| # | Symptom | Cause | Change |
|---|---------|-------|--------|
| 1 | Redis/Memcached cache not serving at runtime | `advanced-cache.php` and the object-cache drop-ins read the stored value before `pluggable.php` defines `wp_salt()`, so `Config::_maybe_lazy_decrypt()` skipped resolution and the raw `enc:v1:` envelope reached the engine | `Util_Crypto::key_salt()` reproduces `wp_salt('secure_auth')` from the `SECURE_AUTH_KEY`/`SECURE_AUTH_SALT` wp-config constants when `wp_salt()` isn't loaded yet; `_maybe_lazy_decrypt()` resolves early when those constants are present, non-destructively |
| 2 | CDN "Test S3/CloudFront" → empty access key | The stored-value refill map listed only one of the two fields for s3/s3_compatible/cf/cf2, so the masked Access Key ID field was never refilled | Added the `key` entries (s3_compatible reuses `cdn.s3.*`) |
| 3 | Redis/Memcached "Test" failed after Save | The masked field submits empty once stored; the test handlers read only the submitted value | Handlers fall back to the stored value via `stored_cache_password()`; the settings page posts the owning module (allowlisted) |

**Known limitation (#1):** installs using DB-generated salts or a `salt` filter — where the wp-config constants can't reproduce `wp_salt()` — still can't resolve the value before `pluggable.php` loads and must re-enter it once.

### Testing

```
php tests/test-crypto-early-bootstrap.php   # expect "10 passed, 0 failed"
./vendor/bin/phpcs Util_Crypto.php Config.php Generic_AdminActions_Test.php Cdn_AdminActions.php
```

- **#1 runtime:** configure Redis/Memcached with an auth value, Save, load front-end pages, confirm the cache serves and the PHP error log is clean.
- **#2 CDN:** configure S3/CloudFront, Save (Access Key ID shows masked dots), click Test → passes (no "empty access key").
- **#3 Test after save:** enter the auth value, Test → passes; Save; Test again → still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
