### PR TITLE
Normalize document_root() output after realpath() so Page Cache rewrite rules work on Windows

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -743,6 +743,7 @@ class Util_Environment {
 
 		if ( $docroot_fix ) {
 			$document_root = untrailingslashit( ABSPATH );
+			$document_root = self::normalize_path( $document_root );
 			return $document_root;
 		}
 
@@ -756,6 +757,7 @@ class Util_Environment {
 			if ( substr( $script_filename, -strlen( $php_self ) ) === $php_self ) {
 				$document_root = substr( $script_filename, 0, -strlen( $php_self ) );
 				$document_root = realpath( $document_root );
+				$document_root = self::normalize_path( $document_root );
 				return $document_root;
 			}
 		}
@@ -773,6 +775,7 @@ class Util_Environment {
 		}
 
 		$document_root = realpath( $document_root );
+		$document_root = self::normalize_path( $document_root );
 		return $document_root;
 	}
 


### PR DESCRIPTION


`Util_Environment::document_root()` returns the raw output of `realpath()` at two of its return points without normalizing the directory separators. On Windows `realpath()` returns back-slashes (and a drive letter), so the returned path does not match the forward-slash-normalized cache directory that other code compares it against. As a result `PgCache_Environment::apache_cache_uri_path()` fails to relativize the cache path and falls back to the absolute path, producing a broken Disk: Enhanced serve rule.

This makes `document_root()` consistent with its sibling `site_root()` in the same file, which already normalizes after `realpath()`. 

### Symptom (Disk: Enhanced on Windows)

The generated `.htaccess` serve rule ends up glueing `%{DOCUMENT_ROOT}` onto an absolute filesystem path, for example:

```
RewriteCond "%{DOCUMENT_ROOT}C:/path/to/site/wp-content/cache/page_enhanced/%{HTTP_HOST}/.../_index....html" -f
```

The `-f` test can never succeed against that path, so every request falls through to PHP (advanced-cache.php) instead of being served statically. Page caching still produces correct files, but the static-serve fast path is silently lost.

### Root cause

`site_root()` normalizes after `realpath()`:

```php
public static function site_root() {
    $site_root = ABSPATH;
    $site_root = realpath( $site_root );
    $site_root = self::normalize_path( $site_root );   // normalized
    return $site_root;
}
```

`document_root()` does not - it returns the raw `realpath()` result. On Windows that value contains back-slashes, so downstream string comparisons against the forward-slash cache directory (in `apache_cache_uri_path()`) miss, and the code falls back to emitting the absolute path.

### Fix

Add `self::normalize_path()` before each return in `document_root()`, so the function always returns a forward-slash path regardless of platform - matching `site_root()`.

### Testing

- Linux is unaffected: `realpath()` already returns forward slashes, so `normalize_path()` is a no-op there and the emitted rewrite rules are unchanged.
- Windows: the emitted Disk: Enhanced serve `RewriteCond` becomes web-root-relative (`%{DOCUMENT_ROOT}/wp-content/cache/page_enhanced/...`), and Apache serves the cached file statically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-targeted path normalization in environment helpers; Linux paths are unchanged and the change only affects how document root strings are formatted for comparisons and rewrite rules.
> 
> **Overview**
> **`Util_Environment::document_root()`** now runs **`normalize_path()`** on every return path, including after **`realpath()`** and on the **`docroot_fix`** branch. That aligns it with **`site_root()`**, which already normalized post-`realpath()` output.
> 
> On Windows, raw **`realpath()`** backslashes broke string comparisons against forward-slash cache paths in Disk: Enhanced rewrite generation (e.g. **`PgCache_Environment::apache_cache_uri_path()`**), so **`.htaccess`** **`RewriteCond`** paths stayed absolute and static serve never matched. Linux behavior is unchanged because normalization is effectively a no-op when paths already use forward slashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14aadadaacd1c6e6d62e93401d6d002f7759e65c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->