### PR TITLE
ENG7-4407: Exclude REST requests from Generic_Plugin output buffering

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -938,8 +938,19 @@ class Generic_Plugin {
 			return $buffer;
 		}
 
+		$is_rest_request = $this->is_rest_ob_request();
+		if ( $is_rest_request && ! $this->should_ob_process_rest() ) {
+			return $buffer;
+		}
+
 		if ( $this->is_wp_die && ! apply_filters( 'w3tc_process_wp_die', false, $buffer ) ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
 			// wp_die is dynamic output (usually fatal errors), dont process it.
+		} elseif ( $is_rest_request ) {
+			// REST caching enabled: pagecache only — skip HTML processors on JSON.
+			$buffer = Util_Bus::do_ob_callbacks(
+				array( 'pagecache' ),
+				$buffer
+			);
 		} else {
 			$buffer = apply_filters( 'w3tc_process_content', $buffer );
 
@@ -1050,12 +1061,44 @@ class Generic_Plugin {
 		}
 
 		/**
+		 * Skip REST API requests unless page-cache REST caching is enabled.
+		 * Uses URL detection because REST_REQUEST is defined later (parse_request).
+		 */
+		if ( $this->is_rest_ob_request() && ! $this->should_ob_process_rest() ) {
+			return false;
+		}
+
+		/**
 		 * Do not skip output buffering based on User-Agent: the value is client-controlled.
 		 * A request claiming "W3 Total Cache" would previously bypass ob_callback, skipping
 		 * page-cache processing and emitting W3TC_DYNAMIC_SECURITY in unprocessed mfunc/mclude.
 		 */
 
 		return true;
+	}
+
+	/**
+	 * Whether the current request looks like a REST API call for OB gating.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool
+	 */
+	private function is_rest_ob_request() {
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+
+		return Util_Environment::is_rest_request( $request_uri );
+	}
+
+	/**
+	 * Whether REST responses should run through the page-cache OB path.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool
+	 */
+	private function should_ob_process_rest() {
+		return 'cache' === $this->_config->get_string( 'pgcache.rest' );
 	}
 
 	/**

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1087,7 +1087,7 @@ class Generic_Plugin {
 	private function is_rest_ob_request() {
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-		return Util_Environment::is_rest_request( $request_uri );
+		return (bool) Util_Environment::is_rest_request( $request_uri );
 	}
 
 	/**

--- a/tests/test-generic-plugin.php
+++ b/tests/test-generic-plugin.php
@@ -226,4 +226,157 @@ class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
 			'can_ob() must remain true when HTTP_USER_AGENT contains W3TC_POWERED_BY (client-controlled).'
 		);
 	}
+
+	/**
+	 * can_ob() must reject REST-shaped URLs before REST_REQUEST is defined.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_can_ob_rejects_rest_request_uri() {
+		global $w3tc_w3_late_init;
+
+		$prev_late                 = $w3tc_w3_late_init;
+		$w3tc_w3_late_init         = false;
+		$prev_uri                  = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+		$_SERVER['REQUEST_URI']    = '/wp-json/wp/v2/posts/1';
+		$config                    = \W3TC\Dispatcher::config();
+		$prev_rest                 = $config->get_string( 'pgcache.rest' );
+		$config->set( 'pgcache.rest', '' );
+
+		$plugin = new Generic_Plugin();
+		$can_ob = $plugin->can_ob();
+
+		$config->set( 'pgcache.rest', $prev_rest );
+		if ( null === $prev_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $prev_uri;
+		}
+		$w3tc_w3_late_init = $prev_late;
+
+		$this->assertFalse(
+			$can_ob,
+			'can_ob() must return false for /wp-json/ requests when pgcache.rest is not cache.'
+		);
+	}
+
+	/**
+	 * can_ob() must allow REST when page-cache REST caching is enabled.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_can_ob_allows_rest_when_pgcache_rest_cache_enabled() {
+		global $w3tc_w3_late_init;
+
+		$prev_late                 = $w3tc_w3_late_init;
+		$w3tc_w3_late_init         = false;
+		$prev_uri                  = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+		$_SERVER['REQUEST_URI']    = '/wp-json/wp/v2/posts/1';
+		$config                    = \W3TC\Dispatcher::config();
+		$prev_rest                 = $config->get_string( 'pgcache.rest' );
+		$config->set( 'pgcache.rest', 'cache' );
+
+		$plugin = new Generic_Plugin();
+		$can_ob = $plugin->can_ob();
+
+		$config->set( 'pgcache.rest', $prev_rest );
+		if ( null === $prev_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $prev_uri;
+		}
+		$w3tc_w3_late_init = $prev_late;
+
+		$this->assertTrue(
+			$can_ob,
+			'can_ob() must return true for REST URIs when pgcache.rest is cache.'
+		);
+	}
+
+	/**
+	 * ob_callback() must return REST JSON unchanged when REST caching is off.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ob_callback_short_circuits_rest_when_not_caching() {
+		$prev_uri               = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts/1';
+		$config                 = \W3TC\Dispatcher::config();
+		$prev_rest              = $config->get_string( 'pgcache.rest' );
+		$config->set( 'pgcache.rest', '' );
+
+		$minify_ran = false;
+		\W3TC\Util_Bus::add_ob_callback(
+			'minify',
+			function ( $buffer ) use ( &$minify_ran ) {
+				$minify_ran = true;
+				return $buffer . '-minified';
+			}
+		);
+
+		$json   = '{"id":1,"title":"Hello"}';
+		$result = $this->plugin->ob_callback( $json );
+
+		$config->set( 'pgcache.rest', $prev_rest );
+		if ( null === $prev_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $prev_uri;
+		}
+
+		$this->assertSame( $json, $result );
+		$this->assertFalse( $minify_ran, 'HTML processors must not run on REST responses when not caching REST.' );
+	}
+
+	/**
+	 * With REST caching enabled, ob_callback() must run pagecache only.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public function test_ob_callback_runs_pagecache_only_for_cached_rest() {
+		$prev_uri               = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts/1';
+		$config                 = \W3TC\Dispatcher::config();
+		$prev_rest              = $config->get_string( 'pgcache.rest' );
+		$config->set( 'pgcache.rest', 'cache' );
+
+		$minify_ran    = false;
+		$pagecache_ran = false;
+		\W3TC\Util_Bus::add_ob_callback(
+			'minify',
+			function ( $buffer ) use ( &$minify_ran ) {
+				$minify_ran = true;
+				return $buffer . '-minified';
+			}
+		);
+		\W3TC\Util_Bus::add_ob_callback(
+			'pagecache',
+			function ( $buffer ) use ( &$pagecache_ran ) {
+				$pagecache_ran = true;
+				return $buffer . '-cached';
+			}
+		);
+
+		$json   = '{"id":1}';
+		$result = $this->plugin->ob_callback( $json );
+
+		$config->set( 'pgcache.rest', $prev_rest );
+		if ( null === $prev_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $prev_uri;
+		}
+
+		$this->assertSame( '{"id":1}-cached', $result );
+		$this->assertTrue( $pagecache_ran );
+		$this->assertFalse( $minify_ran, 'Minify must not run on REST JSON even when REST caching is enabled.' );
+	}
 }


### PR DESCRIPTION
## Summary
- Skip Generic_Plugin page-output buffering for REST API requests (URL detection via `Util_Environment::is_rest_request()`), which runs before `REST_REQUEST` is defined.
- Short-circuit `ob_callback()` for REST when `pgcache.rest` is not `cache`, so minify/lazyload/CDN/etc. do not process JSON responses.
- When `pgcache.rest === 'cache'`, keep OB enabled but run the pagecache callback only.

Fixes intermittent PHP fatal on Block Editor save/update (`Cannot use output buffering in output buffering display handlers`) reported at https://wordpress.org/support/topic/fatal-error-cannot-use-output-buffering-in-output-buffering-display-handlers-2/

Jira: https://imh-internal.atlassian.net/browse/ENG7-4407

## Test plan
- [x] `WP_TESTS_DIR=... phpunit --filter Generic_Plugin_DynamicFragments_Test` (10 tests, including 4 new REST OB cases)
- [x] PHPCS on `Generic_Plugin.php`
- [ ] Manual: edit + update a post in Block Editor with page cache and minify enabled; save succeeds and REST JSON is intact
- [ ] Manual (optional): with `pgcache.rest` set to Cache, confirm REST responses can still be page-cached