### PR TITLE
Fix flock(LOCK_UN) called after fclose() in Cache_File

### DIFF
--- a/Cache_File.php
+++ b/Cache_File.php
@@ -161,11 +161,12 @@ class Cache_File extends Cache_Base {
 		@fputs( $fp, pack( 'L', $expires_at ) );
 		@fputs( $fp, '<?php exit; ?>' );
 		@fputs( $fp, @serialize( $content ) );
-		@fclose( $fp );
 
 		if ( $this->_locking ) {
 			@flock( $fp, LOCK_UN );
 		}
+
+		@fclose( $fp );
 
 		return true;
 	}
@@ -313,11 +314,12 @@ class Cache_File extends Cache_Base {
 				}
 
 				@fputs( $fp, pack( 'L', 0 ) ); // make it expired.
-				@fclose( $fp );
 
 				if ( $this->_locking ) {
 					@flock( $fp, LOCK_UN );
 				}
+
+				@fclose( $fp );
 
 				return true;
 			}


### PR DESCRIPTION
## Summary

`Cache_File::set()` and `Cache_File::delete()` call `@flock( $fp, LOCK_UN )` **after** `@fclose( $fp )`. Since PHP 8, calling `flock()` on an already-closed stream resource throws an uncaught `TypeError` ("supplied resource is not a valid stream resource"), which is a fatal error and is **not** suppressible with the `@` operator.

This only triggers when `pgcache.file.locking` is enabled (off by default), which is presumably why it's gone unnoticed - but once enabled, it fires on essentially every single page cache write.

Ran into this on a production site after enabling `pgcache.file.locking` to fix a torn/corrupted page cache file issue (concurrent PHP-FPM workers writing the same large page without locking). The fatal error happens inside the `ob_callback` after page content has already been sent to the client, so it's invisible to site visitors - but it means the disk page cache silently never gets persisted once locking is on, defeating the purpose of turning it on in the first place.

This is exactly the root cause already diagnosed by @mavas84 in #499, which was closed without a code change:

> `flock( $fp, LOCK_UN );` should be called before `fclose( $fp );`

This PR does exactly that, in both places in `Cache_File.php` where the bug occurs. `Cache_File::get()` already has the correct order elsewhere in the same file, so this brings `set()` and `delete()` in line with it.

## Test plan

- [x] `php -l Cache_File.php` - no syntax errors
- [x] Deployed the fix to a live WordPress site with `pgcache.file.locking` enabled; confirmed the previously constant `flock(): supplied resource is not a valid stream resource` fatal errors stopped appearing in the PHP-FPM error log across multiple subsequent page loads, and `x-cache-status: HIT` is now returned correctly on repeat requests

Fixes #499