### PR TITLE
Fix AlwaysCached queue regeneration on nginx (Disk: Enhanced)

### DIFF
--- a/Extension_AlwaysCached_Plugin.php
+++ b/Extension_AlwaysCached_Plugin.php
@@ -44,6 +44,7 @@ class Extension_AlwaysCached_Plugin {
 		add_filter( 'w3tc_pagecache_flush_url', array( $this, 'w3tc_pagecache_flush_url' ), 1000 );
 		add_filter( 'w3tc_pagecache_flush_all_groups', array( $this, 'w3tc_pagecache_flush_all_groups' ), 1000 );
 		add_filter( 'w3tc_pagecache_rules_apache_rewrite_cond', array( $this, 'w3tc_pagecache_rules_apache_rewrite_cond' ) );
+		add_filter( 'w3tc_pagecache_rules_nginx_rewrite_cond', array( $this, 'w3tc_pagecache_rules_nginx_rewrite_cond' ) );
 
 		// Cron job.
 		add_action( 'w3tc_alwayscached_wp_cron', array( $this, 'w3tc_alwayscached_wp_cron' ) );
@@ -147,6 +148,32 @@ class Extension_AlwaysCached_Plugin {
 	 */
 	public function w3tc_pagecache_rules_apache_rewrite_cond( $rewrite_conditions ) {
 		$rewrite_conditions .= "    RewriteCond %{HTTP:w3tcalwayscached} =\"\"\n";
+		return $rewrite_conditions;
+	}
+
+	/**
+	 * Adds AlwaysCached nginx rules.
+	 *
+	 * Emits the nginx counterpart of {@see self::w3tc_pagecache_rules_apache_rewrite_cond()}:
+	 * when the AlwaysCached loopback request arrives carrying the "w3tcalwayscached"
+	 * header, suppress the static-cache rewrite so the request falls through to PHP
+	 * and regenerates the page (which then echoes back the "w3tcalwayscached" response
+	 * header the worker checks for). Without it, nginx (Disk: Enhanced) serves the
+	 * existing cache file, PHP never runs, the response header is absent, and the
+	 * worker reports the queue item failed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $rewrite_conditions Nginx rules buffer.
+	 *
+	 * @return string
+	 */
+	public function w3tc_pagecache_rules_nginx_rewrite_cond( $rewrite_conditions ) {
+		// A prior callback may have left the buffer without a trailing newline.
+		if ( '' !== $rewrite_conditions && "\n" !== substr( $rewrite_conditions, -1 ) ) {
+			$rewrite_conditions .= "\n";
+		}
+		$rewrite_conditions .= "if (\$http_w3tcalwayscached != \"\") {\n    set \$w3tc_rewrite 0;\n}\n";
 		return $rewrite_conditions;
 	}
 

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1267,6 +1267,26 @@ class PgCache_Environment {
 			$rules .= "}\n";
 		}
 
+		/**
+		 * Filter: Allow extensions to append nginx rewrite-suppression conditions.
+		 *
+		 * Mirrors the Apache "w3tc_pagecache_rules_apache_rewrite_cond" filter. The
+		 * returned string is emitted alongside the built-in reject conditions (POST,
+		 * non-empty query string, rejected cookies / user agents); hooked code should
+		 * append `if (...) { set $w3tc_rewrite 0; }` blocks so matching requests skip
+		 * the static page-cache rewrite and fall through to PHP. The returned string
+		 * is normalized to end with a single newline before it is appended.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param string $rewrite_conditions Nginx rewrite-suppression conditions buffer (starts empty).
+		 */
+		$rewrite_cond = (string) \apply_filters( 'w3tc_pagecache_rules_nginx_rewrite_cond', '' );
+		if ( '' !== $rewrite_cond ) {
+			// Normalize to exactly one trailing newline so a callback that omits it cannot glue the next rule on.
+			$rules .= rtrim( $rewrite_cond, "\n" ) . "\n";
+		}
+
 		// Check mobile groups.
 		if ( $w3tc_config->get_boolean( 'mobile.enabled' ) ) {
 			$mobile_groups = array_reverse( $w3tc_config->get_array( 'mobile.rgroups' ) );


### PR DESCRIPTION
## ENG7-3962: Fix AlwaysCached queue regeneration on nginx (Disk: Enhanced)

### Summary

With AlwaysCached enabled on **nginx + Disk: Enhanced** (`pgcache.engine = file_generic`), processing the regeneration queue — both the per-item "Process" action and the background worker — always failed. Pages were never regenerated and the queue never drained.

### Root cause

AlwaysCached regenerates a queued page by making a loopback HTTP request to the page URL carrying a `w3tcalwayscached` request header. For that to work, the page-cache rules must let the header-bearing request skip the static cache so it reaches PHP, which rebuilds the page and emits a `w3tcalwayscached` response header. The worker treats a response without that header as `failed`.

W3TC only generated that rule for **Apache** (via the `w3tc_pagecache_rules_apache_rewrite_cond` filter, which AlwaysCached hooks). The nginx generator (`PgCache_Environment::rules_core_generate_nginx()` / `for_file_generic()`) had **no equivalent condition and no append point**. So on nginx the loopback request was served the existing static cache file, PHP never ran, the response header was absent, and the worker reported every item failed.

### Fix

Mirror the Apache architecture on nginx:

- **`PgCache_Environment.php`** — add a `w3tc_pagecache_rules_nginx_rewrite_cond` filter alongside the built-in reject conditions (POST / query-string / rejected cookies / UA). It starts from an empty string, so installs that don't hook it produce **byte-identical nginx rules**. The filter output is normalized to end with a single newline so a callback that omits one cannot glue the next rule onto it.
- **`Extension_AlwaysCached_Plugin.php`** — register that filter (only when AlwaysCached is enabled) and emit the nginx counterpart of the Apache rule:
  ```
  if ($http_w3tcalwayscached != "") {
      set $w3tc_rewrite 0;
  }
  ```
  This clears `$w3tc_rewrite` before the final `if ($w3tc_rewrite = 1) { rewrite … last; }`, so the regeneration request reaches PHP.

No `/wp-admin/` carve-out is needed: this only clears the cache-rewrite flag, it adds no redirect. admin-ajax.php — which the AlwaysCached admin JS also stamps with the header — is never served from page cache anyway (the cache-file `-f` check already forces `$w3tc_rewrite 0`), so it continues to its normal PHP handler.

### Testing

```
yarn run php-lint
./vendor/bin/phpcs PgCache_Environment.php Extension_AlwaysCached_Plugin.php
```

- **Manual (the fix)** — nginx + Disk: Enhanced + AlwaysCached enabled: re-save Page Cache settings (or run the environment "fix it" action) so the nginx rules regenerate, reload nginx, then confirm the `PGCACHE_CORE` block contains the `if ($http_w3tcalwayscached != "") { set $w3tc_rewrite 0; }` snippet. Trigger a flush to queue an item, process the queue → succeeds; the item leaves the queue and the regenerated response carries the `w3tcalwayscached` header (before: `{"success":false,"data":"failed"}`).
- **Regression:** normal front-end requests still serve from the static cache; `/wp-admin/` and the AlwaysCached admin-ajax call still work; with AlwaysCached disabled the generated nginx rules are unchanged; Apache installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
