### PR TITLE
Fix flock(LOCK_UN) order in Cache_File_Generic and add locking regression test

### DIFF
--- a/Cache_File.php
+++ b/Cache_File.php
@@ -163,6 +163,7 @@ class Cache_File extends Cache_Base {
 		@fputs( $fp, @serialize( $content ) );
 
 		if ( $this->_locking ) {
+			@\fflush( $fp );
 			@flock( $fp, LOCK_UN );
 		}
 
@@ -316,6 +317,7 @@ class Cache_File extends Cache_Base {
 				@fputs( $fp, pack( 'L', 0 ) ); // make it expired.
 
 				if ( $this->_locking ) {
+					@\fflush( $fp );
 					@flock( $fp, LOCK_UN );
 				}
 

--- a/Cache_File.php
+++ b/Cache_File.php
@@ -161,11 +161,12 @@ class Cache_File extends Cache_Base {
 		@fputs( $fp, pack( 'L', $expires_at ) );
 		@fputs( $fp, '<?php exit; ?>' );
 		@fputs( $fp, @serialize( $content ) );
-		@fclose( $fp );
 
 		if ( $this->_locking ) {
 			@flock( $fp, LOCK_UN );
 		}
+
+		@fclose( $fp );
 
 		return true;
 	}
@@ -313,11 +314,12 @@ class Cache_File extends Cache_Base {
 				}
 
 				@fputs( $fp, pack( 'L', 0 ) ); // make it expired.
-				@fclose( $fp );
 
 				if ( $this->_locking ) {
 					@flock( $fp, LOCK_UN );
 				}
+
+				@fclose( $fp );
 
 				return true;
 			}

--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -80,6 +80,7 @@ class Cache_File_Generic extends Cache_File {
 		@fputs( $fp, $w3tc_value['content'] );
 
 		if ( $this->_locking ) {
+			@\fflush( $fp );
 			@flock( $fp, LOCK_UN );
 		}
 

--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -78,6 +78,11 @@ class Cache_File_Generic extends Cache_File {
 		}
 
 		@fputs( $fp, $w3tc_value['content'] );
+
+		if ( $this->_locking ) {
+			@flock( $fp, LOCK_UN );
+		}
+
 		@fclose( $fp );
 
 		$chmod = 0644;
@@ -86,10 +91,6 @@ class Cache_File_Generic extends Cache_File {
 		}
 
 		@chmod( $tmppath, $chmod );
-
-		if ( $this->_locking ) {
-			@flock( $fp, LOCK_UN );
-		}
 
 		// some hostings create files with restrictive permissions not allowing apache to read it later.
 		@chmod( $path, 0644 );
@@ -293,11 +294,11 @@ class Cache_File_Generic extends Cache_File {
 			$var .= @fread( $fp, 4096 );
 		}
 
-		@fclose( $fp );
-
 		if ( $this->_locking ) {
 			@flock( $fp, LOCK_UN );
 		}
+
+		@fclose( $fp );
 
 		$headers = array();
 		if ( '.xml' === substr( $path, -4 ) ) {

--- a/tests/test-cache-file-locking.php
+++ b/tests/test-cache-file-locking.php
@@ -17,8 +17,13 @@ if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
 	return;
 }
 
+if ( \version_compare( PHP_VERSION, '8.0.0', '<' ) ) {
+	echo 'SKIP: file-cache locking teardown regression requires PHP 8+ for TypeError handling.' . "\n";
+	exit( 0 );
+}
+
 $plugin_root = realpath( __DIR__ . '/..' );
-$cache_root  = $plugin_root . '/.cursor/working/test-cache-file-locking-cache';
+$cache_root  = \sys_get_temp_dir() . '/w3tc-cache-file-locking-' . \getmypid() . '-' . \uniqid();
 
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', $plugin_root . '/' );
@@ -123,7 +128,9 @@ function cfl_assert_no_type_error( $callable, $label ) {
 }
 
 cfl_rmtree( $cache_root );
-mkdir( $cache_root, 0777, true );
+if ( ! @\mkdir( $cache_root, 0777, true ) && ! \is_dir( $cache_root ) ) {
+	cfl_fail( 'Could not create cache test directory: ' . $cache_root );
+}
 
 $config = array(
 	'cache_dir'        => $cache_root,
@@ -212,7 +219,7 @@ $generic_got = cfl_assert_no_type_error(
 	'Cache_File_Generic::get() raised TypeError with locking enabled'
 );
 
-if ( ! is_array( $generic_got ) || false === strpos( $generic_got['content'], 'generic' ) ) {
+if ( ! \is_array( $generic_got ) || ! isset( $generic_got['content'] ) || false === \strpos( $generic_got['content'], 'generic' ) ) {
 	cfl_fail( 'Cache_File_Generic round-trip get() mismatch after set()' );
 }
 cfl_pass( 'Cache_File_Generic round-trip get() after set()' );

--- a/tests/test-cache-file-locking.php
+++ b/tests/test-cache-file-locking.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Standalone regression test for file-cache locking teardown order.
+ *
+ * Verifies flock(LOCK_UN) runs before fclose() when locking is enabled.
+ * On PHP 8+, calling flock() after fclose() raises an uncaught TypeError.
+ *
+ * Run with: php tests/test-cache-file-locking.php
+ *
+ * Exit code 0 = all pass, non-zero = failures.
+ *
+ * @package W3TC\Tests
+ * @since   2.10.2
+ */
+
+if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+	return;
+}
+
+$plugin_root = realpath( __DIR__ . '/..' );
+$cache_root  = $plugin_root . '/.cursor/working/test-cache-file-locking-cache';
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $plugin_root . '/' );
+}
+
+if ( ! defined( 'W3TC_CACHE_FILE_EXPIRE_MAX' ) ) {
+	define( 'W3TC_CACHE_FILE_EXPIRE_MAX', 2592000 );
+}
+
+if ( ! defined( 'W3TC_CACHE_DIR' ) ) {
+	define( 'W3TC_CACHE_DIR', $cache_root );
+}
+
+require_once $plugin_root . '/Cache_Base.php';
+require_once $plugin_root . '/Util_Environment.php';
+require_once $plugin_root . '/Util_File.php';
+require_once $plugin_root . '/Cache_File.php';
+require_once $plugin_root . '/Cache_File_Generic.php';
+
+$pass = 0;
+
+/**
+ * Remove a directory tree.
+ *
+ * @since 2.10.2
+ *
+ * @param string $dir Directory path.
+ *
+ * @return void
+ */
+function cfl_rmtree( $dir ) {
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+
+	$items = scandir( $dir );
+	if ( false === $items ) {
+		return;
+	}
+
+	foreach ( $items as $item ) {
+		if ( '.' === $item || '..' === $item ) {
+			continue;
+		}
+
+		$path = $dir . DIRECTORY_SEPARATOR . $item;
+		if ( is_dir( $path ) ) {
+			cfl_rmtree( $path );
+		} else {
+			unlink( $path );
+		}
+	}
+
+	rmdir( $dir );
+}
+
+/**
+ * Record a passing assertion.
+ *
+ * @since 2.10.2
+ *
+ * @param string $message Description.
+ *
+ * @return void
+ */
+function cfl_pass( $message ) {
+	global $pass;
+	++$pass;
+	echo "PASS: {$message}\n";
+}
+
+/**
+ * Record a failing assertion and exit.
+ *
+ * @since 2.10.2
+ *
+ * @param string $message Description.
+ *
+ * @return void
+ */
+function cfl_fail( $message ) {
+	fwrite( STDERR, "FAIL: {$message}\n" );
+	exit( 1 );
+}
+
+/**
+ * Assert a callable completes without TypeError.
+ *
+ * @since 2.10.2
+ *
+ * @param callable $callable Operation to run.
+ * @param string   $label    Failure label.
+ *
+ * @return mixed Return value from callable.
+ */
+function cfl_assert_no_type_error( $callable, $label ) {
+	try {
+		return call_user_func( $callable );
+	} catch ( \TypeError $e ) {
+		cfl_fail( $label . ': ' . $e->getMessage() );
+	}
+}
+
+cfl_rmtree( $cache_root );
+mkdir( $cache_root, 0777, true );
+
+$config = array(
+	'cache_dir'        => $cache_root,
+	'locking'          => true,
+	'use_expired_data' => true,
+	'blog_id'          => 1,
+	'module'           => 'pgcache',
+	'host'             => 'example.test',
+	'instance_id'      => 1,
+);
+
+// ---------------------------------------------------------------------------
+// Cache_File (db/object cache and pgcache "file" engine).
+// ---------------------------------------------------------------------------
+
+$file_cache = new \W3TC\Cache_File( $config );
+$file_key   = 'locking-file-key';
+$file_value = array(
+	'hello' => 'world',
+	'ts'    => time(),
+);
+
+$set_ok = cfl_assert_no_type_error(
+	function () use ( $file_cache, $file_key, $file_value ) {
+		return $file_cache->set( $file_key, $file_value, 3600, 'default' );
+	},
+	'Cache_File::set() raised TypeError with locking enabled'
+);
+
+if ( ! $set_ok ) {
+	cfl_fail( 'Cache_File::set() returned false' );
+}
+cfl_pass( 'Cache_File::set() with locking enabled' );
+
+$got = cfl_assert_no_type_error(
+	function () use ( $file_cache, $file_key ) {
+		return $file_cache->get( $file_key, 'default' );
+	},
+	'Cache_File::get() raised TypeError with locking enabled'
+);
+
+if ( $got !== $file_value ) {
+	cfl_fail( 'Cache_File round-trip get() mismatch after set()' );
+}
+cfl_pass( 'Cache_File round-trip get() after set()' );
+
+$del_ok = cfl_assert_no_type_error(
+	function () use ( $file_cache, $file_key ) {
+		return $file_cache->delete( $file_key, 'default' );
+	},
+	'Cache_File::delete() raised TypeError with locking + use_expired_data'
+);
+
+if ( ! $del_ok ) {
+	cfl_fail( 'Cache_File::delete() returned false' );
+}
+cfl_pass( 'Cache_File::delete() with locking + use_expired_data' );
+
+// ---------------------------------------------------------------------------
+// Cache_File_Generic (default pgcache "file_generic" / Disk: Enhanced engine).
+// ---------------------------------------------------------------------------
+
+$generic_cache = new \W3TC\Cache_File_Generic( $config );
+$generic_key   = 'locking-generic-key';
+$generic_value = array(
+	'content' => '<html><body>generic</body></html>',
+	'headers' => array(),
+);
+
+$generic_set_ok = cfl_assert_no_type_error(
+	function () use ( $generic_cache, $generic_key, $generic_value ) {
+		return $generic_cache->set( $generic_key, $generic_value, 3600, 'default' );
+	},
+	'Cache_File_Generic::set() raised TypeError with locking enabled'
+);
+
+if ( ! $generic_set_ok ) {
+	cfl_fail( 'Cache_File_Generic::set() returned false' );
+}
+cfl_pass( 'Cache_File_Generic::set() with locking enabled' );
+
+$generic_got = cfl_assert_no_type_error(
+	function () use ( $generic_cache, $generic_key ) {
+		return $generic_cache->get( $generic_key, 'default' );
+	},
+	'Cache_File_Generic::get() raised TypeError with locking enabled'
+);
+
+if ( ! is_array( $generic_got ) || false === strpos( $generic_got['content'], 'generic' ) ) {
+	cfl_fail( 'Cache_File_Generic round-trip get() mismatch after set()' );
+}
+cfl_pass( 'Cache_File_Generic round-trip get() after set()' );
+
+cfl_rmtree( $cache_root );
+
+echo "All {$pass} checks passed on PHP " . PHP_VERSION . "\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

- Reorder `flock(LOCK_UN)` before `fclose()` in `Cache_File_Generic::set()` and `Cache_File_Generic::_read()` — the default page cache engine (`pgcache.engine = file_generic`) overrides `set()` and was still calling `flock()` on a closed stream when `pgcache.file.locking` is enabled.
- Add `tests/test-cache-file-locking.php`, a standalone regression test covering both `Cache_File` and `Cache_File_Generic` with `locking=true` on PHP 8+.
- Include the same `Cache_File.php` reorder from #1356 so the regression test passes on one branch; if #1356 merges first, the `Cache_File.php` hunk should be a no-op on rebase.

Fixes #499

Related: #1356

## Test plan

- [x] `php tests/test-cache-file-locking.php` — all 5 checks pass on PHP 8.3
- [x] `php -l Cache_File_Generic.php` — no syntax errors
- [x] `php -l tests/test-cache-file-locking.php` — no syntax errors