### PR TITLE
Fix "link expired" nonce error on General Settings

### DIFF
--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -585,17 +585,44 @@ function toggle_fragmentcache_notice() {
 // On document ready.
 jQuery(function () {
   // Per-handler tokens live on the button (data-w3tc-nonce) or in w3tc_admin_nonces; copy into the form field before submit.
+  // Track the last-clicked w3tc_ submit button so the handler copies its nonce, not the first-in-DOM button's (the General Settings form holds both Save and flush buttons).
+  var w3tcLastSubmitter = null;
   jQuery(document).on(
     "click",
     'input[type=submit][name^="w3tc_"]',
     function () {
+      w3tcLastSubmitter = this;
       w3tcSetAdminSubmitNonce(this);
     },
   );
-  jQuery(document).on("submit", "form", function () {
-    var $submitter = jQuery(this).find('input[type=submit][name^="w3tc_"]:focus');
+  jQuery(document).on("submit", "form", function (event) {
+    var form = this;
+    // Pick the submit control the user actually triggered, with fallbacks.
+    var native = event.originalEvent ? event.originalEvent.submitter : null;
+    var $submitter = jQuery();
+    if (
+      native &&
+      native.form === form &&
+      jQuery(native).is('input[type=submit][name^="w3tc_"]')
+    ) {
+      $submitter = jQuery(native);
+    }
+    if (
+      !$submitter.length &&
+      w3tcLastSubmitter &&
+      w3tcLastSubmitter.form === form
+    ) {
+      $submitter = jQuery(w3tcLastSubmitter);
+    }
     if (!$submitter.length) {
-      $submitter = jQuery(this).find('input[type=submit][name^="w3tc_"]').first();
+      $submitter = jQuery(form).find(
+        'input[type=submit][name^="w3tc_"]:focus',
+      );
+    }
+    if (!$submitter.length) {
+      $submitter = jQuery(form)
+        .find('input[type=submit][name^="w3tc_"]')
+        .first();
     }
     if ($submitter.length) {
       w3tcSetAdminSubmitNonce($submitter[0]);


### PR DESCRIPTION
On the General Settings page, clicking Empty all caches (or any purge button) failed with "The link you followed has expired." Saving worked, and the admin-bar "Purge All Caches" worked — only the General Settings flush buttons broke. Reported on the .org forums after 2.10.0.

Root cause: The General Settings page is a single <form> containing multiple w3tc_* submit buttons (Save and the flush buttons). The submit handler in pub/js/options.js only honored a button that was :focus, otherwise it copied the nonce from the first w3tc_* button in the DOM — which is Save. So a flush submit was sent with the Save action's nonce, and check_admin_referer() rejected it. Pages where the flush control is in its own form (Dashboard) or is a GET link with a baked-in nonce (admin bar) were unaffected.

Fix: Identify the submit control the user actually activated and copy its nonce, in priority order:
1. event.submitter (the native button that triggered submission),
2. the last w3tc_* submit button clicked in that form,
3. a :focused w3tc_* button,
4. first-in-DOM only as a last resort.

Single-file change to pub/js/options.js.

Test instructions

1. Performance → General Settings.
2. Click Empty all caches (or any "Empty cache" button on the page).
  - Before: "The link you followed has expired."
  - After: the cache purges and the page reloads normally with the success notice.
3. Regression check on the same page: click Save all settings → settings still save correctly.
4. Sanity-check unaffected paths still work: admin-bar Purge All Caches, and Dashboard Empty All Caches.