### PR TITLE
Guard Config::encrypt_secrets() against running before wp_salt() loads

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -1169,6 +1169,38 @@ class Config {
 			return;
 		}
 
+		/*
+		 * Mirror the guard in {@see self::decrypt_secrets()}: the envelope key
+		 * is derived from `wp_salt('secure_auth')`, and `wp_salt()` is the only
+		 * authoritative source of that key. It cannot be reliably reproduced
+		 * from the wp-config salt constants: WordPress ignores any key/salt
+		 * value that is duplicated across schemes (the `$duplicated_keys`
+		 * logic in `wp_salt()`), honours a `salt` filter, and generates and
+		 * stores its own random salts in the database when the constants are
+		 * absent or duplicated. In every one of those cases
+		 * `SECURE_AUTH_KEY . SECURE_AUTH_SALT` differs from what `wp_salt()`
+		 * returns.
+		 *
+		 * Encrypting before `wp_salt()` is defined (early bootstrap — the
+		 * page-cache / object-cache drop-ins, or a plugin's `run()` that saves
+		 * config on the `plugins_loaded` side of `wp-includes/pluggable.php`)
+		 * therefore risks keying the envelope with a salt that will not match
+		 * at decrypt time, silently collapsing every secret to '' on the next
+		 * admin read.
+		 *
+		 * Skip encryption in that window: the value is persisted in whatever
+		 * form the in-memory config already holds — a legacy plaintext value
+		 * stays plaintext (matching the pre-2.10.0 behaviour and the
+		 * {@see Util_Crypto::is_available()} fallback), while an already-wrapped
+		 * value stays wrapped, because {@see self::decrypt_secrets()} and
+		 * {@see self::_maybe_lazy_decrypt()} leave envelopes intact pre-pluggable.
+		 * It is (re-)wrapped by the first save that runs with `wp_salt()`
+		 * available.
+		 */
+		if ( ! \function_exists( 'wp_salt' ) ) {
+			return;
+		}
+
 		$secret_keys = self::secret_keys();
 		if ( empty( $secret_keys ) ) {
 			return;

--- a/tests/test-crypto-encrypt-guard.php
+++ b/tests/test-crypto-encrypt-guard.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Standalone regression test for the Config::encrypt_secrets() pre-pluggable guard.
+ *
+ * Companion to test-crypto-early-bootstrap.php. That test covers the crypto
+ * primitive; this one covers the policy layer: secret-flagged config values
+ * must NOT be envelope-encrypted before `wp-includes/pluggable.php` defines
+ * `wp_salt()`.
+ *
+ * The envelope key is derived from `wp_salt('secure_auth')`, which is the only
+ * authoritative source of that key. It cannot be reproduced from the wp-config
+ * salt constants in the general case — WordPress ignores key/salt values that
+ * are duplicated across schemes, honours a `salt` filter, and falls back to
+ * DB-generated salts. So encrypting during the early-bootstrap window (page /
+ * object-cache drop-ins, or a plugin `run()` that saves config before
+ * pluggable.php) can key the envelope with a salt that won't match at decrypt
+ * time, collapsing every secret to '' on the next admin read.
+ *
+ * This test deliberately defines `wp_salt()` to return a value UNRELATED to the
+ * salt constants, reproducing the real-world case where the constants cannot
+ * reconstruct the runtime salt, and proves the guard is correct regardless.
+ *
+ * This test verifies:
+ *   1. `encrypt_secrets()` leaves a secret-flagged value untouched (no
+ *      `enc:v1:` envelope) while `wp_salt()` is unavailable.
+ *   2. Once `wp_salt()` is defined, `encrypt_secrets()` wraps the value and it
+ *      round-trips — even when `wp_salt()` bears no relation to the constants.
+ *
+ * Run with: php tests/test-crypto-encrypt-guard.php
+ *
+ * Exit code 0 = all pass, non-zero = failures.
+ *
+ * @package W3TC\Tests
+ * @since   2.10.0
+ */
+
+if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+	return;
+}
+
+// Stand-ins for wp-config.php. Defined BEFORE wp_salt() so encrypt_secrets()
+// runs through its pre-pluggable guard. ConfigKeys.php (included by
+// secret_keys()) guards on ABSPATH, and secret_keys() needs W3TC_DIR.
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+define( 'W3TC_DIR', dirname( __DIR__ ) );
+define( 'SECURE_AUTH_KEY', 'ceg-unit-secure-auth-key-0123456789abcdef' );
+define( 'SECURE_AUTH_SALT', 'ceg-unit-secure-auth-salt-fedcba9876543210' );
+define( 'AUTH_KEY', 'ceg-unit-auth-key-should-not-be-used-here' );
+
+require_once __DIR__ . '/../Util_Crypto.php';
+// ConfigKeys.php (included by Config::secret_keys()) references this class at
+// include time for a default value; preload it so the standalone run resolves.
+require_once __DIR__ . '/../PgCache_QsExempts.php';
+require_once __DIR__ . '/../Config.php';
+
+use W3TC\Config;
+use W3TC\Util_Crypto;
+
+$ceg_pass = 0;
+$ceg_fail = 0;
+
+/**
+ * Minimal assert helper (file-unique name per the standalone-test convention).
+ *
+ * @param bool   $cond  Condition that must hold.
+ * @param string $label Human-readable description.
+ *
+ * @return void
+ */
+function ceg_assert( $cond, $label ) {
+	global $ceg_pass, $ceg_fail;
+	if ( $cond ) {
+		$ceg_pass++;
+		echo "  PASS: $label\n";
+	} else {
+		$ceg_fail++;
+		echo "  FAIL: $label\n";
+	}
+}
+
+if ( ! Util_Crypto::is_available() ) {
+	echo "SKIP: OpenSSL AES-256-CBC not available in this PHP build.\n";
+	return;
+}
+
+echo "Config::encrypt_secrets() pre-pluggable guard\n";
+
+// 'cdn.cf.secret' carries the 'secret' flag in ConfigKeys.php.
+$secret_key = 'cdn.cf.secret';
+$plaintext  = 'AKIA-not-a-real-secret-value';
+
+// 1. Pre-pluggable window: wp_salt() undefined → value must be left as-is.
+ceg_assert( ! function_exists( 'wp_salt' ), 'precondition: wp_salt() is undefined (early-bootstrap window)' );
+
+$data = array( $secret_key => $plaintext );
+Config::encrypt_secrets( $data );
+
+ceg_assert( $plaintext === $data[ $secret_key ], 'secret left untouched when wp_salt() is unavailable (no mis-keyed envelope)' );
+ceg_assert( ! Util_Crypto::is_envelope( $data[ $secret_key ] ), 'no enc:v1: envelope produced pre-pluggable' );
+
+// 2. Simulate pluggable.php loading. Return a salt UNRELATED to the constants
+// (the duplicated-keys / DB-salt reality), so the test asserts correctness
+// independent of any constant-based reproduction.
+if ( ! function_exists( 'wp_salt' ) ) {
+	/**
+	 * Stub of WordPress's wp_salt(): a runtime salt unrelated to the constants.
+	 *
+	 * @param string $scheme Salt scheme.
+	 *
+	 * @return string
+	 */
+	function wp_salt( $scheme = 'auth' ) {
+		return 'db-generated-secure-auth-salt-unrelated-to-wpconfig-constants';
+	}
+}
+
+ceg_assert( function_exists( 'wp_salt' ), 'post-condition: wp_salt() now defined (post-pluggable window)' );
+
+$data_post = array( $secret_key => $plaintext );
+Config::encrypt_secrets( $data_post );
+
+ceg_assert( Util_Crypto::is_envelope( $data_post[ $secret_key ] ), 'secret is encrypted once wp_salt() is available' );
+ceg_assert( $plaintext === Util_Crypto::envelope_decrypt( $data_post[ $secret_key ] ), 'post-pluggable envelope round-trips under wp_salt()' );
+
+echo "\n$ceg_pass passed, $ceg_fail failed\n";
+exit( $ceg_fail > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary

`Config::encrypt_secrets()` has no guard against running before `wp-includes/pluggable.php` defines `wp_salt()` — unlike its counterpart `Config::decrypt_secrets()`, which explicitly bails in that window. As a result, secrets can be **encrypted with a key that won't match at decrypt time**, silently collapsing every secret-flagged CDN/API/FTP credential to `''` on the next admin read.

Real-world symptom after upgrading to 2.10.0: the CDN admin notice *"A configuration issue prevents CDN from working: The 'Access key', 'Secret key', 'Bucket' and 'Replace default hostname with' fields cannot be empty."* — with `master.php` holding `enc:v1:...` values that decrypt to empty.

## Root cause

The envelope key is derived from `wp_salt('secure_auth')`, and **`wp_salt()` is the only authoritative source of that key**. It cannot be reliably reproduced from the wp-config salt constants (`SECURE_AUTH_KEY . SECURE_AUTH_SALT`), because WordPress's own `wp_salt()`:

- **ignores any key/salt value duplicated across schemes** (the `$duplicated_keys` map) — e.g. a wp-config that sets all four `*_KEY` constants to one value and all four `*_SALT` constants to another falls through to DB-generated salts;
- honours a `salt` filter;
- generates and stores its own random salts in the DB when the constants are absent or duplicated.

In all of those cases `SECURE_AUTH_KEY . SECURE_AUTH_SALT` ≠ `wp_salt('secure_auth')`.

`encrypt_secrets()` runs from `ConfigCompiler::save()`, which can be reached **before pluggable.php loads** — e.g. the page/object-cache drop-ins during early bootstrap, or a plugin `run()` that saves config on the `plugins_loaded` side of pluggable.php (`Cdn_Plugin::run()` → `migrate_removed_engines()` → `save()` is one such path). Encrypting there keys the envelope with the fallback/reproduced salt, which then fails HMAC verification once admin code reads it under the real `wp_salt()`.

`decrypt_secrets()` already guards for exactly this (`if ( ! function_exists( 'wp_salt' ) ) return;`). This restores the missing symmetry on the encrypt side.

## Fix

Add the symmetric `wp_salt()` guard to `encrypt_secrets()`. Secrets are only encrypted once the authoritative key is derivable. A pre-pluggable save persists the in-memory value as-is (legacy plaintext stays plaintext, matching pre-2.10.0 behaviour and the existing `Util_Crypto::is_available()` fallback; an already-wrapped envelope stays wrapped, since `decrypt_secrets()`/`_maybe_lazy_decrypt()` leave envelopes intact pre-pluggable) and it is re-wrapped by the first save that runs with `wp_salt()` available.

This works for **every** salt configuration — duplicated keys, `salt` filters, DB-generated salts — because it stops trying to reconstruct the key at encrypt time.

## Relationship to #1347 (ENG7-3960)

This complements #1347 rather than replacing it. That PR hardened the **decrypt/read** side: `_maybe_lazy_decrypt()` now reproduces `wp_salt('secure_auth')` from the salt constants during early bootstrap, and — importantly — leaves an envelope intact (non-destructive) when it can't verify. That covers the runtime cache engines that read pre-pluggable and have no later read.

It doesn't cover the **encrypt/write** side. The constant reproduction (`SECURE_AUTH_KEY . SECURE_AUTH_SALT`) only equals `wp_salt('secure_auth')` when WordPress actually uses the constants — which it doesn't when they're duplicated across schemes, a `salt` filter is set, or salts are DB-generated. On those installs a pre-pluggable `save()` still writes a mis-keyed envelope, and `salt_constants_available()` returning `true` means the mismatch isn't detected. Guarding `encrypt_secrets()` closes that path for all salt configurations without relying on reconstruction.

## Test

Adds `tests/test-crypto-encrypt-guard.php` (standalone, same convention as `test-crypto-early-bootstrap.php`). It verifies the value is left untouched pre-pluggable and encrypted+round-trips post-pluggable, deliberately defining `wp_salt()` to return a value **unrelated** to the salt constants to model the duplicated-keys/DB-salt reality.

```
$ php tests/test-crypto-encrypt-guard.php
6 passed, 0 failed
$ php tests/test-crypto-early-bootstrap.php   # unchanged, still green
10 passed, 0 failed
```
