### PR TITLE
ENG7-4894: Restore placeholder unescape for DB Cluster queries

### DIFF
--- a/DbCache_WpdbNew.php
+++ b/DbCache_WpdbNew.php
@@ -213,6 +213,9 @@ class DbCache_WpdbNew extends DbCache_WpdbBase {
 	 * @return mixed The result of the query.
 	 */
 	public function query( $query ) {
+		// Cluster reimplements query and skips core's `query` filter / placeholder unescape.
+		$query = $this->remove_placeholder_escape( $query );
+
 		return $this->active_processor->query( $query );
 	}
 


### PR DESCRIPTION
## Summary
* Database Cluster skipped WordPress placeholder-escape removal, so admin post search (`LIKE '%…%'`) failed with `{hmac}` tokens left in SQL.
* Call `remove_placeholder_escape()` in `DbCache_WpdbNew::query()` before injection processors so Cluster (and Query Caching) receive correct SQL.

Jira: https://imh-internal.atlassian.net/browse/ENG7-4894

## Test plan
- [ ] With Database Cluster enabled, WP Admin → Posts search for a known term returns matches
- [ ] Confirm SQL / debug log uses `%` wildcards, not `{…}` placeholder tokens
- [ ] With DB Cache only (no cluster), search still works
- [ ] Queries without `%` / placeholder escape behave as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix mirroring WordPress core’s existing `wpdb::query()` step; low blast radius aside from correcting broken wildcard SQL.
> 
> **Overview**
> **Database Cluster** routes SQL through `DbCache_WpdbNew::query()` instead of core `wpdb::query()`, so WordPress’s placeholder-escape cleanup never ran. Queries that use `%` wildcards (e.g. admin post search) could reach MySQL still containing `{hmac}` tokens instead of `%`, breaking matches.
> 
> This PR runs `remove_placeholder_escape()` on the query string **before** handing it to cluster/query-cache processors, aligning behavior with core and restoring correct `LIKE` search when Database Cluster (or the same query path) is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f1714b3006e05d14941d5f8355c1c63842892a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->