### PR TITLE
Page Cache: add w3tc_pgcache_rules_required filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,11 @@ Run the standalone cache-unserialize helper test (no WordPress bootstrap needed)
 php tests/test-cache-unserialize.php
 ```
 
+Run the standalone page-cache rules-required filter test (no WordPress bootstrap needed):
+```bash
+php tests/test-pgcache-rules-required-filter.php
+```
+
 #### Writing new standalone tests
 
 Standalone test files in `tests/` use a realpath-guard at the top so they exit early when PHPUnit auto-discovers them, e.g.:

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1313,8 +1313,15 @@ class PgCache_ContentGrabber {
 			return;
 		}
 
-		// we call it as little times as possible its expensive, but have to restore lost .htaccess file.
 		$e = Dispatcher::component( 'PgCache_Environment' );
+
+		// When the "w3tc_pgcache_rules_required" filter suppresses the rules this file is never
+		// written, so without the exit the restore below would repeat on every cache miss.
+		if ( null === $e->get_required_rules( $this->_config ) ) {
+			return;
+		}
+
+		// we call it as little times as possible its expensive, but have to restore lost .htaccess file.
 		try {
 			$e->fix_on_wpadmin_request( $this->_config, true );
 		} catch ( \Exception $ex ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -74,7 +74,8 @@ class PgCache_Environment {
 				if ( $pgcache_enabled && 'file_generic' === $w3tc_engine ) {
 					$this->verify_file_generic_compatibility();
 
-					if ( $w3tc_config->get_boolean( 'pgcache.debug' ) ) {
+					// The rewrite test only makes sense while W3TC owns the rules.
+					if ( $w3tc_config->get_boolean( 'pgcache.debug' ) && $this->is_rules_required( $w3tc_config ) ) {
 						$this->verify_file_generic_rewrite_working();
 					}
 				}
@@ -242,7 +243,26 @@ class PgCache_Environment {
 	private function is_rules_required( $w3tc_c ) {
 		$e = $w3tc_c->get_string( 'pgcache.engine' );
 
-		return $w3tc_c->get_boolean( 'pgcache.enabled' ) && ( 'file_generic' === $e || 'nginx_memcached' === $e );
+		$required = $w3tc_c->get_boolean( 'pgcache.enabled' ) && ( 'file_generic' === $e || 'nginx_memcached' === $e );
+
+		/**
+		 * Filter: Allow external code to suppress the page-cache rewrite rules.
+		 *
+		 * Returning false stops W3TC from writing its page-cache rewrite rules and removes the
+		 * core rules it wrote earlier, on both the Apache and the nginx path. Cache generation
+		 * is untouched, so pages keep being cached and delivery can be handled elsewhere - by a
+		 * server module, for example.
+		 *
+		 * The filter can only suppress: it is not consulted for configurations that do not use
+		 * rewrite rules in the first place, so it cannot emit rules for them.
+		 *
+		 * @since X.X.X
+		 *
+		 * @param bool   $required Whether page-cache rewrite rules are required. Always true here,
+		 *                         since the filter runs only when W3TC would write the rules.
+		 * @param Config $w3tc_c   W3TC Config containing relevant settings.
+		 */
+		return $required && (bool) \apply_filters( 'w3tc_pgcache_rules_required', $required, $w3tc_c );
 	}
 
 	/**

--- a/tests/test-pgcache-rules-required-filter.php
+++ b/tests/test-pgcache-rules-required-filter.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Standalone test for the "w3tc_pgcache_rules_required" filter.
+ *
+ * Run with: php tests/test-pgcache-rules-required-filter.php
+ *
+ * @package W3TC\Tests
+ * @since   X.X.X
+ */
+
+if ( \realpath( __FILE__ ) !== \realpath( $_SERVER['SCRIPT_FILENAME'] ?? '' ) ) {
+	return;
+}
+
+$prr_cases = array();
+$prr_pass  = 0;
+$prr_fail  = 0;
+
+$GLOBALS['prr_filters'] = array();
+
+if ( ! \function_exists( 'add_filter' ) ) {
+	/**
+	 * Minimal add_filter() stub.
+	 *
+	 * @param string   $tag      Filter name.
+	 * @param callable $callback Callback.
+	 *
+	 * @return void
+	 */
+	function add_filter( $tag, $callback ) {
+		$GLOBALS['prr_filters'][ $tag ][] = $callback;
+	}
+}
+
+if ( ! \function_exists( 'apply_filters' ) ) {
+	/**
+	 * Minimal apply_filters() stub.
+	 *
+	 * @param string $tag   Filter name.
+	 * @param mixed  $value Value being filtered.
+	 *
+	 * @return mixed
+	 */
+	function apply_filters( $tag, $value ) {
+		$args = \array_slice( \func_get_args(), 2 );
+
+		foreach ( $GLOBALS['prr_filters'][ $tag ] ?? array() as $callback ) {
+			$value = \call_user_func_array( $callback, \array_merge( array( $value ), $args ) );
+		}
+
+		return $value;
+	}
+}
+
+require_once \dirname( __DIR__ ) . '/PgCache_Environment.php';
+
+/**
+ * Records the outcome of one assertion.
+ *
+ * @param string $label       Case description.
+ * @param bool   $expectation Assertion result.
+ * @param string $detail      Optional detail printed on failure.
+ *
+ * @return void
+ */
+function prr_assert( string $label, bool $expectation, string $detail = '' ): void {
+	global $prr_cases, $prr_pass, $prr_fail;
+
+	if ( $expectation ) {
+		++$prr_pass;
+		$prr_cases[] = array( 'PASS', $label );
+
+		return;
+	}
+
+	++$prr_fail;
+	$prr_cases[] = array( 'FAIL', $label . ( $detail ? ' | ' . $detail : '' ) );
+}
+
+/**
+ * Config stub exposing only what is_rules_required() reads.
+ */
+class PRR_Config_Stub {
+	/**
+	 * Values keyed by config key.
+	 *
+	 * @var array
+	 */
+	private $values;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $values Values keyed by config key.
+	 */
+	public function __construct( array $values ) {
+		$this->values = $values;
+	}
+
+	/**
+	 * Returns a boolean config value.
+	 *
+	 * @param string $key Config key.
+	 *
+	 * @return bool
+	 */
+	public function get_boolean( $key ) {
+		return (bool) ( $this->values[ $key ] ?? false );
+	}
+
+	/**
+	 * Returns a string config value.
+	 *
+	 * @param string $key Config key.
+	 *
+	 * @return string
+	 */
+	public function get_string( $key ) {
+		return (string) ( $this->values[ $key ] ?? '' );
+	}
+}
+
+/**
+ * Calls is_rules_required() with a stub config.
+ *
+ * @param bool   $enabled Whether page cache is enabled.
+ * @param string $engine  Page cache engine.
+ *
+ * @return bool
+ */
+function prr_required( bool $enabled, string $engine ): bool {
+	$environment = new \W3TC\PgCache_Environment();
+	$method      = new \ReflectionMethod( '\W3TC\PgCache_Environment', 'is_rules_required' );
+	$method->setAccessible( true );
+
+	return $method->invoke(
+		$environment,
+		new PRR_Config_Stub(
+			array(
+				'pgcache.enabled' => $enabled,
+				'pgcache.engine'  => $engine,
+			)
+		)
+	);
+}
+
+// Defaults, with nothing hooked.
+prr_assert( '[1] required for Disk: Enhanced', true === prr_required( true, 'file_generic' ) );
+prr_assert( '[2] required for nginx + memcached', true === prr_required( true, 'nginx_memcached' ) );
+prr_assert( '[3] not required for Disk: Basic', false === prr_required( true, 'file' ) );
+prr_assert( '[4] not required when page cache is disabled', false === prr_required( false, 'file_generic' ) );
+
+// A callback returning false suppresses the rules.
+add_filter( 'w3tc_pgcache_rules_required', 'prr_return_false' );
+
+/**
+ * Returns false regardless of input.
+ *
+ * @return bool
+ */
+function prr_return_false(): bool {
+	return false;
+}
+
+prr_assert( '[5] a callback returning false suppresses the rules', false === prr_required( true, 'file_generic' ) );
+
+// The config object is passed to the callback.
+$GLOBALS['prr_filters'] = array();
+add_filter(
+	'w3tc_pgcache_rules_required',
+	function ( $required, $config ) {
+		return $required && 'file_generic' === $config->get_string( 'pgcache.engine' );
+	}
+);
+
+prr_assert( '[6] config reaches the callback, Disk: Enhanced kept', true === prr_required( true, 'file_generic' ) );
+prr_assert( '[7] config reaches the callback, other engine suppressed', false === prr_required( true, 'nginx_memcached' ) );
+
+// A non-boolean return is cast.
+$GLOBALS['prr_filters'] = array();
+add_filter(
+	'w3tc_pgcache_rules_required',
+	function () {
+		return 'yes';
+	}
+);
+
+prr_assert( '[8] a non-boolean return is cast to bool', true === prr_required( true, 'file_generic' ) );
+
+// A callback cannot turn the rules on where they are not used.
+$GLOBALS['prr_filters'] = array();
+add_filter(
+	'w3tc_pgcache_rules_required',
+	function () {
+		return true;
+	}
+);
+
+prr_assert( '[9] a callback cannot force rules on for Disk: Basic', false === prr_required( true, 'file' ) );
+prr_assert( '[10] a callback cannot force rules on when page cache is disabled', false === prr_required( false, 'file_generic' ) );
+
+echo "\n  Page cache rules-required filter\n";
+echo '  ' . \str_repeat( '-', 70 ) . "\n";
+
+foreach ( $prr_cases as $case ) {
+	$mark = 'PASS' === $case[0] ? 'PASS' : 'FAIL';
+	\printf( "  %s  %s\n", $mark, $case[1] );
+}
+
+echo "\n  Total: " . ( $prr_pass + $prr_fail )
+	. "  Passed: {$prr_pass}  Failed: {$prr_fail}\n\n";
+
+exit( $prr_fail > 0 ? 1 : 0 );


### PR DESCRIPTION
# Page Cache: add `w3tc_pgcache_rules_required` filter

Lets an integration tell W3TC not to write its page-cache rewrite rules, while W3TC keeps generating the cache files as usual. With nothing hooked, behaviour is unchanged.

## Why

When Page Cache runs on `file_generic` or `nginx_memcached`, W3TC always owns the rewrite rules, and there is no supported way to ask it to stand down while it keeps building the cache. An integration that serves `page_enhanced/` itself has to either fight W3TC over `.htaccess` / `nginx.conf` or turn page caching off, losing cache generation with it.

The closest thing available today is to inject a condition that can never match through `w3tc_pagecache_rules_apache_rewrite_cond`. That leaves the rules in the file, so they are still parsed and evaluated on every request, and it uses a filter meant for something else.

## The filter

```php
// PgCache_Environment::is_rules_required()
return $required && (bool) \apply_filters( 'w3tc_pgcache_rules_required', $required, $w3tc_c );

// integrator side
add_filter( 'w3tc_pgcache_rules_required', '__return_false' );
```

Both existing callers inherit it, so returning false stops the rules being written and removes blocks written earlier, on the Apache and the nginx path, and `get_required_rules()` returns null so the Install tab stops listing rules that are not on disk. Nothing on the cache-generation path reads this method.

It can only suppress: behind `$required &&` it is not consulted for configurations that never use rewrite rules, so a callback cannot switch rules on where W3TC would not have written them.

Minify already separates writing rewrite rules from generating files, through `minify.rewrite`; page cache has no equivalent. The filter name follows `w3tc_pgcache_rules_apache_last` in the same file.

## Two changes that come with it

- `PgCache_ContentGrabber::_check_rules_present()` returns early when rules are not required. It restores a missing cache-dir `.htaccess` on a front-end request, and once the rules are suppressed that file is never written, so without the exit the restore would fire on every cache miss. It asks through the existing public `get_required_rules()`, whose null return is its cheap branch, so no visibility changes anywhere. The check sits after the existing `file_exists()` exit, so the common path is untouched.
- The `pgcache.debug` rewrite test is gated on the same decision, since otherwise it reports a failure for a rewrite that is deliberately absent. The permalink check next to it still runs.

## Verification

- `phpcs --standard=phpcs.xml` and `php -l` clean on both changed files.
- New standalone test, in the style of `tests/test-apache-cache-rules.php`, with 10 assertions: defaults for `file_generic`, `nginx_memcached`, `file` and page cache disabled; suppression; the config object reaching the callback; the boolean cast; and that a callback cannot force rules on.
  Reverting the filter in the source fails 2 of them, so the test exercises the filter rather than merely running.
- Live stand, Disk: Enhanced. Default: rules and cache-dir `.htaccess` written as before. Suppressed: the rules block is gone from `.htaccess`, cache files keep being written, a front-end request does not bring the rules back, and removing the callback restores the previous state.
- nginx path: both rule blocks in `nginx.conf` removed and restored the same way.
- Restore path instrumented over three forced cache misses: entered on all three; `fix_on_wpadmin_request()` ran three times without the new guard and zero times with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7f15bfb89a7ac947c756b7f030a99e44154270a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->