### PR TITLE
ENG7-4253: Restore Cloudways Varnish flush on loopback HTTP ports

### DIFF
--- a/Util_Url.php
+++ b/Util_Url.php
@@ -17,13 +17,15 @@ namespace W3TC;
  *
  * Every outbound `wp_remote_*` call where the URL is admin-influenced
  * (license API override, AlwaysCached queue, recursive sitemap
- * fetcher, varnish purge, forums-api tab id, etc.) MUST run through
- * {@see self::is_public_host()} before issuing the request. Without
- * this check, a `wp_remote_get( $admin_url )` whose `$admin_url`
- * carries an internal-range value would target internal services:
- * AWS instance metadata at `169.254.169.254`, a Redis at
- * `127.0.0.1:6379`, an RFC1918 neighbour, the WordPress front-end
- * (`http://0.0.0.0/`), etc.
+ * fetcher, forums-api tab id, etc.) MUST run through
+ * {@see self::is_public_host()} before issuing the request. Varnish
+ * PURGE uses {@see self::is_safe_varnish_purge_target()} instead,
+ * because legitimate destinations are often RFC1918 or loopback on
+ * an HTTP port. Without these checks, a `wp_remote_get( $admin_url )`
+ * whose `$admin_url` carries an internal-range value would target
+ * internal services: AWS instance metadata at `169.254.169.254`, a
+ * Redis at `127.0.0.1:6379`, an RFC1918 neighbour, the WordPress
+ * front-end (`http://0.0.0.0/`), etc.
  *
  * **Residual risk: DNS rebinding.** `gethostbynamel()` resolves once
  * at check time; a hostile resolver can return a public IP for the
@@ -270,7 +272,10 @@ class Util_Url {
 	 * Use this (not {@see self::is_public_ip()}) at sinks like
 	 * Varnish purge where the legitimate destination is intentionally
 	 * a private-network host but a forged config value pointing at
-	 * cloud metadata or `127.0.0.1:6379` must be refused.
+	 * cloud metadata must be refused. Loopback is intentionally
+	 * refused here; Varnish callers that need Cloudways-style
+	 * `127.0.0.1:8080` should use {@see self::is_safe_varnish_purge_target()}
+	 * which re-allows loopback only on HTTP/Varnish ports.
 	 *
 	 * @since 2.10.0
 	 *
@@ -362,6 +367,153 @@ class Util_Url {
 
 		// Refuse hosts with no resolved address at all.
 		return ! empty( $ipv4_set ) || ! empty( $ipv6_set );
+	}
+
+	/**
+	 * Returns true when `$ip` is a loopback address (IPv4 `127.0.0.0/8`
+	 * or IPv6 `::1`, including IPv4-mapped `::ffff:127.x.x.x`).
+	 *
+	 * @since 2.10.3
+	 *
+	 * @param string $ip IP literal (v4 or v6).
+	 *
+	 * @return bool
+	 */
+	public static function is_loopback_ip( $ip ) {
+		if ( ! \is_string( $ip ) || '' === $ip ) {
+			return false;
+		}
+
+		if ( false !== \stripos( $ip, '::ffff:' ) ) {
+			$tail = \substr( $ip, \stripos( $ip, '::ffff:' ) + 7 );
+			if ( false !== \filter_var( $tail, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+				return self::is_loopback_ip( $tail );
+			}
+		}
+
+		if ( false !== \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			return 0 === \strpos( $ip, '127.' );
+		}
+
+		if ( false !== \filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+			$packed = @\inet_pton( $ip );
+			$loop   = @\inet_pton( '::1' );
+			return false !== $packed && false !== $loop && $packed === $loop;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns true when `$host` is a hostname or IP literal that
+	 * resolves only to loopback addresses (and resolves to at least
+	 * one address). Used to recognize Cloudways / sidecar Varnish
+	 * targets such as `127.0.0.1` and `localhost`.
+	 *
+	 * @since 2.10.3
+	 *
+	 * @param string $host Hostname or IP literal (no scheme, no port).
+	 *
+	 * @return bool
+	 */
+	public static function host_resolves_loopback_only( $host ) {
+		if ( ! \is_string( $host ) || '' === $host ) {
+			return false;
+		}
+
+		if ( '[' === \substr( $host, 0, 1 ) && ']' === \substr( $host, -1 ) ) {
+			$host = \substr( $host, 1, -1 );
+		}
+
+		if ( false !== \filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return self::is_loopback_ip( $host );
+		}
+
+		$ipv4_set = @\gethostbynamel( $host );
+		if ( false === $ipv4_set ) {
+			$ipv4_set = array();
+		}
+		foreach ( $ipv4_set as $ip ) {
+			if ( ! \is_string( $ip ) || ! self::is_loopback_ip( $ip ) ) {
+				return false;
+			}
+		}
+
+		$ipv6_set = array();
+		if ( \function_exists( 'dns_get_record' ) ) {
+			$aaaa = @\dns_get_record( $host, DNS_AAAA );
+			if ( \is_array( $aaaa ) ) {
+				foreach ( $aaaa as $rec ) {
+					if ( isset( $rec['ipv6'] ) && \is_string( $rec['ipv6'] ) ) {
+						$ipv6_set[] = $rec['ipv6'];
+					}
+				}
+			}
+		}
+		foreach ( $ipv6_set as $ip ) {
+			if ( ! self::is_loopback_ip( $ip ) ) {
+				return false;
+			}
+		}
+
+		return ! empty( $ipv4_set ) || ! empty( $ipv6_set );
+	}
+
+	/**
+	 * Returns true when `$port` is a common HTTP / Varnish listen port
+	 * safe to target on loopback for PURGE (not Redis, memcached, MySQL).
+	 *
+	 * Filterable via `w3tc_varnish_http_ports` for unusual deployments.
+	 *
+	 * @since 2.10.3
+	 *
+	 * @param int $port Destination port.
+	 *
+	 * @return bool
+	 */
+	public static function is_varnish_http_port( $port ) {
+		$port  = (int) $port;
+		$ports = array( 80, 443, 8080, 6081, 6082 );
+		/**
+		 * Filters the HTTP/Varnish ports allowed for loopback PURGE.
+		 *
+		 * @since 2.10.3
+		 *
+		 * @param int[] $ports Allowed destination ports.
+		 */
+		$ports = \apply_filters( 'w3tc_varnish_http_ports', $ports );
+		if ( ! \is_array( $ports ) ) {
+			return false;
+		}
+		$ports = \array_map( 'intval', $ports );
+		return \in_array( $port, $ports, true );
+	}
+
+	/**
+	 * Returns true when `$host`:`$port` is a safe Varnish PURGE target.
+	 *
+	 * Accepts the same destinations as {@see self::host_resolves_safe_internal()}
+	 * (RFC1918 + public; still refuses link-local / metadata), AND also
+	 * accepts loopback (`127.0.0.1`, `localhost`, `::1`) when the port is
+	 * a common HTTP/Varnish port. That restores Cloudways and other
+	 * sidecar-Varnish setups without re-enabling the rt9-127 abuse case
+	 * of pointing PURGE at `127.0.0.1:6379` (Redis), `:11211`
+	 * (memcached), `:3306` (MySQL), etc.
+	 *
+	 * @since 2.10.3
+	 *
+	 * @param string     $host Hostname or IP literal (no scheme, no port).
+	 * @param int|string $port Destination port.
+	 *
+	 * @return bool
+	 */
+	public static function is_safe_varnish_purge_target( $host, $port ) {
+		if ( self::host_resolves_safe_internal( $host ) ) {
+			return true;
+		}
+
+		return self::host_resolves_loopback_only( $host )
+			&& self::is_varnish_http_port( $port );
 	}
 
 	/**

--- a/Util_Url.php
+++ b/Util_Url.php
@@ -270,12 +270,10 @@ class Util_Url {
 	 * dangerous set for SSRF — while leaving RFC1918 ranges valid.
 	 *
 	 * Use this (not {@see self::is_public_ip()}) at sinks like
-	 * Varnish purge where the legitimate destination is intentionally
-	 * a private-network host but a forged config value pointing at
-	 * cloud metadata must be refused. Loopback is intentionally
-	 * refused here; Varnish callers that need Cloudways-style
-	 * `127.0.0.1:8080` should use {@see self::is_safe_varnish_purge_target()}
-	 * which re-allows loopback only on HTTP/Varnish ports.
+	 * Varnish purge where the destination may be a private-network
+	 * host. Loopback is refused here; callers that need loopback on
+	 * an HTTP/Varnish port should use
+	 * {@see self::is_safe_varnish_purge_target()}.
 	 *
 	 * @since 2.10.0
 	 *
@@ -373,7 +371,7 @@ class Util_Url {
 	 * Returns true when `$ip` is a loopback address (IPv4 `127.0.0.0/8`
 	 * or IPv6 `::1`, including IPv4-mapped `::ffff:127.x.x.x`).
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 *
 	 * @param string $ip IP literal (v4 or v6).
 	 *
@@ -405,12 +403,9 @@ class Util_Url {
 	}
 
 	/**
-	 * Returns true when `$host` is a hostname or IP literal that
-	 * resolves only to loopback addresses (and resolves to at least
-	 * one address). Used to recognize Cloudways / sidecar Varnish
-	 * targets such as `127.0.0.1` and `localhost`.
+	 * Returns true when `$host` resolves only to loopback addresses.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 *
 	 * @param string $host Hostname or IP literal (no scheme, no port).
 	 *
@@ -460,12 +455,11 @@ class Util_Url {
 	}
 
 	/**
-	 * Returns true when `$port` is a common HTTP / Varnish listen port
-	 * safe to target on loopback for PURGE (not Redis, memcached, MySQL).
+	 * Returns true when `$port` is a common HTTP / Varnish listen port.
 	 *
-	 * Filterable via `w3tc_varnish_http_ports` for unusual deployments.
+	 * Filterable via `w3tc_varnish_http_ports`.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 *
 	 * @param int $port Destination port.
 	 *
@@ -477,7 +471,7 @@ class Util_Url {
 		/**
 		 * Filters the HTTP/Varnish ports allowed for loopback PURGE.
 		 *
-		 * @since 2.10.3
+		 * @since X.X.X
 		 *
 		 * @param int[] $ports Allowed destination ports.
 		 */
@@ -490,17 +484,12 @@ class Util_Url {
 	}
 
 	/**
-	 * Returns true when `$host`:`$port` is a safe Varnish PURGE target.
+	 * Returns true when `$host`:`$port` is an allowed Varnish PURGE target.
 	 *
-	 * Accepts the same destinations as {@see self::host_resolves_safe_internal()}
-	 * (RFC1918 + public; still refuses link-local / metadata), AND also
-	 * accepts loopback (`127.0.0.1`, `localhost`, `::1`) when the port is
-	 * a common HTTP/Varnish port. That restores Cloudways and other
-	 * sidecar-Varnish setups without re-enabling the rt9-127 abuse case
-	 * of pointing PURGE at `127.0.0.1:6379` (Redis), `:11211`
-	 * (memcached), `:3306` (MySQL), etc.
+	 * Same hosts as {@see self::host_resolves_safe_internal()}, plus
+	 * loopback when the port is a common HTTP/Varnish listen port.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 *
 	 * @param string     $host Hostname or IP literal (no scheme, no port).
 	 * @param int|string $port Destination port.

--- a/Varnish_Flush.php
+++ b/Varnish_Flush.php
@@ -153,34 +153,35 @@ class Varnish_Flush {
 
 		/**
 		 * Refuse outbound purge requests targeting cloud metadata
-		 * (169.254.169.254), loopback (127.0.0.0/8), or any other
-		 * reserved range. Varnish legitimately runs on RFC1918 hosts
-		 * (10.x / 172.16-31.x / 192.168.x) so we use
-		 * `host_resolves_safe_internal()` here rather than the strict
-		 * `is_public_host()`. The check covers both literal IPs in the
-		 * admin-set `varnish.servers` value and hostnames that resolve
-		 * to a dangerous range via DNS. Filterable so an operator with
-		 * an audited reason — e.g. a sidecar Varnish on `127.0.0.1` —
-		 * can opt out per-host.
+		 * (169.254.169.254), link-local, or other reserved ranges, and
+		 * refuse loopback except on common HTTP/Varnish ports. RFC1918
+		 * hosts (10.x / 172.16-31.x / 192.168.x) remain allowed.
+		 * Loopback on ports 80/443/8080/6081/6082 is allowed so
+		 * Cloudways and sidecar Varnish keep working; loopback on
+		 * Redis/memcached/MySQL ports stays blocked (rt9-127).
+		 * Filterable via `w3tc_varnish_skip_host_check` for audited
+		 * exceptions.
 		 */
 		if ( ! \apply_filters(
 			'w3tc_varnish_skip_host_check',
 			false,
 			$varnish_host,
 			$varnish_port
-		) && ! Util_Url::host_resolves_safe_internal( $varnish_host ) ) {
+		) && ! Util_Url::is_safe_varnish_purge_target( $varnish_host, $varnish_port ) ) {
 			$this->_log(
 				$w3tc_url,
 				sprintf(
-					'Refused PURGE to %s — host is loopback, link-local, or reserved range.',
-					$varnish_host
+					'Refused PURGE to %s:%d — host/port is not a safe Varnish target (link-local, reserved, or loopback on a non-HTTP port).',
+					$varnish_host,
+					(int) $varnish_port
 				)
 			);
 			return new \WP_Error(
 				'http_request_failed',
 				sprintf(
-					'Refused to send Varnish PURGE to %s: host is loopback, link-local, or a reserved range. Set varnish.servers to a routable internal host, or filter `w3tc_varnish_skip_host_check` to opt out.',
-					$varnish_host
+					'Refused to send Varnish PURGE to %1$s:%2$d: destination is link-local/reserved, or loopback on a non-HTTP port. Use a routable internal host, an HTTP/Varnish port on loopback (80, 443, 8080, 6081, 6082), or filter `w3tc_varnish_skip_host_check` to opt out.',
+					$varnish_host,
+					(int) $varnish_port
 				)
 			);
 		}

--- a/Varnish_Flush.php
+++ b/Varnish_Flush.php
@@ -152,15 +152,9 @@ class Varnish_Flush {
 		list( $varnish_host, $varnish_port ) = Util_Content::endpoint_to_host_port( $varnish_server, 80 );
 
 		/**
-		 * Refuse outbound purge requests targeting cloud metadata
-		 * (169.254.169.254), link-local, or other reserved ranges, and
-		 * refuse loopback except on common HTTP/Varnish ports. RFC1918
-		 * hosts (10.x / 172.16-31.x / 192.168.x) remain allowed.
-		 * Loopback on ports 80/443/8080/6081/6082 is allowed so
-		 * Cloudways and sidecar Varnish keep working; loopback on
-		 * Redis/memcached/MySQL ports stays blocked (rt9-127).
-		 * Filterable via `w3tc_varnish_skip_host_check` for audited
-		 * exceptions.
+		 * Allow RFC1918 and loopback-on-HTTP-port targets; refuse
+		 * link-local, reserved, and loopback on non-HTTP ports.
+		 * Opt out per host via `w3tc_varnish_skip_host_check`.
 		 */
 		if ( ! \apply_filters(
 			'w3tc_varnish_skip_host_check',

--- a/tests/admin/class-w3tc-util-url-test.php
+++ b/tests/admin/class-w3tc-util-url-test.php
@@ -173,4 +173,72 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 		$this->assertFalse( Util_Url::is_public_ip( '' ) );
 		$this->assertFalse( Util_Url::is_public_ip( 'not an ip' ) );
 	}
+
+	/**
+	 * Loopback classification for the Varnish PURGE exception path.
+	 *
+	 * @since 2.10.3
+	 */
+	public function test_is_loopback_ip_classifies_ranges_correctly() {
+		$this->assertTrue( Util_Url::is_loopback_ip( '127.0.0.1' ) );
+		$this->assertTrue( Util_Url::is_loopback_ip( '127.255.255.254' ) );
+		$this->assertTrue( Util_Url::is_loopback_ip( '::1' ) );
+		$this->assertTrue( Util_Url::is_loopback_ip( '::ffff:127.0.0.1' ) );
+
+		$this->assertFalse( Util_Url::is_loopback_ip( '10.0.0.1' ) );
+		$this->assertFalse( Util_Url::is_loopback_ip( '192.168.0.1' ) );
+		$this->assertFalse( Util_Url::is_loopback_ip( '169.254.169.254' ) );
+		$this->assertFalse( Util_Url::is_loopback_ip( '8.8.8.8' ) );
+		$this->assertFalse( Util_Url::is_loopback_ip( '::ffff:10.0.0.1' ) );
+		$this->assertFalse( Util_Url::is_loopback_ip( '' ) );
+	}
+
+	/**
+	 * Cloudways-style loopback Varnish on HTTP ports must be allowed;
+	 * the rt9-127 abuse cases (Redis / memcached / MySQL / metadata)
+	 * must still be refused.
+	 *
+	 * @since 2.10.3
+	 */
+	public function test_is_safe_varnish_purge_target_allows_cloudways_blocks_ssrf() {
+		// Cloudways / sidecar Varnish — loopback + HTTP/Varnish ports.
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 80 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 8080 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 6081 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 443 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( 'localhost', 8080 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '::1', 80 ) );
+
+		// RFC1918 internal Varnish — still allowed on any port policy
+		// of host_resolves_safe_internal (port unused once host is safe).
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '10.0.0.1', 80 ) );
+		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '192.168.1.10', 8080 ) );
+
+		// rt9-127: loopback to non-HTTP service ports must stay blocked.
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 6379 ) );
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 11211 ) );
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 3306 ) );
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( 'localhost', 6379 ) );
+
+		// Cloud metadata / link-local still refused regardless of port.
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '169.254.169.254', 80 ) );
+		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '169.254.169.254', 8080 ) );
+	}
+
+	/**
+	 * Operators can extend the HTTP-port allow-list via filter.
+	 *
+	 * @since 2.10.3
+	 */
+	public function test_is_varnish_http_port_filterable() {
+		$this->assertFalse( Util_Url::is_varnish_http_port( 9080 ) );
+
+		$callback = static function ( $ports ) {
+			$ports[] = 9080;
+			return $ports;
+		};
+		\add_filter( 'w3tc_varnish_http_ports', $callback );
+		$this->assertTrue( Util_Url::is_varnish_http_port( 9080 ) );
+		\remove_filter( 'w3tc_varnish_http_ports', $callback );
+	}
 }

--- a/tests/admin/class-w3tc-util-url-test.php
+++ b/tests/admin/class-w3tc-util-url-test.php
@@ -177,7 +177,7 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	/**
 	 * Loopback classification for the Varnish PURGE exception path.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 */
 	public function test_is_loopback_ip_classifies_ranges_correctly() {
 		$this->assertTrue( Util_Url::is_loopback_ip( '127.0.0.1' ) );
@@ -194,14 +194,12 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Cloudways-style loopback Varnish on HTTP ports must be allowed;
-	 * the rt9-127 abuse cases (Redis / memcached / MySQL / metadata)
-	 * must still be refused.
+	 * Loopback on HTTP/Varnish ports is allowed; other loopback ports
+	 * and link-local destinations are refused.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 */
-	public function test_is_safe_varnish_purge_target_allows_cloudways_blocks_ssrf() {
-		// Cloudways / sidecar Varnish — loopback + HTTP/Varnish ports.
+	public function test_is_safe_varnish_purge_target_allows_loopback_http_ports() {
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 80 ) );
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 8080 ) );
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 6081 ) );
@@ -209,18 +207,14 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( 'localhost', 8080 ) );
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '::1', 80 ) );
 
-		// RFC1918 internal Varnish — still allowed on any port policy
-		// of host_resolves_safe_internal (port unused once host is safe).
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '10.0.0.1', 80 ) );
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '192.168.1.10', 8080 ) );
 
-		// rt9-127: loopback to non-HTTP service ports must stay blocked.
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 6379 ) );
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 11211 ) );
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 3306 ) );
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( 'localhost', 6379 ) );
 
-		// Cloud metadata / link-local still refused regardless of port.
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '169.254.169.254', 80 ) );
 		$this->assertFalse( Util_Url::is_safe_varnish_purge_target( '169.254.169.254', 8080 ) );
 	}
@@ -228,7 +222,7 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	/**
 	 * Operators can extend the HTTP-port allow-list via filter.
 	 *
-	 * @since 2.10.3
+	 * @since X.X.X
 	 */
 	public function test_is_varnish_http_port_filterable() {
 		$this->assertFalse( Util_Url::is_varnish_http_port( 9080 ) );


### PR DESCRIPTION
## Summary
- Fixes Cloudways (and other sidecar) Varnish purge breakage introduced in 2.10.0 when `varnish.servers` is set to `127.0.0.1:8080` / `:80`.
- Updates `Varnish_Flush` to use `Util_Url::is_safe_varnish_purge_target()`, which allows loopback only on common HTTP/Varnish ports (`80`, `443`, `8080`, `6081`, `6082`) while continuing to refuse non-HTTP loopback ports and link-local / reserved destinations.
- Adds unit coverage for the allow and deny paths; ports remain filterable via `w3tc_varnish_http_ports`.

Reported on wordpress.org: Varnish purge stopped working after 2.10.0 on Cloudways; rolling back to 2.9.4 restored PURGE requests.

## Test plan
- [ ] `./vendor/bin/phpunit --filter W3tc_Util_Url_Test` passes
- [ ] Confirm allow matrix:
  - `127.0.0.1:80`, `127.0.0.1:8080`, `localhost:8080` → allowed
  - `10.x` / `192.168.x` → still allowed
  - `127.0.0.1:6379`, `:11211`, `:3306` → still refused
  - `169.254.169.254:80` → still refused
- [ ] With Reverse Proxy enabled and `varnish.servers` = `127.0.0.1:8080` (or `:80`), enable `varnish.debug`, purge cache, and confirm the varnish debug log shows a PURGE attempt (not a “Refused PURGE” message)
- [ ] On a Cloudways-like setup: update a page / Empty Varnish Cache and verify the change is visible in an incognito session without a server-level purge
- [ ] Optional: `add_filter( 'w3tc_varnish_http_ports', … )` with a custom port and confirm that port is accepted for loopback
