### PR TITLE
Fix for htaccess -multiviews error

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -744,7 +744,6 @@ class PgCache_Environment {
 
 		$rules  = '';
 		$rules .= W3TC_MARKER_BEGIN_PGCACHE_CORE . "\n";
-		$rules .= "Options -MultiViews\n";
 		$rules .= "<IfModule mod_rewrite.c>\n";
 		$rules .= "    RewriteEngine On\n";
 		$rules .= '    RewriteBase ' . $rewrite_base . "\n";

--- a/qa/plugins/disk-enhanced-probe.php
+++ b/qa/plugins/disk-enhanced-probe.php
@@ -144,7 +144,6 @@ echo wp_json_encode(
 		'apache_cond_exists'     => ( '' !== $apache_cond_resolved && file_exists( $apache_cond_resolved ) ),
 		'htaccess_core'          => ( false !== strpos( $htaccess, W3TC_MARKER_BEGIN_PGCACHE_CORE ) ),
 		'htaccess_uri'           => ( false !== strpos( $htaccess, 'W3TC_URI_PATH_SLASH' ) ),
-		'htaccess_multiviews'    => ( false !== strpos( $htaccess, 'Options -MultiViews' ) ),
 		'apache_prefix_sample'   => $apache_prefix,
 	)
 );


### PR DESCRIPTION
2.10.0 introduced a total-site-outage regression on Apache/LiteSpeed. The page-cache CORE rules block — written to the site-root .htaccess (Util_Rule::get_pgcache_rules_core_path()), which Apache parses on every request — began emitting an unconditional Options -MultiViews:

# BEGIN W3TC Page Cache core
Options -MultiViews          ← added in 2.10.0
<IfModule mod_rewrite.c>
...

An Options directive in .htaccess requires the vhost to grant AllowOverride Options (or All). Many secure/shared hosts use AllowOverride FileInfo — which permits W3TC's RewriteRules (so rewrites kept working) but forbids Options. On those hosts Apache aborts .htaccess parsing with Option MultiViews not allowed here and returns HTTP 500 for every URL, taking down both the front end and /wp-admin/. Affected: Page Cache enabled with method Disk: Enhanced (file_generic).

Reported on the support forum by multiple users (all Apache 2.4, error .htaccess:Option MultiViews not allowed here); recovery required manual .htaccess/plugin edits over SSH/FTP.

Root cause / rationale

The root-level directive was added in the 2.10.0 cycle as a QA/functional-consistency change (commit "Fix tests"), alongside a new disk-enhanced-probe.php flag that asserted its presence — not a security fix. It carries no RT9-NNN reference, maps to no audit finding, and is not load-bearing for any security RewriteCond. W3TC shipped for years (through 2.9.x) without this directive in the root file. QA missed the regression because every sandbox vhost uses AllowOverride All, which makes the directive legal.

▎ Note: an Options directive in .htaccess is fundamentally unenforceable on the exact hosts that crash (their AllowOverride forbids it), and an <IfModule> wrapper cannot suppress the error (it originates from AllowOverride at parse time, not a missing module). So there is no safe "keep it" variant for those servers.

Changes

- PgCache_Environment.php — remove Options -MultiViews from the CORE block. The block now goes directly from the marker to <IfModule mod_rewrite.c>, restoring pre-2.10.0 behavior.
- qa/plugins/disk-enhanced-probe.php — drop the now-obsolete htaccess_multiviews probe flag (nothing in the JS suite asserted on it).

The guarded, subdirectory-scoped Options -MultiViews directives (PgCache_Environment.php cache-dir block and Minify_Environment.php, both gated by $compatibility || $disk_enhanced_apache) are intentionally left in place — they write to subdir .htaccess files and were not the outage cause.

Testing instructions

Repro (before this fix / on 2.10.0):
1. Apache 2.4 vhost with a restrictive override, e.g. AllowOverride FileInfo (grants mod_rewrite, not Options).
2. W3TC → Page Cache enabled, method Disk: Enhanced; Save all settings & purge caches.
3. Load any front-end URL or /wp-admin/ → HTTP 500; error log shows .htaccess: Option MultiViews not allowed here.

Verify the fix (this branch):
1. Deploy the branch to the same environment.
2. W3TC → Save all settings & purge caches (regenerates the root .htaccess).
3. Inspect the site-root .htaccess: the # BEGIN W3TC Page Cache core block no longer contains Options -MultiViews (marker → <IfModule mod_rewrite.c>).
4. Front end and /wp-admin/ return HTTP 200; no Option MultiViews not allowed here in the error log.
5. Confirm Disk: Enhanced caching still works — request a cached page twice and verify it's served from cache (cache file present under wp-content/cache/page_enhanced/..., and served HTML/X-W3TC markers as expected).

Regression check (permissive server, AllowOverride All):
- Disk: Enhanced page caching functions exactly as before, minus the Options -MultiViews line.