### PR TITLE
Skip storing redirect page responses

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -853,10 +853,13 @@ class PgCache_ContentGrabber {
 			return false;
 		}
 
-		if ( isset( $response_headers['kv']['location'] ) && ! $this->_enhanced_mode ) {
+		if ( isset( $response_headers['kv']['location'] ) ) {
 			$this->cache_reject_reason = 'Redirect response';
 			$this->process_status      = 'miss_redirect';
-			return false;
+
+			if ( ! $this->_enhanced_mode ) {
+				return false;
+			}
 		}
 
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'HEAD' === $_SERVER['REQUEST_METHOD'] ) {

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -853,7 +853,7 @@ class PgCache_ContentGrabber {
 			return false;
 		}
 
-		if ( isset( $response_headers['kv']['location'] ) ) {
+		if ( isset( $response_headers['kv']['location'] ) && ! $this->_enhanced_mode ) {
 			$this->cache_reject_reason = 'Redirect response';
 			$this->process_status      = 'miss_redirect';
 			return false;

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -854,21 +854,9 @@ class PgCache_ContentGrabber {
 		}
 
 		if ( isset( $response_headers['kv']['location'] ) ) {
-			/**
-			 * Dont cache query-string normalization redirects (e.g. from wp core) when cache key is normalized,
-			 * since that cause redirect loop.
-			 */
-
-			if (
-				$this->_get_page_key( $this->_page_key_extension ) === $this->_get_page_key(
-					$this->_page_key_extension,
-					$response_headers['kv']['location']
-				)
-			) {
-				$this->cache_reject_reason = 'Normalization redirect';
-				$this->process_status      = 'miss_normalization_redirect';
-				return false;
-			}
+			$this->cache_reject_reason = 'Redirect response';
+			$this->process_status      = 'miss_redirect';
+			return false;
 		}
 
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'HEAD' === $_SERVER['REQUEST_METHOD'] ) {

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -331,6 +331,7 @@ class PgCache_Plugin {
 				'php_requests_pagecache_miss_logged_in',
 				'php_requests_pagecache_miss_mfunc',
 				'php_requests_pagecache_miss_query_string',
+				'php_requests_pagecache_miss_redirect',
 				'php_requests_pagecache_miss_third_party',
 				'php_requests_pagecache_miss_wp_admin',
 				'pagecache_requests_time_10ms',

--- a/UsageStatistics_Page_View.php
+++ b/UsageStatistics_Page_View.php
@@ -160,6 +160,14 @@ require W3TC_INC_DIR . '/options/common/header.php';
 				'miss_query_string'
 			);
 			$this->summary_item(
+				'php_php_requests_pagecache_miss_redirect',
+				esc_html__( 'Redirect', 'w3-total-cache' ),
+				false,
+				'ustats_php_php_requests_pagecache_miss_level2',
+				'',
+				'miss_redirect'
+			);
+			$this->summary_item(
 				'php_php_requests_pagecache_miss_third_party',
 				esc_html__( 'Third Party', 'w3-total-cache' ),
 				false,

--- a/qa/tests/pagecache/redirect-caching.js
+++ b/qa/tests/pagecache/redirect-caching.js
@@ -10,7 +10,7 @@ const sys = requireRoot("lib/sys");
 const w3tc = requireRoot("lib/w3tc");
 const wp = requireRoot("lib/wp");
 
-// file_generic doesnt support redirect caching
+// Redirect responses should not be stored by page cache.
 /**environments:
 variable_equals('W3D_WP_NETWORK', ['single'],
 	multiply(
@@ -73,10 +73,11 @@ describe("", function () {
     );
   });
 
-  it("check redirect still happens - since cached", async () => {
+  it("check redirect no longer happens", async () => {
     await page.goto(testPageUrl);
-    expect(page.url()).equals(
-      env.scheme + "://for-tests.sandbox" + env.wpMaybeColonPort + "/",
-    );
+    expect(page.url()).equals(testPageUrl);
+
+    let content = await page.content();
+    expect(content).contains("no redirect");
   });
 });

--- a/tests/test-pgcache-redirect-cache.php
+++ b/tests/test-pgcache-redirect-cache.php
@@ -200,6 +200,16 @@ namespace {
 		true,
 		pgcr_can_write_cache( $enhanced_redirect_grabber, '', $redirect_headers )
 	);
+	pgcr_assert_same(
+		'Enhanced redirect rejection reason is recorded',
+		'Redirect response',
+		pgcr_get_private_property( $enhanced_redirect_grabber, 'cache_reject_reason' )
+	);
+	pgcr_assert_same(
+		'Enhanced redirect rejection status is recorded',
+		'miss_redirect',
+		pgcr_get_private_property( $enhanced_redirect_grabber, 'process_status' )
+	);
 
 	$html_grabber = pgcr_new_grabber();
 	$html_headers = array(

--- a/tests/test-pgcache-redirect-cache.php
+++ b/tests/test-pgcache-redirect-cache.php
@@ -130,13 +130,14 @@ namespace {
 		return $reflection->invoke( $object, $buffer, $headers );
 	}
 
-	function pgcr_new_grabber() {
+	function pgcr_new_grabber( $enhanced_mode = false ) {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$_SERVER['REQUEST_URI']    = '/';
 
 		$grabber = new W3TC_Test_PgCacheRedirectGrabber();
 
 		pgcr_set_private_property( $grabber, '_caching', true );
+		pgcr_set_private_property( $grabber, '_enhanced_mode', $enhanced_mode );
 		pgcr_set_private_property(
 			$grabber,
 			'_request_url_fragments',
@@ -190,6 +191,14 @@ namespace {
 		'Redirect rejection status is recorded',
 		'miss_redirect',
 		pgcr_get_private_property( $redirect_grabber, 'process_status' )
+	);
+
+	$enhanced_redirect_grabber = pgcr_new_grabber( true );
+
+	pgcr_assert_same(
+		'Enhanced redirect responses can reach existing cleanup path',
+		true,
+		pgcr_can_write_cache( $enhanced_redirect_grabber, '', $redirect_headers )
 	);
 
 	$html_grabber = pgcr_new_grabber();

--- a/tests/test-pgcache-redirect-cache.php
+++ b/tests/test-pgcache-redirect-cache.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Standalone regression test for page-cache redirect write decisions.
+ *
+ * Run with: php tests/test-pgcache-redirect-cache.php
+ *
+ * Exit code 0 = all pass, non-zero = failures.
+ *
+ * @package W3TC\Tests
+ * @since   2.10.0
+ */
+
+namespace {
+	if ( \realpath( __FILE__ ) !== \realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+		return;
+	}
+}
+
+namespace W3TC {
+	if ( ! \class_exists( __NAMESPACE__ . '\\Dispatcher', false ) ) {
+		/**
+		 * Config stub for the standalone page-cache redirect test.
+		 */
+		class PgCacheRedirectTestConfigStub {
+			public function get_boolean( $key ) {
+				return false;
+			}
+
+			public function get_integer( $key ) {
+				return 0;
+			}
+
+			public function get_string( $key ) {
+				return '';
+			}
+
+			public function get_array( $key ) {
+				return array();
+			}
+		}
+
+		/**
+		 * Dispatcher stub for the standalone page-cache redirect test.
+		 */
+		class Dispatcher {
+			public static function config() {
+				return new PgCacheRedirectTestConfigStub();
+			}
+
+			public static function component( $name ) {
+				return null;
+			}
+		}
+
+		/**
+		 * Environment stub for the standalone page-cache redirect test.
+		 */
+		class Util_Environment {
+			public static function host_port() {
+				return 'example.com';
+			}
+
+			public static function is_https() {
+				return false;
+			}
+
+			public static function is_preview_mode() {
+				return false;
+			}
+
+			public static function parse_path( $path ) {
+				return $path;
+			}
+		}
+	}
+}
+
+namespace {
+	if ( ! \function_exists( 'w3tc_apply_filters' ) ) {
+		function w3tc_apply_filters( $tag, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! \function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( $url ) {
+			return \parse_url( $url );
+		}
+	}
+
+	require_once __DIR__ . '/../PgCache_ContentGrabber.php';
+
+	class W3TC_Test_PgCacheRedirectGrabber extends \W3TC\PgCache_ContentGrabber {
+		public function _passed_accept_files() {
+			return true;
+		}
+	}
+
+	$w3tc_pgcache_redirect_failures = 0;
+
+	function pgcr_assert_same( $label, $expected, $actual ) {
+		global $w3tc_pgcache_redirect_failures;
+
+		if ( $expected === $actual ) {
+			echo "[PASS] $label\n";
+			return;
+		}
+
+		++$w3tc_pgcache_redirect_failures;
+		echo "[FAIL] $label\n";
+		echo '  Expected: ' . \var_export( $expected, true ) . "\n";
+		echo '  Actual:   ' . \var_export( $actual, true ) . "\n";
+	}
+
+	function pgcr_set_private_property( $object, $property, $value ) {
+		$reflection = new \ReflectionProperty( \W3TC\PgCache_ContentGrabber::class, $property );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $object, $value );
+	}
+
+	function pgcr_get_private_property( $object, $property ) {
+		$reflection = new \ReflectionProperty( \W3TC\PgCache_ContentGrabber::class, $property );
+		$reflection->setAccessible( true );
+		return $reflection->getValue( $object );
+	}
+
+	function pgcr_can_write_cache( $object, $buffer, $headers ) {
+		$reflection = new \ReflectionMethod( \W3TC\PgCache_ContentGrabber::class, '_can_write_cache' );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( $object, $buffer, $headers );
+	}
+
+	function pgcr_new_grabber() {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI']    = '/';
+
+		$grabber = new W3TC_Test_PgCacheRedirectGrabber();
+
+		pgcr_set_private_property( $grabber, '_caching', true );
+		pgcr_set_private_property(
+			$grabber,
+			'_request_url_fragments',
+			array(
+				'host'        => 'example.com',
+				'path'        => '/',
+				'querystring' => '',
+			)
+		);
+		pgcr_set_private_property(
+			$grabber,
+			'_page_key_extension',
+			array(
+				'useragent'    => '',
+				'referrer'     => '',
+				'cookie'       => '',
+				'encryption'   => '',
+				'group'        => '',
+				'content_type' => '',
+				'compression'  => false,
+			)
+		);
+
+		return $grabber;
+	}
+
+	$redirect_grabber = pgcr_new_grabber();
+	$redirect_headers = array(
+		'kv'    => array(
+			'location' => 'http://127.0.0.1',
+		),
+		'plain' => array(
+			array(
+				'name'  => 'Location',
+				'value' => 'http://127.0.0.1',
+			),
+		),
+	);
+
+	pgcr_assert_same(
+		'Redirect responses are not written to page cache',
+		false,
+		pgcr_can_write_cache( $redirect_grabber, '', $redirect_headers )
+	);
+	pgcr_assert_same(
+		'Redirect rejection reason is recorded',
+		'Redirect response',
+		pgcr_get_private_property( $redirect_grabber, 'cache_reject_reason' )
+	);
+	pgcr_assert_same(
+		'Redirect rejection status is recorded',
+		'miss_redirect',
+		pgcr_get_private_property( $redirect_grabber, 'process_status' )
+	);
+
+	$html_grabber = pgcr_new_grabber();
+	$html_headers = array(
+		'kv'    => array(),
+		'plain' => array(),
+	);
+
+	pgcr_assert_same(
+		'Non-empty HTML response can still be written',
+		true,
+		pgcr_can_write_cache( $html_grabber, '<html><body>ok</body></html>', $html_headers )
+	);
+
+	if ( $w3tc_pgcache_redirect_failures > 0 ) {
+		exit( 1 );
+	}
+}

--- a/tests/test-pgcache-redirect-cache.php
+++ b/tests/test-pgcache-redirect-cache.php
@@ -77,7 +77,7 @@ namespace W3TC {
 
 namespace {
 	if ( ! \function_exists( 'w3tc_apply_filters' ) ) {
-		function w3tc_apply_filters( $tag, $value ) {
+		function w3tc_apply_filters( $tag, $value, ...$args ) {
 			return $value;
 		}
 	}


### PR DESCRIPTION
## Summary
- Stops page-cache writes when the generated response includes a `Location` header.
- Keeps Disk Enhanced redirect handling on its existing cleanup path while recording the redirect miss status.
- Adds standalone and W3TCQA coverage for redirect responses not being retained.
- Ref: https://wordpress.org/support/topic/w3-is-caching-an-error-state-for-all-public-visitors-to-home-page/

## Reviewer acceptance testing
- Configure Page Cache with a PHP-backed engine such as Memcached, Redis, APCu, or Disk Basic. Use a test page that redirects to the site home from `template_redirect`.
- Visit the test page anonymously and confirm the browser follows the redirect to the home page.
- Disable the source redirect without clearing page cache, then visit the same test page again. The browser should remain on the test page and show the non-redirect page content.
- Repeat with Disk Enhanced if desired: the redirect should not be retained, and the existing cleanup behavior should still run without writing a redirect page entry.
- With Usage Statistics enabled, trigger the redirect response and confirm the Page Cache miss breakdown includes a `Redirect` row.
- Optional W3TCQA coverage: run `qa/tests/pagecache/redirect-caching.js` against the single-site page-cache engine matrix.

## Test plan
- `php -l PgCache_ContentGrabber.php && php -l PgCache_Plugin.php && php -l UsageStatistics_Page_View.php && php -l tests/test-pgcache-redirect-cache.php`
- `php tests/test-pgcache-redirect-cache.php`
- `php -r "require 'tests/test-pgcache-redirect-cache.php'; echo 'include ok' . PHP_EOL;"`
- `./vendor/bin/phpcs PgCache_ContentGrabber.php PgCache_Plugin.php UsageStatistics_Page_View.php`
- `yarn run js-lint -- qa/tests/pagecache/redirect-caching.js`