### PR TITLE
Patch Release 2.10.3

### DIFF
--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -111,6 +111,7 @@ On a full release branch, also align (outside this skill's scope unless requeste
 - `w3-total-cache.php` `Version:` header
 - `w3-total-cache-api.php` `W3TC_VERSION`
 - `readme.txt` `Stable tag:` line
+- Run `yarn run update:since` after the version bump and commit the `@since X.X.X` → current-version replacements before tagging (so placeholders do not remain in the git tag; packaging alone is not enough)
 
 Do **not** bump version numbers or edit POT/`readme.txt` stable tag on `master` per project policy — only on release branches when explicitly requested.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This project is a WordPress plugin designed to enhance website performance throu
 - WordPress Documentation Standards for JavaScript: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/
 
 ## Contribution Process
-- Add `@since X.X.X` to all new doc blocks. After bumping `Version` in `w3-total-cache.php`, run `yarn run update:since` and commit the replacements on `master` before tagging.
+- Add `@since X.X.X` to all new doc blocks. When prepping a release branch, after bumping `Version` in `w3-total-cache.php`, run `yarn run update:since` and commit the replacements before tagging so placeholders do not ship in the git tag (the packaging script also runs this, but only for the built artifact).
 - Do not update POT files -- it's done in our build process.
 - Do not change the `readme.txt` file -- it's done on release branches.
 - Do not increment the plugin version number -- it's done in our build process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Component suffixes indicate role:
 - Prefix all global namespace function calls with a backslash (e.g., `\strlen()`)
 - Opening parenthesis of multi-line function calls must be the last content on the line
 - Do not make unrelated coding-standards fixes in changed files
-- Add `@since X.X.X` to all new doc blocks. After bumping `Version` in `w3-total-cache.php`, run `yarn run update:since` and commit the replacements on `master` before tagging.
+- Add `@since X.X.X` to all new doc blocks. When prepping a release branch, after bumping `Version` in `w3-total-cache.php`, run `yarn run update:since` and commit the replacements before tagging so placeholders do not ship in the git tag (the packaging script also runs this, but only for the built artifact).
 
 ### Contribution Notes
 - Do not update POT files, `readme.txt`, or the plugin version — all handled in the build process

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1080,7 +1080,7 @@ class Generic_Plugin {
 	/**
 	 * Whether the current request looks like a REST API call for OB gating.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return bool
 	 */
@@ -1093,7 +1093,7 @@ class Generic_Plugin {
 	/**
 	 * Whether REST responses should run through the page-cache OB path.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return bool
 	 */

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -9,8 +9,8 @@ namespace W3TC;
 
 defined( 'ABSPATH' ) || exit;
 // Define repeated regex to simplify changes.
-define( 'W3TC_MINIFY_AUTO_FILENAME_REGEX', '([a-zA-Z0-9-_]+)\\.(css|js)([?].*)?' );
-define( 'W3TC_MINIFY_MANUAL_FILENAME_REGEX', '([a-f0-9]+)\\.(.+)\\.(include(\\-(footer|body))?)\\.[a-f0-9]+\\.(css|js)' );
+define( 'W3TC_MINIFY_AUTO_FILENAME_REGEX', '([a-zA-Z0-9_-]+)\\.(css|js)([?].*)?' );
+define( 'W3TC_MINIFY_MANUAL_FILENAME_REGEX', '([a-f0-9]+)\\.([a-zA-Z0-9_-]+)\\.(include(\\-(footer|body))?)\\.[a-f0-9]+\\.(css|js)' );
 
 /**
  * Class Minify_MinifiedFileRequestHandler

--- a/Util_Url.php
+++ b/Util_Url.php
@@ -371,7 +371,7 @@ class Util_Url {
 	 * Returns true when `$ip` is a loopback address (IPv4 `127.0.0.0/8`
 	 * or IPv6 `::1`, including IPv4-mapped `::ffff:127.x.x.x`).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 *
 	 * @param string $ip IP literal (v4 or v6).
 	 *
@@ -405,7 +405,7 @@ class Util_Url {
 	/**
 	 * Returns true when `$host` resolves only to loopback addresses.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 *
 	 * @param string $host Hostname or IP literal (no scheme, no port).
 	 *
@@ -459,7 +459,7 @@ class Util_Url {
 	 *
 	 * Filterable via `w3tc_varnish_http_ports`.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 *
 	 * @param int $port Destination port.
 	 *
@@ -471,7 +471,7 @@ class Util_Url {
 		/**
 		 * Filters the HTTP/Varnish ports allowed for loopback PURGE.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.2
 		 *
 		 * @param int[] $ports Allowed destination ports.
 		 */
@@ -489,7 +489,7 @@ class Util_Url {
 	 * Same hosts as {@see self::host_resolves_safe_internal()}, plus
 	 * loopback when the port is a common HTTP/Varnish listen port.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 *
 	 * @param string     $host Hostname or IP literal (no scheme, no port).
 	 * @param int|string $port Destination port.

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -14,7 +14,7 @@ rm -rf .claude .cursor .github qa
 # Find and replace symlinks in the "vendor" directory.
 for i in $(find vendor/ -type l); do \cp -f --remove-destination $(realpath $i) $i;done
 
-# Update @since 2.10.0 placeholders (no-op when already applied on master).
+# Replace any leftover @since X.X.X placeholders (prefer yarn run update:since on the release branch before tagging).
 chmod +x ./bin/update-since-versions.sh && ./bin/update-since-versions.sh
 
 # Install WP-CLI

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 === W3 Total Cache Changelog ===
 
+= 2.10.3 =
+* Fix: Output buffering: Skip REST API requests unless page cache REST caching is enabled
+* Fix: Minify: Keep cache file operations within the cache directory
+* Fix: Defer Scripts: Restore timeout configuration placeholder replacement
+
 = 2.10.2 =
 * Fix: Disk cache: Restore file-locking writes on PHP 8+
 * Fix: Apache: Limit Options -MultiViews in page cache rules to compatibility mode

--- a/composer.lock
+++ b/composer.lock
@@ -219,22 +219,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.2",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fa88c57803501ad0770f5cddb1e60525d49da9a1",
-                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.12.5",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -247,7 +247,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -327,7 +327,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -343,7 +343,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-14T18:15:01+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -431,16 +431,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.5",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -530,7 +530,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -546,7 +546,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:27:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "microsoft/azure-storage-blob",
@@ -2847,16 +2847,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
                 "shasum": ""
             },
             "require": {
@@ -2866,8 +2866,8 @@
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
                 "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -2909,7 +2909,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-16T13:05:29+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -33,6 +33,63 @@ class Minify_Cache_File {
 	}
 
 	/**
+	 * Resolve a cache id to a path under the cache root.
+	 *
+	 * @param string $id Cache id (filename or relative nested key).
+	 *
+	 * @return string|false Absolute path under `_path`, or false when rejected.
+	 *
+	 * @since X.X.X
+	 */
+	private function _path_for_id($id)
+	{
+		if (!is_string($id) || '' === $id || false !== strpos($id, "\0")) {
+			return false;
+		}
+
+		$id_norm = str_replace('\\', '/', $id);
+		if (false !== strpos($id_norm, '..')) {
+			return false;
+		}
+
+		if ('/' === $id_norm[0] || preg_match('#^[a-zA-Z]:/#', $id_norm)) {
+			return false;
+		}
+
+		$base = realpath($this->_path);
+		if (false === $base) {
+			return false;
+		}
+
+		$base_norm   = rtrim(str_replace('\\', '/', $base), '/');
+		$base_prefix = $base_norm . '/';
+		$candidate   = $base_prefix . $id_norm;
+
+		$probe = $candidate;
+		while (true) {
+			$fs = realpath($probe);
+			if (false !== $fs) {
+				$resolved = str_replace('\\', '/', $fs);
+				if ($resolved !== $base_norm && 0 !== strpos($resolved, $base_prefix)) {
+					return false;
+				}
+				break;
+			}
+
+			$parent = dirname($probe);
+			if ($parent === $probe || '' === $parent) {
+				if (0 !== strpos(str_replace('\\', '/', $candidate), $base_prefix)) {
+					return false;
+				}
+				break;
+			}
+			$probe = $parent;
+		}
+
+		return $candidate;
+	}
+
+	/**
 	 * Write data to cache.
 	 *
 	 * @param string $id cache id (e.g. a filename)
@@ -43,7 +100,11 @@ class Minify_Cache_File {
 	 */
 	public function store($id, $data)
 	{
-		$path = $this->_path . '/' . $id;
+		$path = $this->_path_for_id($id);
+		if (false === $path) {
+			return false;
+		}
+
 		$flag = $this->_locking ? LOCK_EX : null;
 
 		if (is_file($path)) {
@@ -85,11 +146,16 @@ class Minify_Cache_File {
 	 *
 	 * @param string $id cache id (e.g. a filename)
 	 *
-	 * @return int size in bytes
+	 * @return int|false Size in bytes, or false when the cache id is rejected or unreadable.
 	 */
 	public function getSize($id)
 	{
-		return filesize($this->_path . '/' . $id);
+		$path = $this->_path_for_id($id);
+		if (false === $path) {
+			return false;
+		}
+
+		return filesize($path);
 	}
 
 	/**
@@ -103,7 +169,11 @@ class Minify_Cache_File {
 	 */
 	public function isValid($id, $srcMtime)
 	{
-		$file = $this->_path . '/' . $id;
+		$file = $this->_path_for_id($id);
+		if (false === $file) {
+			return false;
+		}
+
 		return (is_file($file) && (filemtime($file) >= $srcMtime));
 	}
 
@@ -114,7 +184,10 @@ class Minify_Cache_File {
 	 */
 	public function display($id)
 	{
-		$path = $this->_path . '/' . $id;
+		$path = $this->_path_for_id($id);
+		if (false === $path) {
+			return false;
+		}
 
 		$fp = @fopen($path, 'rb');
 
@@ -141,7 +214,10 @@ class Minify_Cache_File {
 	 */
 	public function fetch($id)
 	{
-		$path = $this->_path . '/' . $id;
+		$path = $this->_path_for_id($id);
+		if (false === $path) {
+			return false;
+		}
 
 		$data = @file_get_contents($path . '_meta');
 		if ( ! empty( $data ) ) {

--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -39,7 +39,7 @@ class Minify_Cache_File {
 	 *
 	 * @return string|false Absolute path under `_path`, or false when rejected.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 */
 	private function _path_for_id($id)
 	{

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: boldgrid, fredericktownes, maxicusc, gidomanders, bwmarkle, harryj
 Tags: CDN, pagespeed, caching, performance, optimize
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 2.10.2
+Stable tag: 2.10.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -365,6 +365,11 @@ Please reach out to all of these people and support their projects if you're so 
 
 == Changelog ==
 
+= 2.10.3 =
+* Fix: Output buffering: Skip REST API requests unless page cache REST caching is enabled
+* Fix: Minify: Keep cache file operations within the cache directory
+* Fix: Defer Scripts: Restore timeout configuration placeholder replacement
+
 = 2.10.2 =
 * Fix: Disk cache: Restore file-locking writes on PHP 8+
 * Fix: Apache: Limit Options -MultiViews in page cache rules to compatibility mode
@@ -550,6 +555,9 @@ Please reach out to all of these people and support their projects if you're so 
 * Update: Added Premium Services tabs
 
 == Upgrade Notice ==
+
+= 2.10.3 =
+This update resolves Block Editor save failures related to output buffering and restores Defer Scripts timeout configuration. All users are encouraged to update.
 
 = 2.10.1 =
 This update resolves regressions introduced in 2.10.0. Users who upgraded to 2.10.0 are encouraged to update.

--- a/tests/admin/class-w3tc-util-url-test.php
+++ b/tests/admin/class-w3tc-util-url-test.php
@@ -177,7 +177,7 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	/**
 	 * Loopback classification for the Varnish PURGE exception path.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 */
 	public function test_is_loopback_ip_classifies_ranges_correctly() {
 		$this->assertTrue( Util_Url::is_loopback_ip( '127.0.0.1' ) );
@@ -197,7 +197,7 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	 * Loopback on HTTP/Varnish ports is allowed; other loopback ports
 	 * and link-local destinations are refused.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 */
 	public function test_is_safe_varnish_purge_target_allows_loopback_http_ports() {
 		$this->assertTrue( Util_Url::is_safe_varnish_purge_target( '127.0.0.1', 80 ) );
@@ -222,7 +222,7 @@ class W3tc_Util_Url_Test extends WP_UnitTestCase {
 	/**
 	 * Operators can extend the HTTP-port allow-list via filter.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.2
 	 */
 	public function test_is_varnish_http_port_filterable() {
 		$this->assertFalse( Util_Url::is_varnish_http_port( 9080 ) );

--- a/tests/test-generic-plugin.php
+++ b/tests/test-generic-plugin.php
@@ -230,7 +230,7 @@ class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
 	/**
 	 * can_ob() must reject REST-shaped URLs before REST_REQUEST is defined.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return void
 	 */
@@ -265,7 +265,7 @@ class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
 	/**
 	 * can_ob() must allow REST when page-cache REST caching is enabled.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return void
 	 */
@@ -300,7 +300,7 @@ class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
 	/**
 	 * ob_callback() must return REST JSON unchanged when REST caching is off.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return void
 	 */
@@ -337,7 +337,7 @@ class Generic_Plugin_DynamicFragments_Test extends WP_UnitTestCase {
 	/**
 	 * With REST caching enabled, ob_callback() must run pagecache only.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.3
 	 *
 	 * @return void
 	 */

--- a/tests/test-minify-cache-id-path.php
+++ b/tests/test-minify-cache-id-path.php
@@ -6,7 +6,7 @@
  * Run with: php tests/test-minify-cache-id-path.php
  *
  * @package W3TC\Tests
- * @since   X.X.X
+ * @since   2.10.3
  */
 
 if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {

--- a/tests/test-minify-cache-id-path.php
+++ b/tests/test-minify-cache-id-path.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Standalone regression test for minify filesystem cache-id path containment
+ * and the manual minify filename template charset.
+ *
+ * Run with: php tests/test-minify-cache-id-path.php
+ *
+ * @package W3TC\Tests
+ * @since   X.X.X
+ */
+
+if ( realpath( __FILE__ ) !== realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+	return;
+}
+
+$mcp_pass  = 0;
+$mcp_fail  = 0;
+$mcp_cases = array();
+
+if ( ! function_exists( 'mcp_assert' ) ) {
+	/**
+	 * Registers a test result.
+	 *
+	 * @param string $label       Human-readable description.
+	 * @param bool   $expectation Condition that should hold.
+	 * @param string $detail      Optional failure context.
+	 */
+	function mcp_assert( string $label, bool $expectation, string $detail = '' ): void {
+		global $mcp_pass, $mcp_fail, $mcp_cases;
+		if ( $expectation ) {
+			$mcp_cases[] = array( 'PASS', $label );
+			++$mcp_pass;
+		} else {
+			$mcp_cases[] = array( 'FAIL', $label . ( $detail ? " | $detail" : '' ) );
+			++$mcp_fail;
+		}
+	}
+}
+
+$handler_src       = file_get_contents( __DIR__ . '/../Minify_MinifiedFileRequestHandler.php' );
+$manual_re         = '([a-f0-9]+)\\.([a-zA-Z0-9_-]+)\\.(include(\\-(footer|body))?)\\.[a-f0-9]+\\.(css|js)';
+$mcp_define_match  = array();
+$defined_re        = '';
+
+if ( is_string( $handler_src ) ) {
+	preg_match(
+		"/define\\(\\s*'W3TC_MINIFY_MANUAL_FILENAME_REGEX'\\s*,\\s*'([^']+)'\\s*\\)/",
+		$handler_src,
+		$mcp_define_match
+	);
+	$defined_re = isset( $mcp_define_match[1] ) ? stripcslashes( $mcp_define_match[1] ) : '';
+}
+
+mcp_assert(
+	'[1] handler defines tightened manual filename regex',
+	$manual_re === $defined_re,
+	'got ' . $defined_re
+);
+
+$valid_manual   = '74ab2.index.include.deadbeef.js';
+$valid_footer   = '74ab2.page-home.include-footer.abc123.css';
+$nested_id      = '74ab2.stage/seed.include.deadbeef.js';
+$traversal_id   = '74ab2.stage/../../../outside.include.deadbeef.js';
+$dot_template   = '74ab2.stage..x.include.deadbeef.js';
+
+mcp_assert(
+	'[2] valid manual filename matches',
+	(bool) preg_match( '~^' . $manual_re . '$~', $valid_manual )
+);
+mcp_assert(
+	'[3] hyphenated template + include-footer matches',
+	(bool) preg_match( '~^' . $manual_re . '$~', $valid_footer )
+);
+mcp_assert(
+	'[4] path separator in template is rejected',
+	! preg_match( '~^' . $manual_re . '$~', $nested_id )
+);
+mcp_assert(
+	'[5] parent-directory segments in template are rejected',
+	! preg_match( '~^' . $manual_re . '$~', $traversal_id )
+);
+mcp_assert(
+	'[6] dots in template segment are rejected',
+	! preg_match( '~^' . $manual_re . '$~', $dot_template )
+);
+
+$base_tmp  = sys_get_temp_dir() . '/w3tc_mcp_' . getmypid() . '_' . bin2hex( random_bytes( 4 ) );
+$cache_dir = $base_tmp . '/cache/minify';
+$outside   = $base_tmp . '/outside-target.js';
+
+mkdir( $cache_dir, 0777, true );
+file_put_contents( $cache_dir . '/index.html', '' );
+file_put_contents( $outside, "BEFORE\n" );
+
+if ( ! defined( 'W3TC_CACHE_DIR' ) ) {
+	define( 'W3TC_CACHE_DIR', $base_tmp . '/cache' );
+}
+
+require_once __DIR__ . '/../lib/Minify/Minify/Cache/File.php';
+
+$cache = new \W3TCL\Minify\Minify_Cache_File( $cache_dir );
+
+$ok_store = $cache->store(
+	$valid_manual,
+	array( 'content' => "var ok = 1;\n" )
+);
+mcp_assert( '[7] store accepts a flat cache id under the cache root', false !== $ok_store && is_file( $cache_dir . '/' . $valid_manual ) );
+
+$fetched = $cache->fetch( $valid_manual );
+mcp_assert(
+	'[8] fetch returns stored content for a flat cache id',
+	is_array( $fetched ) && isset( $fetched['content'] ) && "var ok = 1;\n" === $fetched['content']
+);
+
+$group_id   = '74ab2/default.include.js.id';
+$group_path = $cache_dir . '/' . $group_id;
+mkdir( dirname( $group_path ), 0777, true );
+$group_store = $cache->store(
+	$group_id,
+	array( 'content' => "group-id\n" )
+);
+$group_fetch = $cache->fetch( $group_id );
+mcp_assert(
+	'[9] store accepts get_id_key_group-shaped nested cache ids',
+	false !== $group_store && is_file( $group_path )
+);
+mcp_assert(
+	'[10] fetch returns stored content for nested group ids',
+	is_array( $group_fetch ) && isset( $group_fetch['content'] ) && "group-id\n" === $group_fetch['content']
+);
+
+$before_hash = hash_file( 'sha256', $outside );
+$bad_store   = $cache->store(
+	'stage/../../../outside-target.js',
+	array( 'content' => "AFTER\n" )
+);
+$after_hash = hash_file( 'sha256', $outside );
+
+mcp_assert( '[11] store rejects parent-directory cache ids', false === $bad_store );
+mcp_assert(
+	'[12] rejected store does not modify a file outside the cache root',
+	$before_hash === $after_hash && "BEFORE\n" === file_get_contents( $outside ),
+	'outside file hash changed'
+);
+
+$bad_fetch = $cache->fetch( '../outside-target.js' );
+mcp_assert( '[13] fetch rejects parent-directory cache ids', false === $bad_fetch );
+
+$bad_size = $cache->getSize( '..\\outside-target.js' );
+mcp_assert( '[14] getSize rejects backslash parent-directory segments', false === $bad_size );
+
+$bad_valid = $cache->isValid( 'foo/../outside-target.js', 0 );
+mcp_assert( '[15] isValid rejects embedded parent-directory segments', false === $bad_valid );
+
+$bad_abs = $cache->store(
+	'/etc/passwd',
+	array( 'content' => "ABS\n" )
+);
+mcp_assert( '[16] store rejects absolute cache ids', false === $bad_abs );
+
+$outside_dir = $base_tmp . '/outside-dir';
+$link_dir    = $cache_dir . '/linkout';
+mkdir( $outside_dir, 0777, true );
+file_put_contents( $outside_dir . '/marker.js', "MARKER\n" );
+$symlink_ok = @symlink( $outside_dir, $link_dir );
+if ( $symlink_ok ) {
+	$before_marker = hash_file( 'sha256', $outside_dir . '/marker.js' );
+	$bad_link      = $cache->store(
+		'linkout/escaped.js',
+		array( 'content' => "ESCAPED\n" )
+	);
+	$after_marker = hash_file( 'sha256', $outside_dir . '/marker.js' );
+	mcp_assert( '[17] store rejects ids under symlinked subdir outside cache root', false === $bad_link );
+	mcp_assert(
+		'[18] rejected symlink store does not modify the outside target dir',
+		$before_marker === $after_marker && ! is_file( $outside_dir . '/escaped.js' ),
+		'outside symlink target was written'
+	);
+} else {
+	mcp_assert( '[17] store rejects ids under symlinked subdir outside cache root (skipped: no symlink)', true );
+	mcp_assert( '[18] rejected symlink store does not modify the outside target dir (skipped: no symlink)', true );
+}
+
+/**
+ * Cleanup.
+ */
+@unlink( $cache_dir . '/' . $valid_manual );
+@unlink( $cache_dir . '/' . $valid_manual . '_meta' );
+@unlink( $group_path );
+@unlink( $group_path . '_meta' );
+@rmdir( dirname( $group_path ) );
+if ( $symlink_ok ) {
+	@unlink( $link_dir );
+}
+@unlink( $outside_dir . '/marker.js' );
+@rmdir( $outside_dir );
+@unlink( $cache_dir . '/index.html' );
+@rmdir( $cache_dir );
+@rmdir( dirname( $cache_dir ) );
+@unlink( $outside );
+@rmdir( $base_tmp );
+
+echo "\n=== Minify cache-id path containment ===\n\n";
+foreach ( $mcp_cases as $case ) {
+	$mark = 'PASS' === $case[0] ? "\033[32m✔\033[0m" : "\033[31m✘\033[0m";
+	echo "  {$mark}  {$case[1]}\n";
+}
+echo "\n  Total: " . ( $mcp_pass + $mcp_fail ) . "  Passed: \033[32m{$mcp_pass}\033[0m  Failed: \033[31m{$mcp_fail}\033[0m\n\n";
+
+exit( $mcp_fail > 0 ? 1 : 0 );

--- a/tests/test-minify-f-array-security.php
+++ b/tests/test-minify-f-array-security.php
@@ -224,8 +224,8 @@ fa_assert(
  * [11] Confirm the exploit precondition: the PoC token parses as MANUAL (empty hash),
  * which is exactly the branch the fix guards.
  */
-define( 'MINIFY_AUTO_FILENAME_REGEX_T', '([a-zA-Z0-9-_]+)\\.(css|js)([?].*)?' );
-define( 'MINIFY_MANUAL_FILENAME_REGEX_T', '([a-f0-9]+)\\.(.+)\\.(include(\\-(footer|body))?)\\.[a-f0-9]+\\.(css|js)' );
+define( 'MINIFY_AUTO_FILENAME_REGEX_T', '([a-zA-Z0-9_-]+)\\.(css|js)([?].*)?' );
+define( 'MINIFY_MANUAL_FILENAME_REGEX_T', '([a-f0-9]+)\\.([a-zA-Z0-9_-]+)\\.(include(\\-(footer|body))?)\\.[a-f0-9]+\\.(css|js)' );
 $poc_token   = '87fee.default.include.452061.js';
 $is_auto     = (bool) preg_match( '~^' . MINIFY_AUTO_FILENAME_REGEX_T . '$~', $poc_token );
 $is_manual   = (bool) preg_match( '~^' . MINIFY_MANUAL_FILENAME_REGEX_T . '$~', $poc_token );

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -10,7 +10,7 @@
 defined( 'ABSPATH' ) || die;
 
 define( 'W3TC', true );
-define( 'W3TC_VERSION', '2.10.2' );
+define( 'W3TC_VERSION', '2.10.3' );
 define( 'W3TC_POWERED_BY', 'W3 Total Cache' );
 define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       W3 Total Cache
  * Plugin URI:        https://www.boldgrid.com/totalcache/
  * Description:       The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
- * Version:           2.10.2
+ * Version:           2.10.3
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            BoldGrid

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,9 +895,9 @@
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
 "@csstools/css-syntax-patches-for-csstree@^1.0.19":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz#3a1e91cefb65b4a74ae7dd78c9b2dd60cdbf3ad4"
-  integrity sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz#67a65f4b26766c315ddfd2bdb89ac4c53fdd51e7"
+  integrity sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==
 
 "@csstools/css-tokenizer@^3.0.1", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
@@ -934,9 +934,9 @@
     jsdoc-type-pratt-parser "~4.0.0"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
-  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
+  integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
@@ -1148,9 +1148,9 @@
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
 "@sinclair/typebox@^0.27.8":
-  version "0.27.10"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
-  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
+  version "0.27.12"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.12.tgz#0cacd3cff047a32936b1ace47ea7c86eaab60a7f"
+  integrity sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==
 
 "@stylistic/stylelint-plugin@^3.0.1":
   version "3.1.3"
@@ -1822,10 +1822,10 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
-baseline-browser-mapping@^2.10.42:
-  version "2.10.43"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz#7b5d11590ce5acdbe4859443e3c940e81ce8c02d"
-  integrity sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==
+baseline-browser-mapping@^2.10.44:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz#390b4714558634093df77add4acca0c5c0c1605e"
+  integrity sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==
 
 boolify@^1.0.1:
   version "1.0.1"
@@ -1855,13 +1855,13 @@ braces@^3.0.3:
     fill-range "^7.1.1"
 
 browserslist@^4.21.10, browserslist@^4.24.0, browserslist@^4.28.1:
-  version "4.28.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.6.tgz#7cf83afcd69c55fde6fb2dcc5039ff0f4ba42610"
-  integrity sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==
+  version "4.28.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.7.tgz#409046517fccd2e51cdc20f077454b7141184028"
+  integrity sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==
   dependencies:
-    baseline-browser-mapping "^2.10.42"
-    caniuse-lite "^1.0.30001803"
-    electron-to-chromium "^1.5.389"
+    baseline-browser-mapping "^2.10.44"
+    caniuse-lite "^1.0.30001806"
+    electron-to-chromium "^1.5.393"
     node-releases "^2.0.51"
     update-browserslist-db "^1.2.3"
 
@@ -1935,10 +1935,10 @@ camelcase@^8.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-8.0.0.tgz#c0d36d418753fb6ad9c5e0437579745c1c14a534"
   integrity sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==
 
-caniuse-lite@^1.0.30001803:
-  version "1.0.30001805"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz#78d5d5968a69b7ff81af87a96d7ddc7ea6670b1e"
-  integrity sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==
+caniuse-lite@^1.0.30001806:
+  version "1.0.30001806"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz#1bc8e502b723fa393455dfbedd5ccec0c29bb74e"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -2258,10 +2258,10 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-electron-to-chromium@^1.5.389:
-  version "1.5.391"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.391.tgz#a210ae1e913357bb61d7d1c9f9a7986f80e247a9"
-  integrity sha512-YmCu4856jkgKT1Nh6fwRdeVrM6Ydf/fBnq51tpmSfX+jOcUMTxh31yH6hjKScRenhB2oDSvA9oooxcpjogPeig==
+electron-to-chromium@^1.5.393:
+  version "1.5.396"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz#4aa96428486c8d1c9c8aeb205b2d6e04928ca046"
+  integrity sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2733,9 +2733,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
-  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -2797,9 +2797,9 @@ flat-cache@^6.1.23:
     hookified "^1.15.0"
 
 flatted@^3.2.9, flatted@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
-  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.3.tgz#be5c21e943b2d7a328bb23795ae28c98f0103a9e"
+  integrity sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -3618,9 +3618,9 @@ mdn-data@2.27.1:
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
 mdn-data@^2.25.0:
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.28.1.tgz#798ed0511d4097c22b091718435059fdb0a64ad9"
-  integrity sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.29.0.tgz#7f1ffe95753a1883e1146b2af9cee2772a793bc9"
+  integrity sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==
 
 memize@^2.1.0:
   version "2.1.1"
@@ -3691,7 +3691,7 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -3815,11 +3815,12 @@ optionator@^0.9.3:
     word-wrap "^1.2.5"
 
 own-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
-  integrity sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.2.tgz#31448ec1f781ecb1447f6f6aa0d6534222af59de"
+  integrity sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==
   dependencies:
-    get-intrinsic "^1.2.6"
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
 
@@ -3973,11 +3974,11 @@ postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.4.41, postcss@^8.5.6:
-  version "8.5.19"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.19.tgz#45ad5cfde499408e20147348237551381a922037"
-  integrity sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -4036,9 +4037,9 @@ prettier-linter-helpers@^1.0.1:
     fast-diff "^1.1.2"
 
 prettier@^3.5.3:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.9.5.tgz#4fec97736e33b9d0b620b48914fe93b530e835ad"
-  integrity sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.9.6.tgz#b3ea5146515d40fc53f18aa63f74dfab1e10dbf6"
+  integrity sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==
 
 pretty-format@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-4404

## Summary
- Patch release 2.10.3 (version bump, changelog, dependency refresh)
- Minify: keep cache file operations within the cache directory
- Includes related master fixes already reflected in the 2.10.3 changelog (REST/output buffering skip; Defer Scripts timeout placeholder)

## Test plan
- [x] Confirm version constants / Stable tag are `2.10.3`
- [x] Confirm `readme.txt` / `changelog.txt` 2.10.3 entries match intended release notes
- [ ] Smoke minify (manual mode, disk cache): generate and serve a minified CSS/JS group successfully
- [x] Run `php tests/test-minify-cache-id-path.php`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-wide output buffering (REST/Block Editor) and minify disk cache path handling; incorrect gating or path logic could break saves or minify serving, while the containment change is in a sensitive filesystem area.
> 
> **Overview**
> **Patch release 2.10.3** bumps `W3TC_VERSION` / plugin header, syncs `readme.txt` (stable tag, changelog, upgrade notice), and refreshes `composer.lock` / `yarn.lock`.
> 
> **Minify:** `Minify_Cache_File` now resolves cache IDs through `_path_for_id()` so `store`, `fetch`, `display`, `getSize`, and `isValid` cannot write or read outside the minify cache root. Manual minify filename parsing tightens the template segment in `W3TC_MINIFY_MANUAL_FILENAME_REGEX` (alphanumeric, underscore, hyphen only). A standalone regression script `tests/test-minify-cache-id-path.php` exercises both behaviors.
> 
> **Output buffering:** `Generic_Plugin` documents and finalizes REST gating (`@since 2.10.3`): skip OB unless `pgcache.rest` is `cache`; when caching REST, run pagecache only and leave JSON untouched by HTML processors.
> 
> **Release hygiene:** Contributor docs and `bin/release.sh` now say to run `yarn run update:since` on the release branch before tagging so `@since X.X.X` placeholders are not left in the git tag. Prior `@since` placeholders are replaced with `2.10.2` / `2.10.3` where applicable.
> 
> Changelog also lists REST OB, minify containment, and Defer Scripts timeout placeholder fixes; the defer-scripts change is not in this diff (already on the branch per PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5010ddf58b12bba8da0bf8a793033c8821cfc5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->