### PR TITLE
Render unrecognized dynamic-fragment tags as empty output

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -2259,6 +2259,20 @@ class PgCache_ContentGrabber {
 	 * The HMAC envelope (`hmac:<hex>`) is added automatically at
 	 * cache-write time; emitters MUST NOT compute it themselves.
 	 *
+	 * **Migrating a legacy tag.** A pre-2.10.0 tag that embedded raw PHP, e.g.
+	 * `<!-- mfunc TOKEN --> echo my_widget(); <!-- /mfunc TOKEN -->`, is no
+	 * longer dispatched (it renders as empty output). Move the logic into a
+	 * registered callback and emit the `call:<slug>` form instead:
+	 *
+	 *     add_filter( 'w3tc_dynamic_callbacks', function( $cbs ) {
+	 *         $cbs['my_widget'] = function( $args, $kind ) {
+	 *             return my_widget();
+	 *         };
+	 *         return $cbs;
+	 *     } );
+	 *
+	 *     <!-- mfunc TOKEN call:my_widget {} --><!-- /mfunc TOKEN -->
+	 *
 	 * **Cache-miss fallback content.** Use the *inline-header* form (with the
 	 * `call:slug` descriptor inside the opening comment) if you want HTML
 	 * placed between the comments to survive a cache miss. The *body-form*
@@ -2458,35 +2472,30 @@ class PgCache_ContentGrabber {
 	 * @param string $slug Callback slug.
 	 * @param array  $args Decoded JSON args.
 	 *
-	 * @return string The callback's HTML output, or an error sentinel.
+	 * @return string The callback's HTML output, or an empty string when the tag cannot be dispatched.
 	 */
 	private function _dispatch_dynamic_callback( $kind, $slug, $args ) {
 		$callbacks = $this->_get_dynamic_callbacks();
 
 		if ( empty( $callbacks ) ) {
-			return \htmlspecialchars(
-				sprintf( 'W3TC dynamic %s registry is empty; no callbacks registered.', $kind ),
-				ENT_QUOTES,
-				'UTF-8'
-			);
+			$this->_log_dynamic_deprecation( $kind, sprintf( 'no callbacks registered (slug "%s")', $slug ) );
+
+			return '';
 		}
 
 		if ( ! isset( $callbacks[ $slug ] ) || ! \is_callable( $callbacks[ $slug ] ) ) {
-			return \htmlspecialchars(
-				sprintf( 'W3TC dynamic %s slug "%s" is not registered.', $kind, $slug ),
-				ENT_QUOTES,
-				'UTF-8'
-			);
+			$this->_log_dynamic_deprecation( $kind, sprintf( 'unregistered slug "%s"', $slug ) );
+
+			return '';
 		}
 
 		try {
 			$w3tc_output = \call_user_func( $callbacks[ $slug ], $args, $kind );
 		} catch ( \Throwable $ex ) {
-			return \htmlspecialchars(
-				sprintf( 'W3TC dynamic %s slug "%s" raised an exception.', $kind, $slug ),
-				ENT_QUOTES,
-				'UTF-8'
-			);
+			// Log the exception class only (not its message) so the operator notice stays actionable without leaking detail.
+			$this->_log_dynamic_deprecation( $kind, sprintf( 'slug "%s" raised %s', $slug, \get_class( $ex ) ) );
+
+			return '';
 		}
 
 		if ( ! \is_string( $w3tc_output ) ) {
@@ -2535,7 +2544,7 @@ class PgCache_ContentGrabber {
 	 * @param string $kind    'mfunc' or 'mclude'.
 	 * @param array  $matches preg_replace_callback matches: [0]=full, [1]=header, [2]=body.
 	 *
-	 * @return string
+	 * @return string Callback output, or an empty string when the tag is refused.
 	 */
 	private function _dispatch_dynamic( $kind, $matches ) {
 		$header = isset( $matches[1] ) ? trim( $matches[1] ) : '';
@@ -2549,13 +2558,10 @@ class PgCache_ContentGrabber {
 		$parsed    = $this->_parse_dynamic_header( $candidate );
 
 		if ( null === $parsed ) {
+			// Render nothing to visitors; the operator log above records the tag to migrate.
 			$this->_log_dynamic_deprecation( $kind, 'raw payload (no call:slug + hmac envelope)' );
 
-			return \htmlspecialchars(
-				sprintf( 'W3TC dynamic %s tag refused: missing call:slug + hmac envelope.', $kind ),
-				ENT_QUOTES,
-				'UTF-8'
-			);
+			return '';
 		}
 
 		$expected = $this->_dynamic_hmac( $kind, $parsed['slug'], $parsed['args_json'] );
@@ -2563,11 +2569,7 @@ class PgCache_ContentGrabber {
 		if ( ! \hash_equals( $expected, $parsed['hmac'] ) ) {
 			$this->_log_dynamic_deprecation( $kind, 'HMAC mismatch' );
 
-			return \htmlspecialchars(
-				sprintf( 'W3TC dynamic %s tag refused: HMAC mismatch.', $kind ),
-				ENT_QUOTES,
-				'UTF-8'
-			);
+			return '';
 		}
 
 		return $this->_dispatch_dynamic_callback( $kind, $parsed['slug'], $this->_decode_dynamic_args( $parsed['args_json'] ) );
@@ -2584,7 +2586,7 @@ class PgCache_ContentGrabber {
 	 *
 	 * @param array $matches The matches from the regular expression.
 	 *
-	 * @return string The callback's output, or an error message.
+	 * @return string The callback's output, or an empty string when refused.
 	 */
 	public function _parse_dynamic_mfunc( $matches ) {
 		return $this->_dispatch_dynamic( 'mfunc', $matches );
@@ -2602,7 +2604,7 @@ class PgCache_ContentGrabber {
 	 *
 	 * @param array $matches The matches from the regular expression.
 	 *
-	 * @return string The callback's output, or an error message.
+	 * @return string The callback's output, or an empty string when refused.
 	 */
 	public function _parse_dynamic_mclude( $matches ) {
 		return $this->_dispatch_dynamic( 'mclude', $matches );
@@ -2619,10 +2621,9 @@ class PgCache_ContentGrabber {
 	 * are signed in place, because dispatch accepts both shapes.
 	 *
 	 * Tags whose payload is not in the safe `call:<slug>` form are left
-	 * unsigned — at dispatch time they will fall through to the
-	 * deprecation path and refuse to execute.  This is intentional: it
-	 * makes back-compat behavior visible (an error in place of the tag)
-	 * rather than silently dropping the tag at write time.
+	 * unsigned — at dispatch time they fall through to the deprecation path,
+	 * render as empty output, and emit a rate-limited operator notice naming
+	 * the tag to migrate.
 	 *
 	 * @since 2.10.0
 	 *

--- a/tests/test-mfunc-security.php
+++ b/tests/test-mfunc-security.php
@@ -489,9 +489,9 @@ $reset_callbacks();
 $raw_php = '<!-- mfunc ' . $token . ' phpinfo(); --><!-- /mfunc ' . $token . ' -->';
 $result  = $grabber->_parse_dynamic( $raw_php );
 assert_true(
-	'[4a] Raw-PHP mfunc payload is refused (no eval, error sentinel)',
+	'[4a] Raw-PHP mfunc payload is refused (not executed, renders empty)',
 	false === strpos( $result, 'phpinfo' )
-		&& false !== strpos( $result, 'refused' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -502,7 +502,7 @@ $result      = $grabber->_parse_dynamic( $raw_between );
 assert_true(
 	'[4b] Raw-PHP between-tags mfunc is refused',
 	false === strpos( $result, 'phpinfo' )
-		&& false !== strpos( $result, 'refused' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -513,7 +513,7 @@ $result   = $grabber->_parse_dynamic( $lfi );
 assert_true(
 	'[4c] mclude with file-path payload is refused',
 	false === strpos( $result, 'root:' )
-		&& false !== strpos( $result, 'refused' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -527,7 +527,7 @@ $result   = $grabber->_parse_dynamic( $unsigned );
 assert_true(
 	'[4d] mfunc with call:slug but no HMAC is refused',
 	false === strpos( $result, 'USER:alice' )
-		&& false !== strpos( $result, 'refused' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -541,7 +541,7 @@ $result     = $grabber->_parse_dynamic( $wrong_hmac );
 assert_true(
 	'[4e] mfunc with wrong HMAC is refused (cache-poisoning defense)',
 	false === strpos( $result, 'USER:alice' )
-		&& false !== strpos( $result, 'HMAC mismatch' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -574,7 +574,7 @@ $result      = $grabber->_parse_dynamic( $bad_tag );
 assert_true(
 	'[4g] mfunc with valid HMAC but unregistered slug is refused',
 	false === strpos( $result, 'OTHER' )
-		&& false !== strpos( $result, 'not registered' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -591,7 +591,7 @@ $result          = $grabber->_parse_dynamic( $mclude_tag );
 assert_true(
 	'[4h] mclude with valid HMAC but unregistered slug is refused',
 	false === strpos( $result, 'OTHER' )
-		&& false !== strpos( $result, 'not registered' ),
+		&& '' === $result,
 	"result: $result"
 );
 
@@ -617,8 +617,8 @@ $hmac        = $grabber->_dynamic_hmac( 'mfunc', 'render_user', $args_json );
 $tag         = '<!-- mfunc ' . $token . ' call:render_user ' . $args_json . ' hmac:' . $hmac . ' --><!-- /mfunc ' . $token . ' -->';
 $result      = $grabber->_parse_dynamic( $tag );
 assert_true(
-	'[4j] Empty callback registry refuses dispatch (no callbacks registered)',
-	false !== strpos( $result, 'registry is empty' ),
+	'[4j] Empty callback registry refuses dispatch (renders empty)',
+	'' === $result,
 	"result: $result"
 );
 
@@ -753,8 +753,8 @@ assert_true(
  * `wp_salt()` IS defined. The HMAC key MUST be derived from
  * constants available before pluggable (AUTH_KEY / AUTH_SALT), not
  * from `wp_salt()`, otherwise the keys diverge and a regular cache
- * HIT renders the "HMAC mismatch" sentinel in place of every
- * callback's output. We simulate the boundary by mutating what
+ * HIT drops every callback's output (renders empty) in place of
+ * the real content. We simulate the boundary by mutating what
  * `wp_salt()` returns between sign and dispatch: if the HMAC
  * derivation consults `wp_salt()`, dispatch breaks; if it doesn't,
  * the round-trip succeeds.
@@ -781,8 +781,7 @@ $bound_out                 = $grabber->_parse_dynamic( $bound_tag );
 
 assert_true(
 	'[4n.bound] HMAC key is stable across wp_salt() boundary (advanced-cache.php fix)',
-	false !== strpos( $bound_out, 'USER:alice' )
-		&& false === strpos( $bound_out, 'HMAC mismatch' ),
+	'USER:alice' === $bound_out,
 	"result: $bound_out"
 );
 
@@ -802,7 +801,7 @@ $result      = $grabber->_parse_dynamic( $tampered );
 assert_true(
 	'[4o] Tampered args after signing is refused (HMAC mismatch)',
 	false === strpos( $result, 'OUT:bob' )
-		&& false !== strpos( $result, 'HMAC mismatch' ),
+		&& '' === $result,
 	"result: $result"
 );
 


### PR DESCRIPTION
When a cached `mfunc` / `mclude` tag isn't in the regis
`call:<slug>` form — or its HMAC envelope doesn't verify, or its slug isn't
registered — `PgCache_ContentGrabber` rendered an inter
`"W3TC dynamic mfunc tag refused: …"` notice **into the page**, so every
visitor saw that text in place of the fragment. Reporte
sites using third-party fragment integrations (e.g. AdRotate "W3TC
compatibility" mode) and hand-written theme tags.

### Change

- For every non-dispatchable case, **render empty outpu
  of the internal notice (the five branches in `_dispatch_dynamic` /
  `_dispatch_dynamic_callback`: missing `call:slug`/HMA
  registry, unregistered slug, callback exception).
- Route all of those cases through the existing **rate-
  (`_log_dynamic_deprecation`), which already names the tag and points at the
  `w3tc_dynamic_callbacks` filter — so operators still
  migration notice while visitors see nothing.
- Document a **before/after migration example** for the
  filter in its docblock, and update the docblocks that described "an error in
  place of the tag."

No change to which tags are dispatched: a tag must stil
registered-callback `call:<slug>` form to run. This only changes what a visitor
sees for a non-dispatchable tag (empty vs. an internal
supported migration path.

### Testing

**Automated**

    php tests/test-mfunc-security.php          # expect "Total: 58  Passed: 58  Failed: 0"
    ./vendor/bin/phpcs PgCache_ContentGrabber.php   # e
    php -l PgCache_ContentGrabber.php

The standalone suite now asserts a non-dispatchable tag renders empty (and is
not executed) rather than asserting on the removed noti
cross-boundary HMAC test asserts the exact dispatch output.

**Manual — front-end behavior** (Page Cache enabled; `define( 'W3TC_DYNAMIC_SECURITY', '…' )` in `wp-config.php`):

1. Put a legacy raw-PHP tag in a post/template, e.g.
   `<!-- mfunc TOKEN --> echo 'x'; <!-- /mfunc TOKEN --
   (cache the page, then request it again so the dispatcher runs).
   - **Before:** the page shows `W3TC dynamic mfunc tag
     call:slug + hmac envelope.` where the fragment should be.
   - **After:** the fragment renders **empty** (no inte
     visitors).
2. Confirm operators are still informed: with `WP_DEBUG
   PHP error log), the first such request logs one
   `_doing_it_wrong` / `error_log` notice naming the ta
   `w3tc_dynamic_callbacks` filter; repeated requests within 5 minutes do **not**
   re-log (rate-limited).

**Manual — migration path works** (the supported replac

1. Register a callback:
   ```php
   add_filter( 'w3tc_dynamic_callbacks', function ( $cb
       $cbs['my_widget'] = function ( $args, $kind ) {
           return 'OUT:' . ( $args['name'] ?? '' );
       };
       return $cbs;
   } );
2. Emit the new form: <!-- mfunc TOKEN call:my_widget {TOKEN -->.
3. Cache the page and re-request → the fragment renders OUT:bob (dispatch
succeeds; the hmac: envelope was added automatically at

Regression checks

- A correctly registered call:<slug> tag with a valid e
dispatches and renders its output.
- A tag whose HMAC doesn't verify, or whose slug isn't
empty (not executed) and logs once.
- With W3TC_DYNAMIC_SECURITY undefined, dynamic dispatc