### PR TITLE
ENG7-4410: Match Defer Scripts timeout placeholder to Prettier format

### DIFF
--- a/UserExperience_DeferScripts_Extension.php
+++ b/UserExperience_DeferScripts_Extension.php
@@ -194,7 +194,7 @@ class UserExperience_DeferScripts_Extension {
 
 		$content = file_get_contents( W3TC_DIR . '/UserExperience_DeferScripts_Script.js' );
 		$content = str_replace(
-			'{config_timeout}',
+			'{ config_timeout }',
 			$config_timeout,
 			$content
 		);


### PR DESCRIPTION
## Summary
- Fixes Defer Scripts timeout injection broken since 2.10.0 (#1344), when Prettier reformatted `{config_timeout}` to `{ config_timeout }` in `UserExperience_DeferScripts_Script.js` while PHP still replaced the unspaced token.
- Updates `UserExperience_DeferScripts_Extension::embed_script()` to replace `{ config_timeout }` so the configured timeout is injected and the footer script remains valid JS.
- Prefers a PHP-side match over changing the JS (as in #1363) so `prettier-eslint` / `yarn run js-lint` stays clean and a future lint-fix cannot silently re-break the inject.

Closes community approach in favor of this durable fix; see #1363.

Jira: https://imh-internal.atlassian.net/browse/ENG7-4410

## Test plan
- [ ] Confirm `UserExperience_DeferScripts_Script.js` still contains `setTimeout(f, { config_timeout });` (Prettier form)
- [ ] Enable Defer Scripts with a known timeout (e.g. 2500); view page source and confirm the footer script has `setTimeout(f, 2500)` (or the configured value), not a leftover `{ config_timeout }` placeholder
- [ ] `php -r` / `str_replace( '{ config_timeout }', … )` against the JS file succeeds; `node --check` on the injected output passes
- [ ] `yarn run prettier-eslint UserExperience_DeferScripts_Script.js --list-different` exits 0 (no JS change required)