### PR TITLE
ENG7-4000: Fix W3TC admin page links breaking in multisite network admin

### DIFF
--- a/Cdnfsd_GeneralPage_View.php
+++ b/Cdnfsd_GeneralPage_View.php
@@ -60,7 +60,7 @@ defined( 'W3TC' ) || die;
 							'For even better performance, combine FSD with other powerful features like Browser Cache, Minify, Fragment caching, or Lazy Load! Did you know that we offer premium support, customization and audit services? %1$sClick here for more information%2$s.',
 							'w3-total-cache'
 						),
-						'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
+						'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
 						'</a>'
 					),
 					array(

--- a/Generic_AdminNotes.php
+++ b/Generic_AdminNotes.php
@@ -235,7 +235,7 @@ class Generic_AdminNotes {
 									'key'      => 'common.show_note.plugins_updated',
 									'value'    => 'false',
 									'page'     => 'w3tc_minify',
-									'redirect' => esc_url( admin_url( 'admin.php?page=w3tc_minify' ) ),
+									'redirect' => esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_minify' ) ),
 								)
 							)
 						)

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -633,7 +633,7 @@ class Generic_Plugin {
 						'parent' => 'w3tc',
 						'title'  => __( 'Purge Current Page', 'w3-total-cache' ),
 						'href'   => Util_Nonce::admin_nonce_url(
-							admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' . Util_Environment::detect_post_id() . '&force=true' ),
+							network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' . Util_Environment::detect_post_id() . '&force=true' ),
 							'w3tc_flush_post'
 						),
 					);

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -934,7 +934,7 @@ class Generic_Plugin_Admin {
 							'<a target="_blank" href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#PayingForInvalidation">',
 							'</a>.<br/>',
 							'<br/>',
-							'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_cdn#advanced' ) ) . '">',
+							'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_cdn#advanced' ) ) . '">',
 							'</a>'
 						),
 						array(
@@ -1174,7 +1174,7 @@ class Generic_Plugin_Admin {
 			$capability = 'manage_options';
 		}
 
-		$actions[ Util_Nonce::admin_nonce_url( admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_all' ), 'w3tc_flush_all' ) ] = array(
+		$actions[ Util_Nonce::admin_nonce_url( network_admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_all' ), 'w3tc_flush_all' ) ] = array(
 			__( 'Empty Caches', 'w3-total-cache' ),
 			$capability,
 		);

--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -275,7 +275,7 @@ class Minify_Environment {
 
 			$error .= '<br />Unfortunately minification will not function without custom rewrite rules. ' .
 				'Please ask your server administrator for assistance. Also refer to <a href="' .
-				admin_url( 'admin.php?page=w3tc_install' ) . '">the install page</a>  for the rules for your server.';
+				Util_Ui::admin_url( 'admin.php?page=w3tc_install' ) . '">the install page</a>  for the rules for your server.';
 
 			throw new Util_Environment_Exception(
 				esc_html( $error ),

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -366,7 +366,7 @@ class PgCache_Environment {
 			$error .= '<br />Unfortunately disk enhanced page caching will ' .
 				'not function without custom rewrite rules. ' .
 				'Please ask your server administrator for assistance. Also refer to <a href="' .
-				admin_url( 'admin.php?page=w3tc_install' ) .
+				Util_Ui::admin_url( 'admin.php?page=w3tc_install' ) .
 				'">the install page</a>  for the rules for your server.';
 
 			throw new Util_Environment_Exception(

--- a/UsageStatistics_GeneralPage_View.php
+++ b/UsageStatistics_GeneralPage_View.php
@@ -49,7 +49,7 @@ Util_Ui::config_item_pro(
 				sprintf(
 					// translators: 1 The opening anchor tag linking to our support page, 2 its closing tag.
 					__( 'Use the caching statistics to compare the performance of different configurations like caching methods, object lifetimes and so on. Did you know that we offer premium support, customization and audit services? %1$sClick here for more information%2$s.', 'w3-total-cache' ),
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
 					'</a>'
 				),
 				array( 'a' => array( 'href' => array() ) )

--- a/UserExperience_DeferScripts_Page_View.php
+++ b/UserExperience_DeferScripts_Page_View.php
@@ -101,7 +101,7 @@ if ( is_null( $w3tc_c->get( array( 'user-experience-defer-scripts', 'timeout' ) 
 				),
 				'<em>',
 				'</em>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
+				'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
 				'</a>'
 			),
 			array(

--- a/UserExperience_Remove_CssJs_Page_View.php
+++ b/UserExperience_Remove_CssJs_Page_View.php
@@ -86,7 +86,7 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS On Homepage', 'w3-total-cach
 				),
 				'<em>',
 				'</em>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
+				'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
 				'</a>'
 			),
 			array(
@@ -344,7 +344,7 @@ Util_Ui::postbox_header( esc_html__( 'Remove CSS/JS Individually', 'w3-total-cac
 				),
 				'<em>',
 				'</em>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
+				'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '">',
 				'</a>'
 			),
 			array(

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -982,7 +982,7 @@ require W3TC_INC_DIR . '/options/common/header.php';
 									'</acronym>',
 									'<acronym title="' . esc_attr__( 'Hypertext Transfer Protocol', 'w3-total-cache' ) . '">',
 									'</acronym>',
-									'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
+									'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
 									'</a>'
 								),
 								array(

--- a/inc/options/dbcache.php
+++ b/inc/options/dbcache.php
@@ -230,7 +230,7 @@ $w3tc_dbcache_learn_more_output   = static function ( $anchor, $config_key = '' 
 						// Translators: 3 closing HTML a tag, 4 closing HTML p tag followed by closing HTML div tag.
 						__( '%1$sDatabase Cache is disabled! Enable it %2$shere%3$s to enable this feature.%4$s', 'w3-total-cache' ),
 						'<div class="notice notice-error inline"><p>',
-						'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '">',
+						'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '">',
 						'</a>',
 						'</p></div>'
 					),

--- a/inc/options/install.php
+++ b/inc/options/install.php
@@ -165,7 +165,7 @@ if ( ! defined( 'W3TC' ) ) {
 				),
 				array(
 					'a'       => array(
-						'herf' => array(),
+						'href' => array(),
 					),
 					'em'      => array(),
 					'acronym' => array(

--- a/inc/options/install.php
+++ b/inc/options/install.php
@@ -30,7 +30,7 @@ if ( ! defined( 'W3TC' ) ) {
 						'On the "%1$sGeneral%2$s" tab and select your caching methods for page, database and minify. In most cases, "disk enhanced" mode for page cache, "disk" mode for minify and "disk" mode for database caching are "good" settings.',
 						'w3-total-cache'
 					),
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general' ) ) . '">',
 					'</a>'
 				),
 				array(
@@ -50,7 +50,7 @@ if ( ! defined( 'W3TC' ) ) {
 						'1. The "Compatibility Mode" option found in the advanced section of the %1$s"Page Cache Settings"%2$s tab will enable functionality that optimizes the interoperablity of caching with WordPress, is disabled by default, but highly recommended. Years of testing in hundreds of thousands of installations have helped us learn how to make caching behave well with WordPress. The tradeoff is that disk enhanced page cache performance under load tests will be decreased by ~20%% at scale.',
 						'w3-total-cache'
 					),
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_pgcache' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_pgcache' ) ) . '">',
 					'</a>'
 				),
 				array(
@@ -116,7 +116,7 @@ if ( ! defined( 'W3TC' ) ) {
 					),
 					'<em>',
 					'</em>',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
 					'</a>',
 					'<acronym title="' . esc_attr__( 'Hypertext Transfer Protocol', 'w3-total-cache' ) . '">',
 					'</acronym>'
@@ -152,7 +152,7 @@ if ( ! defined( 'W3TC' ) ) {
 					'</em>',
 					'<acronym title="' . esc_attr__( 'Content Delivery Network', 'w3-total-cache' ) . '">',
 					'</acronym>',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_cdn' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_cdn' ) ) . '">',
 					'</a>',
 					'<acronym title="' . esc_attr__( 'Content Delivery Network', 'w3-total-cache' ) . '">',
 					'</acronym>',
@@ -187,7 +187,7 @@ if ( ! defined( 'W3TC' ) ) {
 					),
 					'<em>',
 					'</em>',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_dbcache' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_dbcache' ) ) . '">',
 					'</a>'
 				),
 				array(
@@ -211,7 +211,7 @@ if ( ! defined( 'W3TC' ) ) {
 					),
 					'<em>',
 					'</em>',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_objectcache' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_objectcache' ) ) . '">',
 					'</a>'
 				),
 				array(
@@ -235,7 +235,7 @@ if ( ! defined( 'W3TC' ) ) {
 					),
 					'<em>',
 					'</em>',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '">',
 					'</a>'
 				),
 				array(

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -1127,7 +1127,7 @@ $w3tc_minify_learn_more_output   = static function ( $anchor, $config_key = '', 
 						// Translators: 3 closing HTML a tag, 4 closing HTML p tag followed by closing HTML div tag.
 						__( '%1$sMinify is disabled! Enable it %2$shere%3$s to enable this feature.%4$s', 'w3-total-cache' ),
 						'<div class="notice notice-error inline"><p>',
-						'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '">',
+						'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '">',
 						'</a>',
 						'</p></div>'
 					),
@@ -1210,7 +1210,7 @@ $w3tc_minify_learn_more_output   = static function ( $anchor, $config_key = '', 
 									),
 									'<acronym title="' . esc_attr__( 'Hypertext Transfer Protocol', 'w3-total-cache' ) . '">',
 									'</acronym>',
-									'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
+									'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
 									'</a>'
 								),
 								array(
@@ -1236,7 +1236,7 @@ $w3tc_minify_learn_more_output   = static function ( $anchor, $config_key = '', 
 									),
 									'<acronym title="' . esc_attr__( 'Time to Live', 'w3-total-cache' ) . '">',
 									'</acronym>',
-									'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
+									'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
 									'</a>'
 								),
 								array(

--- a/inc/options/minify/css.php
+++ b/inc/options/minify/css.php
@@ -35,7 +35,7 @@ Util_Ui::config_item_pro(
 				sprintf(
 					// translators: 1 The opening anchor tag linking to our support page, 2 its closing tag.
 					__( 'Need help? Take a look at our %1$spremium support, customization and audit services%2$s.', 'w3-total-cache' ),
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
 					'</a>'
 				),
 				array( 'a' => array( 'href' => array() ) )

--- a/inc/options/objectcache.php
+++ b/inc/options/objectcache.php
@@ -210,7 +210,7 @@ $w3tc_objectcache_learn_more_output = static function ( $anchor, $config_key = '
 						// Translators: 3 closing HTML a tag, 4 closing HTML p tag followed by closing HTML div tag.
 						__( '%1$sObject Cache is disabled! Enable it %2$shere%3$s to enable this feature.%4$s', 'w3-total-cache' ),
 						'<div class="notice notice-error inline"><p>',
-						'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '">',
+						'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '">',
 						'</a>',
 						'</p></div>'
 					),

--- a/inc/options/parts/dashboard_banner.php
+++ b/inc/options/parts/dashboard_banner.php
@@ -25,7 +25,7 @@ if ( ! defined( 'W3TC' ) ) {
 						'w3-total-cache'
 					),
 					'<br />',
-					'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
+					'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_support' ) ) . '">',
 					'</a>'
 				),
 				array(

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -1033,7 +1033,7 @@ $w3tc_page_cache_learn_more_output   = static function ( $anchor, $config_key = 
 						// Translators: 3 closing HTML a tag, 4 closing HTML p tag followed by closing HTML div tag.
 						__( '%1$sPage Cache is disabled! Enable it %2$shere%3$s to enable this feature.%4$s', 'w3-total-cache' ),
 						'<div class="notice notice-error inline"><p>',
-						'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '">',
+						'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '">',
 						'</a>',
 						'</p></div>'
 					),
@@ -1119,7 +1119,7 @@ $w3tc_page_cache_learn_more_output   = static function ( $anchor, $config_key = 
 									'</acronym>',
 									'<acronym title="' . esc_attr__( 'Hypertext Markup Language', 'w3-total-cache' ) . '">',
 									'</acronym>',
-									'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
+									'<a href="' . esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_browsercache' ) ) . '">',
 									'</a>'
 								),
 								array(


### PR DESCRIPTION
## Summary

Absolute links to W3TC admin pages were built with WordPress's `admin_url()`, which always emits `/wp-admin/` regardless of context. In the multisite **network admin** (`/wp-admin/network/admin.php`) these links dropped the `network/` segment and 404'd.

Reported case: on `network/admin.php?page=w3tc_objectcache`, the *"Object Cache is disabled! Enable it here to enable this feature."* notice linked to the non-existent `/wp-admin/admin.php?page=w3tc_general#object_cache` instead of `/wp-admin/network/admin.php?page=w3tc_general#object_cache`.

A full sweep found the same bug class in **28 links across 17 files**.

## Fix

Replace bare `admin_url()` calls that target `w3tc_*` pages with the existing network-aware helper **`Util_Ui::admin_url()`** (`is_network_admin() ? network_admin_url() : admin_url()`). It's a no-op outside network admin, so single-site behavior is unchanged.

Two admin-bar / favorite-action **purge** links (`Generic_Plugin`, `Generic_Plugin_Admin`) use `network_admin_url()` instead, to stay consistent with their sibling flush links in the same blocks.

### Left unchanged (already correct on multisite)
- Relative `href="admin.php?page=..."` / `<form action="admin.php?...">` links — resolve against the current page URL.
- `self_admin_url()` calls and relative `wp_safe_redirect('admin.php?...')`.
- The explicit `is_network_admin() ? network_admin_url() : admin_url()` ternary in `Licensing_Plugin_Admin.php`.

## Files changed (17)
`inc/options/objectcache.php`, `pgcache.php`, `dbcache.php`, `minify.php`, `cdn.php`, `install.php`, `minify/css.php`, `parts/dashboard_banner.php`; `Cdnfsd_GeneralPage_View.php`, `UsageStatistics_GeneralPage_View.php`, `UserExperience_DeferScripts_Page_View.php`, `UserExperience_Remove_CssJs_Page_View.php`, `Generic_AdminNotes.php`, `Generic_Plugin_Admin.php`, `Generic_Plugin.php`, `Minify_Environment.php`, `PgCache_Environment.php`.

## Testing

**Prerequisite:** a WordPress **multisite** install with W3TC network-activated (settings managed from the network admin).

1. In the network admin, disable Object Cache so the notice appears. Go to `…/wp-admin/network/admin.php?page=w3tc_objectcache`.
2. Click **"Object Cache is disabled! Enable it here…"**.
   - **Before:** lands on `…/wp-admin/admin.php?page=w3tc_general#object_cache` → *"Sorry, you are not allowed to access this page."* / 404.
   - **After:** lands on `…/wp-admin/network/admin.php?page=w3tc_general#object_cache` (valid page, scrolled to the Object Cache section).
3. Repeat the equivalent "…is disabled! Enable it here…" notices on **Page Cache**, **Database Cache**, and **Minify** — all should now stay within `network/`.
4. Spot-check other converted links in network admin: the **Support** links (CDN FSD / Usage Statistics general sections, minify/css, dashboard banner), the **User Experience** "here" links, the CDN CloudFront warning's "advanced" link, and the `w3tc_install` links surfaced when rewrite rules can't be written.
5. **Regression — single site:** on a normal single-site install, all of the above links must continue to resolve to `/wp-admin/admin.php?page=…` exactly as before (no `network/`).
6. **Purge actions:** confirm the admin-bar **Purge Current Page** (front end) and the **Empty Caches** favorite action still work and now point through `network_admin_url()` on multisite.

## Checks
- `./vendor/bin/phpcs` — clean on all 17 files.
- `php -l` — clean on all 17 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
