### PR TITLE
Correct placeholder name for string replacement injecting the timeout config

### DIFF
--- a/UserExperience_DeferScripts_Script.js
+++ b/UserExperience_DeferScripts_Script.js
@@ -1,5 +1,5 @@
 (function (w, k, o) {
-  var t = setTimeout(f, { config_timeout });
+  var t = setTimeout(f, {config_timeout});
   k.forEach(function (e) {
     w.addEventListener(e, f, o);
   });


### PR DESCRIPTION
The JS file has recently been re-written, introducing spaces that break the string replacement inside the PHP script. This fixes it.