### PR TITLE
Patch Release 2.10.4

### DIFF
--- a/Generic_AdminActions_Flush.php
+++ b/Generic_AdminActions_Flush.php
@@ -259,6 +259,10 @@ class Generic_AdminActions_Flush {
 	 */
 	public function w3tc_flush_post() {
 		$post_id = Util_Request::get_integer( 'post_id' );
+		if ( $post_id <= 0 ) {
+			$post_id = (int) Util_Environment::detect_post_id();
+		}
+
 		w3tc_flush_post( $post_id, true, array( 'ui_action' => 'flush_button' ) );
 
 		$this->_redirect_after_flush( 'pgcache_purge_post', __( 'purge Page cache for post', 'w3-total-cache' ) );

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -635,12 +635,9 @@ class Generic_Plugin {
 			}
 
 			if ( ! is_admin() ) {
-				$post_id           = (int) Util_Environment::detect_post_id();
-				$can_purge_current = $post_id > 0
-					? ( $is_full_admin || Util_Capability::can_flush_post_id( $post_id ) )
-					: ( $is_full_admin || Util_Capability::can_flush_post() );
+				$post_id = (int) Util_Environment::detect_post_id();
 
-				if ( $can_purge_current ) {
+				if ( $post_id > 0 && ( $is_full_admin || Util_Capability::can_flush_post_id( $post_id ) ) ) {
 					$menu_items['10020.generic'] = array(
 						'id'     => 'w3tc_flush_current_page',
 						'parent' => 'w3tc',

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -566,7 +566,7 @@ class Generic_Plugin {
 		 * Full Performance menu for manage_options; otherwise a purge-only
 		 * subset when the user has a filterable purge capability.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		if ( ! $is_full_admin && ! Util_Capability::user_can_purge_anything() ) {
 			return;
@@ -726,7 +726,7 @@ class Generic_Plugin {
 		 * filterable purge action (extensions may reuse an allowlisted id
 		 * with a dashboard-only link).
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		if ( ! $is_full_admin ) {
 			$menu_items = \array_filter(

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -129,7 +129,7 @@ class Generic_Plugin_Admin {
 	/**
 	 * Detect a dispatchable admin-action key from the current request.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param Root_AdminActions $executor Action executor.
 	 *
@@ -180,7 +180,7 @@ class Generic_Plugin_Admin {
 	/**
 	 * Execute allowlisted purge actions on admin_init (no W3TC menu required).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return void
 	 */
@@ -241,7 +241,7 @@ class Generic_Plugin_Admin {
 			 * keep the manage_options floor.
 			 *
 			 * @since 2.10.0
-			 * @since X.X.X Purge allowlist exception.
+			 * @since 2.10.4 Purge allowlist exception.
 			 */
 			if ( Util_Capability::is_purge_action( $action ) ) {
 				if ( ! Util_Capability::can_execute_purge( $action ) ) {
@@ -1214,7 +1214,7 @@ class Generic_Plugin_Admin {
 		/**
 		 * Filterable purge-all capability (default manage_options).
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		if ( ! Util_Capability::can_flush_all() ) {
 			return $actions;

--- a/Generic_Plugin_AdminRowActions.php
+++ b/Generic_Plugin_AdminRowActions.php
@@ -52,7 +52,7 @@ class Generic_Plugin_AdminRowActions {
 	/**
 	 * Append Purge from cache when the user may flush this post.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param array  $actions Actions.
 	 * @param object $post    Post.

--- a/UserExperience_LazyLoad_Mutator.php
+++ b/UserExperience_LazyLoad_Mutator.php
@@ -407,7 +407,7 @@ class UserExperience_LazyLoad_Mutator {
 	/**
 	 * Replace top-level quoted attributes, skipping matches inside other attribute values.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string   $content      Tag markup to rewrite.
 	 * @param string   $attr_pattern Attribute name or alternation (e.g. `src` or `srcset|sizes`).
@@ -468,7 +468,7 @@ class UserExperience_LazyLoad_Mutator {
 	/**
 	 * Read the first top-level quoted attribute value, or null if none.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string $content Tag markup.
 	 * @param string $attr    Attribute name.
@@ -500,7 +500,7 @@ class UserExperience_LazyLoad_Mutator {
 	/**
 	 * Whether the byte offset sits outside a quoted HTML attribute value.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string $content Tag markup.
 	 * @param int    $offset  Byte offset into $content.

--- a/UserExperience_LazyLoad_Mutator.php
+++ b/UserExperience_LazyLoad_Mutator.php
@@ -157,21 +157,25 @@ class UserExperience_LazyLoad_Mutator {
 	 * @return string The modified <img> tag.
 	 */
 	public function tag_img_content_replace( $content, $dim ) {
-		// do replace.
-		$w3tc_count = 0;
-		$content    = preg_replace(
-			'~(\s)src=~is',
-			'$1src="' . $this->placeholder( $dim['w'], $dim['h'] ) . '" data-src=',
+		$placeholder = $this->placeholder( $dim['w'], $dim['h'] );
+		$w3tc_count  = 0;
+		$content     = $this->replace_top_level_quoted_attributes(
 			$content,
-			-1,
+			'src',
+			static function ( $whitespace, $name, $quoted_value ) use ( $placeholder ) {
+				return $whitespace . 'src="' . $placeholder . '" data-src=' . $quoted_value;
+			},
+			1,
 			$w3tc_count
 		);
 
 		if ( $w3tc_count > 0 ) {
-			$content = preg_replace(
-				'~(\s)(srcset|sizes)=~is',
-				'$1data-$2=',
-				$content
+			$content = $this->replace_top_level_quoted_attributes(
+				$content,
+				'srcset|sizes',
+				static function ( $whitespace, $name, $quoted_value ) {
+					return $whitespace . 'data-' . $name . '=' . $quoted_value;
+				}
 			);
 
 			$content        = $this->add_class_lazy( $content );
@@ -206,17 +210,10 @@ class UserExperience_LazyLoad_Mutator {
 		}
 
 		// if not in attributes - try to find via url.
-		if (
-			! preg_match(
-				'~\ssrc=(\'([^\']*)\'|"([^"]*)"|([^\'"][^\\s]*))~is',
-				$content,
-				$m
-			)
-		) {
+		$w3tc_url = $this->get_top_level_quoted_attribute_value( $content, 'src' );
+		if ( null === $w3tc_url ) {
 			return $dim;
 		}
-
-		$w3tc_url = ( ! empty( $m[4] ) ? $m[4] : ( ( ! empty( $m[3] ) ? $m[3] : $m[2] ) ) );
 
 		// full url found.
 		if ( isset( $this->posts_by_url[ $w3tc_url ] ) ) {
@@ -401,7 +398,128 @@ class UserExperience_LazyLoad_Mutator {
 	 * @return string The SVG placeholder.
 	 */
 	public function placeholder( $w, $h ) {
-		return 'data:image/svg+xml,%3Csvg%20xmlns=\'http://www.w3.org/2000/svg\'%20viewBox=\'0%200%20' .
-			$w . '%20' . $h . '\'%3E%3C/svg%3E';
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' .
+			(int) $w . ' ' . (int) $h . '"></svg>';
+
+		return 'data:image/svg+xml,' . rawurlencode( $svg );
+	}
+
+	/**
+	 * Replace top-level quoted attributes, skipping matches inside other attribute values.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string   $content      Tag markup to rewrite.
+	 * @param string   $attr_pattern Attribute name or alternation (e.g. `src` or `srcset|sizes`).
+	 * @param callable $replacer     Callback `( $whitespace, $name, $quoted_value ) => string`.
+	 * @param int      $limit        Max replacements; -1 for all.
+	 * @param int      $count        Set to the number of replacements performed.
+	 *
+	 * @return string
+	 */
+	public function replace_top_level_quoted_attributes( $content, $attr_pattern, $replacer, $limit = -1, &$count = 0 ) {
+		$count = 0;
+
+		if ( ! preg_match_all(
+			'~(\s)(' . $attr_pattern . ')=(\'([^\']*)\'|"([^"]*)")~is',
+			$content,
+			$matches,
+			PREG_OFFSET_CAPTURE
+		) ) {
+			return $content;
+		}
+
+		$replacements = array();
+		foreach ( $matches[0] as $i => $full ) {
+			if ( $limit >= 0 && \count( $replacements ) >= $limit ) {
+				break;
+			}
+
+			$offset = $full[1];
+			if ( ! $this->is_outside_attribute_value( $content, $offset ) ) {
+				continue;
+			}
+
+			$replacements[] = array(
+				'offset'      => $offset,
+				'length'      => \strlen( $full[0] ),
+				'replacement' => \call_user_func(
+					$replacer,
+					$matches[1][ $i ][0],
+					$matches[2][ $i ][0],
+					$matches[3][ $i ][0]
+				),
+			);
+		}
+
+		for ( $i = \count( $replacements ) - 1; $i >= 0; $i-- ) {
+			$content = \substr_replace(
+				$content,
+				$replacements[ $i ]['replacement'],
+				$replacements[ $i ]['offset'],
+				$replacements[ $i ]['length']
+			);
+			++$count;
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Read the first top-level quoted attribute value, or null if none.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $content Tag markup.
+	 * @param string $attr    Attribute name.
+	 *
+	 * @return string|null
+	 */
+	public function get_top_level_quoted_attribute_value( $content, $attr ) {
+		if ( ! preg_match_all(
+			'~(\s)' . \preg_quote( $attr, '~' ) . '=(\'([^\']*)\'|"([^"]*)")~is',
+			$content,
+			$matches,
+			PREG_OFFSET_CAPTURE
+		) ) {
+			return null;
+		}
+
+		foreach ( $matches[0] as $i => $full ) {
+			if ( ! $this->is_outside_attribute_value( $content, $full[1] ) ) {
+				continue;
+			}
+
+			$quoted = $matches[2][ $i ][0];
+			return \substr( $quoted, 1, -1 );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the byte offset sits outside a quoted HTML attribute value.
+	 *
+	 * @since X.X.X
+	 *
+	 * @param string $content Tag markup.
+	 * @param int    $offset  Byte offset into $content.
+	 *
+	 * @return bool
+	 */
+	private function is_outside_attribute_value( $content, $offset ) {
+		$in = null;
+		for ( $i = 0; $i < $offset; $i++ ) {
+			$ch = $content[ $i ];
+			if ( null === $in ) {
+				if ( '"' === $ch || "'" === $ch ) {
+					$in = $ch;
+				}
+			} elseif ( $ch === $in ) {
+				$in = null;
+			}
+		}
+
+		return null === $in;
 	}
 }

--- a/UserExperience_LazyLoad_Mutator_Picture.php
+++ b/UserExperience_LazyLoad_Mutator_Picture.php
@@ -87,12 +87,12 @@ class UserExperience_LazyLoad_Mutator_Picture {
 	private function tag_source( $matches ) {
 		$content = $matches[0];
 
-		$content = preg_replace(
-			'~(\s)(srcset|sizes)=~i',
-			'$1data-$2=',
-			$content
+		return $this->common->replace_top_level_quoted_attributes(
+			$content,
+			'srcset|sizes',
+			static function ( $whitespace, $name, $quoted_value ) {
+				return $whitespace . 'data-' . $name . '=' . $quoted_value;
+			}
 		);
-
-		return $content;
 	}
 }

--- a/Util_Capability.php
+++ b/Util_Capability.php
@@ -285,11 +285,11 @@ class Util_Capability {
 
 		if ( 'w3tc_flush_post' === $action ) {
 			$post_id = Util_Request::get_integer( 'post_id' );
-			if ( $post_id > 0 ) {
-				return self::can_flush_post_id( $post_id );
+			if ( $post_id <= 0 ) {
+				$post_id = (int) Util_Environment::detect_post_id();
 			}
 
-			return self::can_flush_post();
+			return self::can_flush_post_id( $post_id );
 		}
 
 		return self::can_flush_current_page_request();

--- a/Util_Capability.php
+++ b/Util_Capability.php
@@ -6,7 +6,7 @@
  * settings, config save, extensions, and AJAX stay floored elsewhere.
  *
  * @package W3TC
- * @since   X.X.X
+ * @since   2.10.4
  */
 
 namespace W3TC;
@@ -14,14 +14,14 @@ namespace W3TC;
 /**
  * Class Util_Capability
  *
- * @since X.X.X
+ * @since 2.10.4
  */
 class Util_Capability {
 
 	/**
 	 * Admin-action keys that may use filterable purge caps.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @var string[]
 	 */
@@ -34,7 +34,7 @@ class Util_Capability {
 	/**
 	 * Admin-bar menu item ids allowed for non-manage_options purge users.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @var string[]
 	 */
@@ -49,7 +49,7 @@ class Util_Capability {
 	 *
 	 * Non-string or empty values fall back to manage_options.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param mixed $capability Filtered capability.
 	 *
@@ -69,7 +69,7 @@ class Util_Capability {
 	 * Applies `w3tc_capability_admin_bar`, then `w3tc_capability_flush_all`,
 	 * then `w3tc_capability_favorite_action_flush_all`.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return string
 	 */
@@ -84,7 +84,7 @@ class Util_Capability {
 		/**
 		 * Filters the capability required to purge all caches.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 *
 		 * @param string $capability Capability slug.
 		 */
@@ -106,7 +106,7 @@ class Util_Capability {
 	 * Applies `w3tc_capability_admin_bar`, then `w3tc_capability_flush_post`,
 	 * then `w3tc_capability_row_action_w3tc_flush_post`.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return string
 	 */
@@ -121,7 +121,7 @@ class Util_Capability {
 		/**
 		 * Filters the capability required to purge a specific post/page.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 *
 		 * @param string $capability Capability slug.
 		 */
@@ -140,7 +140,7 @@ class Util_Capability {
 	/**
 	 * Whether the current user may purge all caches.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return bool
 	 */
@@ -151,7 +151,7 @@ class Util_Capability {
 	/**
 	 * Whether the current user may purge posts/pages (role-level gate).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return bool
 	 */
@@ -164,7 +164,7 @@ class Util_Capability {
 	 *
 	 * Requires the filtered flush-post capability and edit_post for the id.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param int $post_id Post ID.
 	 *
@@ -187,7 +187,7 @@ class Util_Capability {
 	/**
 	 * Whether the current user has any purge privilege.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return bool
 	 */
@@ -201,7 +201,7 @@ class Util_Capability {
 	 * Uses a purge cap the current user already satisfies so flush-all-only
 	 * grants still show the parent item.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return string
 	 */
@@ -220,7 +220,7 @@ class Util_Capability {
 	/**
 	 * Whether an admin-action key is a filterable purge action.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string $action Dispatcher handler key.
 	 *
@@ -237,7 +237,7 @@ class Util_Capability {
 	 * a filterable purge action — extensions may reuse an allowlisted id with
 	 * a dashboard-only link.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param array $item Admin-bar menu item.
 	 *
@@ -268,7 +268,7 @@ class Util_Capability {
 	/**
 	 * Whether the current user may execute a purge admin-action.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string $action Dispatcher handler key.
 	 *
@@ -301,7 +301,7 @@ class Util_Capability {
 	 * Flush-all may clear any same-host URL. Flush-post requires edit_post on
 	 * the post resolved from the URL.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @return bool
 	 */
@@ -335,7 +335,7 @@ class Util_Capability {
 	/**
 	 * Build a nonce-protected admin URL for a purge action (no W3TC page).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 *
 	 * @param string              $action Dispatcher handler key.
 	 * @param array<string,mixed> $args   Extra query args (e.g. post_id).

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 === W3 Total Cache Changelog ===
 
+= 2.10.4 =
+* Fix: Lazy Load: Match only quoted image attributes when rewriting src/srcset/sizes
+* Fix: Cache purge: Restore filterable capabilities for purge-all and purge-post
+
 = 2.10.3 =
 * Fix: Output buffering: Skip REST API requests unless page cache REST caching is enabled
 * Fix: Minify: Keep cache file operations within the cache directory

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: boldgrid, fredericktownes, maxicusc, gidomanders, bwmarkle, harryj
 Tags: CDN, pagespeed, caching, performance, optimize
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 2.10.3
+Stable tag: 2.10.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -365,6 +365,10 @@ Please reach out to all of these people and support their projects if you're so 
 
 == Changelog ==
 
+= 2.10.4 =
+* Fix: Lazy Load: Match only quoted image attributes when rewriting src/srcset/sizes
+* Fix: Cache purge: Restore filterable capabilities for purge-all and purge-post
+
 = 2.10.3 =
 * Fix: Output buffering: Skip REST API requests unless page cache REST caching is enabled
 * Fix: Minify: Keep cache file operations within the cache directory
@@ -555,6 +559,10 @@ Please reach out to all of these people and support their projects if you're so 
 * Update: Added Premium Services tabs
 
 == Upgrade Notice ==
+
+= 2.10.4 =
+This update restores filterable cache-purge capabilities and improves Lazy Load image attribute handling. All users are encouraged to update.
+
 
 = 2.10.3 =
 This update resolves Block Editor save failures related to output buffering and restores Defer Scripts timeout configuration. All users are encouraged to update.

--- a/tests/admin/class-w3tc-purge-capability-test.php
+++ b/tests/admin/class-w3tc-purge-capability-test.php
@@ -158,6 +158,47 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Missing post_id still object-gates when a post is resolved another way.
+	 *
+	 * @since 2.10.4
+	 */
+	public function test_flush_post_without_post_id_still_requires_edit_post() {
+		\add_filter( 'w3tc_capability_flush_post', static function () {
+			return 'edit_posts';
+		} );
+
+		$admin_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$post_id   = $this->factory->post->create(
+			array(
+				'post_author' => $admin_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( $author_id );
+		$this->assertTrue( Util_Capability::can_flush_post() );
+		$this->assertFalse( Util_Capability::can_flush_post_id( $post_id ) );
+
+		$this->assertFalse( Util_Capability::can_execute_purge( 'w3tc_flush_post' ) );
+
+		$_GET['p'] = (string) $post_id;
+		$this->assertFalse( Util_Capability::can_execute_purge( 'w3tc_flush_post' ) );
+		unset( $_GET['p'] );
+
+		$own_post_id = $this->factory->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$_GET['p'] = (string) $own_post_id;
+		$this->assertTrue( Util_Capability::can_execute_purge( 'w3tc_flush_post' ) );
+		unset( $_GET['p'] );
+	}
+
+	/**
 	 * Invalid filter returns fall back to manage_options.
 	 *
 	 * @since 2.10.4

--- a/tests/admin/class-w3tc-purge-capability-test.php
+++ b/tests/admin/class-w3tc-purge-capability-test.php
@@ -7,7 +7,7 @@
  *
  * @package    W3TC
  * @subpackage W3TC/tests/admin
- * @since      X.X.X
+ * @since      2.10.4
  */
 
 declare( strict_types = 1 );
@@ -17,14 +17,14 @@ use W3TC\Util_Capability;
 /**
  * Class: W3tc_Purge_Capability_Test
  *
- * @since X.X.X
+ * @since 2.10.4
  */
 class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tear down filters and user.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function tear_down() {
 		\remove_all_filters( 'w3tc_capability_flush_all' );
@@ -39,7 +39,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Default (no filters): only manage_options can purge.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_default_admin_can_purge_editor_cannot() {
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
@@ -58,7 +58,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Filter flush_all to edit_posts: editor can purge all, not implied for post-only separation.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_filter_flush_all_grants_editor() {
 		\add_filter( 'w3tc_capability_flush_all', static function () {
@@ -78,7 +78,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Filter flush_post only: editor can purge posts they can edit.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_filter_flush_post_requires_edit_post() {
 		\add_filter( 'w3tc_capability_flush_post', static function () {
@@ -115,7 +115,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Low-cap filter is honored (ill-advised but possible).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_filter_read_honored_for_flush_all() {
 		\add_filter( 'w3tc_capability_flush_all', static function () {
@@ -132,7 +132,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Purge-current-page with a post_id uses the object gate (UI and action align).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_flush_post_with_post_id_requires_edit_post() {
 		\add_filter( 'w3tc_capability_flush_post', static function () {
@@ -160,7 +160,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Invalid filter returns fall back to manage_options.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_invalid_filter_returns_manage_options() {
 		\add_filter( 'w3tc_capability_flush_all', static function () {
@@ -178,7 +178,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Subscriber without filter cannot purge even with a valid mental model of nonce.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_subscriber_without_filter_cannot_purge() {
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -192,7 +192,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Legacy admin_bar filter grants both purge caps (historical agency pattern).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_legacy_admin_bar_filter_grants_purge() {
 		\add_filter( 'w3tc_capability_admin_bar', static function () {
@@ -209,7 +209,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Flush-all-only must still resolve an admin-bar parent cap the editor can meet.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_admin_bar_parent_cap_with_flush_all_only() {
 		\add_filter( 'w3tc_capability_flush_all', static function () {
@@ -228,7 +228,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Flush-post-only parent cap uses flush-post.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_admin_bar_parent_cap_with_flush_post_only() {
 		\add_filter( 'w3tc_capability_flush_post', static function () {
@@ -245,7 +245,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Non-purge actions stay outside the allowlist.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_non_purge_actions_not_allowlisted() {
 		$this->assertFalse( Util_Capability::is_purge_action( 'w3tc_flush_pgcache' ) );
@@ -259,7 +259,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Admin-bar allowlist rejects reused ids that do not target purge actions.
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_admin_bar_item_requires_purge_action_href() {
 		$this->assertTrue(
@@ -291,7 +291,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * URL flush requires a same-host URL and edit_post (or flush-all).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_flush_current_page_requires_edit_post_for_url() {
 		\add_filter(
@@ -348,7 +348,7 @@ class W3tc_Purge_Capability_Test extends WP_UnitTestCase {
 	/**
 	 * Editor with purge filters still lacks manage_options (settings stay sealed).
 	 *
-	 * @since X.X.X
+	 * @since 2.10.4
 	 */
 	public function test_purge_filter_does_not_grant_manage_options() {
 		\add_filter( 'w3tc_capability_flush_all', static function () {

--- a/tests/admin/class-w3tc-userexperience-lazyload-mutator.php
+++ b/tests/admin/class-w3tc-userexperience-lazyload-mutator.php
@@ -118,7 +118,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Substring "src=" inside a single-quoted alt value is left alone.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_ignores_src_substring_in_alt() {
 				$mutator = $this->get_mutator();
@@ -135,7 +135,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Double-quoted alt containing a quoted src= fragment is left alone.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_ignores_quoted_src_fragment_in_alt() {
 				$mutator = $this->get_mutator();
@@ -150,7 +150,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Opposite-quote src= text inside a double-quoted alt is left alone.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_ignores_opposite_quote_src_in_double_alt() {
 				$mutator = $this->get_mutator();
@@ -166,7 +166,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Opposite-quote src= text inside a single-quoted alt is left alone.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_ignores_opposite_quote_src_in_single_alt() {
 				$mutator = $this->get_mutator();
@@ -182,7 +182,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Double-quoted src values may contain an apostrophe.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_allows_apostrophe_in_double_quoted_src() {
 				$mutator = $this->get_mutator();
@@ -197,7 +197,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Placeholder data-URI contains no literal apostrophe or quote characters.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_placeholder_has_no_literal_quotes() {
 				$mutator    = $this->get_mutator();
@@ -212,7 +212,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Single-quoted src attributes still convert to lazy-load form.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_tag_img_content_replace_handles_single_quoted_src() {
 				$mutator = $this->get_mutator();
@@ -228,7 +228,7 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 		/**
 		 * Picture source and image attributes are converted to lazy-load form.
 		 *
-		 * @since X.X.X
+		 * @since 2.10.4
 		 */
 		public function test_picture_source_and_image_attributes_are_replaced() {
 				$picture = new UserExperience_LazyLoad_Mutator_Picture( $this->get_mutator() );

--- a/tests/admin/class-w3tc-userexperience-lazyload-mutator.php
+++ b/tests/admin/class-w3tc-userexperience-lazyload-mutator.php
@@ -12,6 +12,7 @@
 declare( strict_types = 1 );
 
 use W3TC\UserExperience_LazyLoad_Mutator;
+use W3TC\UserExperience_LazyLoad_Mutator_Picture;
 
 /**
  * Class: W3tc_UserExperience_LazyLoad_Test
@@ -112,5 +113,134 @@ class W3tc_UserExperience_LazyLoad_Mutator_Test extends WP_UnitTestCase {
 				$this->assertStringContainsString( 'data-bg="bg.jpg"', $result );
 				$this->assertStringNotContainsString( 'background-image', $result );
 				$this->assertStringContainsString( 'style="color:red;"', $result );
+		}
+
+		/**
+		 * Substring "src=" inside a single-quoted alt value is left alone.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_ignores_src_substring_in_alt() {
+				$mutator = $this->get_mutator();
+				$img     = "<img alt='avatar src=x data-marker=value name' src='avatar.jpg' width='96' height='96'>";
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 96, 'h' => 96 ) );
+
+				$this->assertStringContainsString( "alt='avatar src=x data-marker=value name'", $result );
+				$this->assertStringContainsString( "data-src='avatar.jpg'", $result );
+				$this->assertStringNotContainsString( 'data-src=x', $result );
+				$this->assertMatchesRegularExpression( '/\ssrc="data:image\\/svg\\+xml,/', $result );
+		}
+
+		/**
+		 * Double-quoted alt containing a quoted src= fragment is left alone.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_ignores_quoted_src_fragment_in_alt() {
+				$mutator = $this->get_mutator();
+				$img     = '<img alt="photo src=&quot;x&quot; title" src="photo.jpg" width="10" height="10">';
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 10, 'h' => 10 ) );
+
+				$this->assertStringContainsString( 'alt="photo src=&quot;x&quot; title"', $result );
+				$this->assertStringContainsString( 'data-src="photo.jpg"', $result );
+		}
+
+		/**
+		 * Opposite-quote src= text inside a double-quoted alt is left alone.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_ignores_opposite_quote_src_in_double_alt() {
+				$mutator = $this->get_mutator();
+				$img     = '<img alt="photo src=\'x\' data-marker=1" src="photo.jpg" width="10" height="10">';
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 10, 'h' => 10 ) );
+
+				$this->assertStringContainsString( 'alt="photo src=\'x\' data-marker=1"', $result );
+				$this->assertStringContainsString( 'data-src="photo.jpg"', $result );
+				$this->assertStringNotContainsString( "data-src='x'", $result );
+		}
+
+		/**
+		 * Opposite-quote src= text inside a single-quoted alt is left alone.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_ignores_opposite_quote_src_in_single_alt() {
+				$mutator = $this->get_mutator();
+				$img     = "<img alt='photo src=\"x\" data-marker=1' src='photo.jpg' width='10' height='10'>";
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 10, 'h' => 10 ) );
+
+				$this->assertStringContainsString( "alt='photo src=\"x\" data-marker=1'", $result );
+				$this->assertStringContainsString( "data-src='photo.jpg'", $result );
+				$this->assertStringNotContainsString( 'data-src="x"', $result );
+		}
+
+		/**
+		 * Double-quoted src values may contain an apostrophe.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_allows_apostrophe_in_double_quoted_src() {
+				$mutator = $this->get_mutator();
+				$img     = '<img src="image\'s.jpg" width="10" height="10">';
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 10, 'h' => 10 ) );
+
+				$this->assertStringContainsString( 'data-src="image\'s.jpg"', $result );
+				$this->assertMatchesRegularExpression( '/\ssrc="data:image\\/svg\\+xml,/', $result );
+		}
+
+		/**
+		 * Placeholder data-URI contains no literal apostrophe or quote characters.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_placeholder_has_no_literal_quotes() {
+				$mutator    = $this->get_mutator();
+				$placeholder = $mutator->placeholder( 10, 20 );
+
+				$this->assertStringStartsWith( 'data:image/svg+xml,', $placeholder );
+				$this->assertStringNotContainsString( "'", $placeholder );
+				$this->assertStringNotContainsString( '"', $placeholder );
+				$this->assertStringContainsString( 'viewBox', $placeholder );
+		}
+
+		/**
+		 * Single-quoted src attributes still convert to lazy-load form.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_tag_img_content_replace_handles_single_quoted_src() {
+				$mutator = $this->get_mutator();
+				$img     = "<img src='image.jpg' width='10' height='10'>";
+
+				$result = $mutator->tag_img_content_replace( $img, array( 'w' => 10, 'h' => 10 ) );
+
+				$this->assertStringContainsString( "data-src='image.jpg'", $result );
+				$this->assertMatchesRegularExpression( '/\ssrc="data:image\\/svg\\+xml,/', $result );
+				$this->assertMatchesRegularExpression( '/class="[^"]*lazy[^"]*"/', $result );
+		}
+
+		/**
+		 * Picture source and image attributes are converted to lazy-load form.
+		 *
+		 * @since X.X.X
+		 */
+		public function test_picture_source_and_image_attributes_are_replaced() {
+				$picture = new UserExperience_LazyLoad_Mutator_Picture( $this->get_mutator() );
+				$content = '<picture><source srcset="image.webp 1x, image-2x.webp 2x" sizes="100vw">' .
+					'<img alt="image src=opaque" src="image.jpg" width="10" height="10"></picture>';
+
+				$result = $picture->run( $content );
+
+				$this->assertStringContainsString( 'data-srcset="image.webp 1x, image-2x.webp 2x"', $result );
+				$this->assertStringContainsString( 'data-sizes="100vw"', $result );
+				$this->assertStringContainsString( 'alt="image src=opaque"', $result );
+				$this->assertStringContainsString( 'data-src="image.jpg"', $result );
+				$this->assertMatchesRegularExpression( '/\ssrc="data:image\\/svg\\+xml,/', $result );
 		}
 }

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -10,7 +10,7 @@
 defined( 'ABSPATH' ) || die;
 
 define( 'W3TC', true );
-define( 'W3TC_VERSION', '2.10.3' );
+define( 'W3TC_VERSION', '2.10.4' );
 define( 'W3TC_POWERED_BY', 'W3 Total Cache' );
 define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name:       W3 Total Cache
  * Plugin URI:        https://www.boldgrid.com/totalcache/
  * Description:       The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
- * Version:           2.10.3
+ * Version:           2.10.4
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            BoldGrid


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-4790

## Summary
- Patch release 2.10.4 (version bump, changelog, upgrade notice)
- Lazy Load: match only quoted image attributes when rewriting `src` / `srcset` / `sizes`
- Cache purge: restore filterable capabilities for purge-all and purge-post (already on master; changelog / `@since` aligned for 2.10.4)

## Test plan
- [x] Confirm version constants / Stable tag are `2.10.4`
- [x] Confirm `readme.txt` / `changelog.txt` 2.10.4 entries match intended release notes
- [x] Smoke Lazy Load: images/avatars with quoted attributes still rewrite; attribute values containing quote-like fragments are left alone
- [x] Smoke editor purge: filterable purge capabilities still apply for purge-all / purge-post
- [x] Run `./vendor/bin/phpunit tests/userexperience/class-w3tc-userexperience-lazyload-mutator.php`
- [x] Run `./vendor/bin/phpunit tests/admin/class-w3tc-purge-capability-test.php`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes front-end HTML mutation and cache-purge authorization paths; behavior is covered by new tests but mis-parsing or cap checks could affect editors or image markup.
> 
> **Overview**
> **Patch release 2.10.4** bumps plugin/readme version constants and documents two fixes in changelog/readme.
> 
> **Lazy Load** rewrites `src`, `srcset`, and `sizes` only on **top-level quoted** attributes (new helpers skip matches inside other attribute values), and builds SVG placeholders via `rawurlencode` instead of hand-escaped markup. `<picture>` `<source>` tags use the same path as `<img>`.
> 
> **Cache purge** keeps **filterable** purge-all / purge-post capabilities (`Util_Capability`, admin-bar subset, purge actions without opening full W3TC settings). **Purge current page** shows only when a post ID is detected and the user passes per-post checks; `w3tc_flush_post` authorization and flushing **fall back to** `Util_Environment::detect_post_id()` when `post_id` is missing. `@since` tags are set to 2.10.4; unit tests cover lazy-load edge cases and purge caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9a820a65d98d6d61dcaec0c14cb28b273a85c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->