### PR TITLE
ENG7-4846: Defer footer comment and query conditionals until WP load completes

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -1000,7 +1000,12 @@ class Generic_Plugin {
 		} else {
 			$buffer = apply_filters( 'w3tc_process_content', $buffer );
 
-			if ( Util_Content::can_print_comment( $buffer ) ) {
+			/**
+			 * The buffer is also flushed when a request aborts before the WordPress load completes.
+			 * Building the footer comment then would translate strings before the text domain is
+			 * available, so the comment is only added once the load has reached init.
+			 */
+			if ( \did_action( 'init' ) && Util_Content::can_print_comment( $buffer ) ) {
 				/**
 				 * Add footer comment
 				 */

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -206,7 +206,7 @@ class Minify_Plugin {
 		$css_enable  = $this->_config->get_boolean( 'minify.css.enable' );
 		$html_enable = $this->_config->get_boolean( 'minify.html.enable' );
 
-		if ( function_exists( 'is_feed' ) && is_feed() ) {
+		if ( $this->is_query_available() && is_feed() ) {
 			$js_enable  = false;
 			$css_enable = false;
 		}
@@ -642,7 +642,7 @@ var extsrc=null;
 			$w3tc_engine = 'html';
 		}
 
-		if ( function_exists( 'is_feed' ) && is_feed() ) {
+		if ( $this->is_query_available() && is_feed() ) {
 			$w3tc_engine .= 'xml';
 		}
 
@@ -984,6 +984,21 @@ var extsrc=null;
 	}
 
 	/**
+	 * Checks whether WordPress conditional query tags can be evaluated.
+	 *
+	 * Conditional tags always return false and emit a notice when the main query has not run,
+	 * which happens when a request aborts before the WordPress load completes but the output
+	 * buffer is still flushed.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return bool True when conditional query tags are safe to call.
+	 */
+	private function is_query_available() {
+		return \function_exists( 'is_feed' ) && isset( $GLOBALS['wp_query'] );
+	}
+
+	/**
 	 * Checks whether minification can be applied to the provided buffer.
 	 *
 	 * @param string $buffer The buffer to check.
@@ -999,7 +1014,7 @@ var extsrc=null;
 		}
 
 		// Check feed minify.
-		if ( $this->_config->get_boolean( 'minify.html.reject.feed' ) && function_exists( 'is_feed' ) && is_feed() ) {
+		if ( $this->_config->get_boolean( 'minify.html.reject.feed' ) && $this->is_query_available() && is_feed() ) {
 			$this->minify_reject_reason = 'Feed is rejected';
 
 			return false;


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-4846

## Summary

W3 Total Cache starts its output buffer at plugin-load time, well before WordPress finishes loading. When another plugin ends the request early — most commonly a security plugin serving a "403 Forbidden" block page and calling `exit` — PHP still flushes that buffer during shutdown, so `Generic_Plugin::ob_callback()` runs against a half-loaded WordPress.

Two `_doing_it_wrong()` notices result:

- The `w3tc_footer_comment` filter builds translated strings, so `__()` is called before the text domain can be loaded. WordPress reports `Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the w3-total-cache domain was triggered too early.` Twelve footer-comment callbacks contain `__()`, so which one appears in the trace depends on the enabled caching modules.
- `Minify_Plugin::ob_callback()` calls `is_feed()`, producing `Conditional query tags do not work before the query is run.` The existing `function_exists( 'is_feed' )` guards do not help, because that function always exists; the missing check is whether the main query has run.

Neither notice is locale-dependent. Both reproduce on an English site with no language pack installed, because the plugin ships a `languages/` directory that the text domain registry resolves for any locale.

Reported at https://wordpress.org/support/topic/php-notice-258/.

## Changes

- `Generic_Plugin::ob_callback()` now adds the footer comment only once `init` has fired. The comment carries no useful information on an aborted request, and gating it in one place covers every `w3tc_footer_comment` callback rather than guarding each translated string individually. Gating on `init` rather than `after_setup_theme` keeps the fix effective across the supported WordPress range, since the version that introduced this notice checked `init`.
- `Minify_Plugin` gains a small `is_query_available()` helper that confirms the main query exists, and the three `function_exists( 'is_feed' )` guards now use it.

No behavior change for normal requests.

## Test plan

- [x] Reproduced both notices before the change by ending a request at `plugins_loaded` with the page cache active, capturing `doing_it_wrong_run` directly.
- [x] Confirmed the exit-point matrix: notices fire when the request ends at `plugins_loaded`, and not at `muplugins_loaded`, `after_setup_theme`, `init`, or `wp_loaded`.
- [x] Both notices gone after the change at every tested exit point.
- [x] Footer comment still emitted on normal front-end responses, with unchanged content.
- [x] Page cache MISS/HIT timings unchanged (roughly 0.44s cold, 0.06s warm on the test site).
- [x] Feed request still returns valid RSS with the correct content type.
- [x] Admin smoke across administrator, editor, and subscriber roles matches the pre-change baseline, including the expected capability denials on the plugin's admin pages.
- [x] PHPUnit suite: 302 tests, 1105 assertions, all passing.
- [x] Standalone test scripts pass.
- [x] `php -l` and `phpcs` clean on both changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guards for aborted requests; normal front-end, feed, and cache behavior is unchanged per the PR test plan.
> 
> **Overview**
> When W3TC’s output buffer flushes on **early-terminated** requests (e.g. a security plugin `exit` before WordPress finishes loading), this PR stops two `_doing_it_wrong()` notices without changing normal page behavior.
> 
> **`Generic_Plugin::ob_callback()`** only appends the HTML footer comment (and runs `w3tc_footer_comment`, which calls `__()`) after **`init` has fired**, so translations are not triggered before the `w3-total-cache` text domain is ready.
> 
> **`Minify_Plugin`** adds **`is_query_available()`** (`is_feed` exists and `$GLOBALS['wp_query']` is set) and uses it everywhere **`is_feed()`** was previously guarded only with `function_exists( 'is_feed' )`, avoiding “conditional query tags do not work before the query is run” during the same shutdown flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9527c4b3883eb209d0b79a194a8a663bf98b36f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->