### PR TITLE
ENG3-884: Omit development-only files from the public release ZIP

### DIFF
--- a/bin/build-release-zip.sh
+++ b/bin/build-release-zip.sh
@@ -234,7 +234,7 @@ if [[ -n "$forbidden" ]]; then
 fi
 
 forbidden_files="$(
-	unzip -l "$OUTPUT" | awk '{print $4}' | grep -E "^${PLUGIN_SLUG}/(\.sec-project\.yaml|phpcs\.xml|phpunit\.xml|AGENTS\.md|CLAUDE\.md)$" || true
+	unzip -l "$OUTPUT" | awk '{print $4}' | grep -E "^${PLUGIN_SLUG}/(\.jshintrc|\.sec-project\.yaml|AGENTS\.md|CLAUDE\.md|codecov|coverage\.xml|phpcs\.xml|phpunit\.xml)$" || true
 )"
 if [[ -n "$forbidden_files" ]]; then
 	echo 'error: ZIP contains development-only files' >&2

--- a/bin/build-release-zip.sh
+++ b/bin/build-release-zip.sh
@@ -153,9 +153,17 @@ rsync -a \
 	--exclude='.git/' \
 	--exclude='.github/' \
 	--exclude='node_modules/' \
+	--exclude='.claude/' \
 	--exclude='.cursor/' \
 	--exclude='.cursor/working/' \
 	--exclude='vendor/' \
+	--exclude='qa/' \
+	--exclude='ci/' \
+	--exclude='policies/' \
+	--exclude='rules/' \
+	--exclude='tmp/' \
+	--exclude='phpcs-rules/' \
+	--exclude='tests/' \
 	--exclude="${PLUGIN_SLUG}."*.zip \
 	--exclude='w3-total-cache.zip' \
 	"$PLUGIN_ROOT/" "$STAGING/"
@@ -169,10 +177,9 @@ patch_version_in_staging
 echo 'Installing production Composer dependencies...'
 composer install --no-dev --no-interaction --prefer-dist -o
 
-echo 'Applying release cleanup (bin/release.sh)...'
+echo 'Applying release cleanup (bin/release-strip-dev.sh)...'
 remove_vcs_metadata
-rm -f .jshintrc AGENTS.md CLAUDE.md codecov coverage.xml phpcs.xml
-rm -rf .claude .cursor qa
+bash bin/release-strip-dev.sh
 
 while IFS= read -r -d '' link; do
 	target="$(readlink -f "$link" || realpath "$link")"
@@ -190,34 +197,18 @@ bash bin/make-pot.sh
 rm -f package.* yarn.lock
 
 echo 'Applying wordpress-tag-sync cleanup...'
-rm -rf tests apigen coverage node_modules bin tools bower_components
+rm -rf node_modules bin
 remove_vcs_metadata
 rm -f \
 	.travis.yml \
-	release.sh \
-	Gruntfile.js \
-	gulpfile.js \
-	bower.json \
-	karma.conf.js \
-	karma.config.js \
 	yarn.lock \
-	webpack.config.js \
 	package.json \
-	.jscrsrc \
-	.jshintrc \
 	composer.json \
 	composer.lock \
-	phpunit.xml \
-	phpunit.xml.dist \
 	README.md \
-	.coveralls.yml \
 	.editorconfig \
-	.scrutinizer.yml \
-	apigen.neon \
-	CHANGELOG.txt \
 	stylelint.config.js \
-	.stylelintignore \
-	CONTRIBUTING.md
+	.stylelintignore
 
 verify_no_vcs_metadata
 
@@ -230,6 +221,24 @@ rm -f "$OUTPUT"
 if unzip -l "$OUTPUT" | grep -E '/\.git/|/\.git$' | grep -v '/\.github' >/dev/null 2>&1; then
 	echo 'error: ZIP contains .git paths' >&2
 	unzip -l "$OUTPUT" | grep -E '/\.git/|/\.git$' | grep -v '/\.github' >&2 || true
+	exit 1
+fi
+
+forbidden="$(
+	unzip -l "$OUTPUT" | awk '{print $4}' | grep -E "^${PLUGIN_SLUG}/(ci|policies|rules|tmp|phpcs-rules|qa|tests|bin|\.claude|\.cursor|\.github)(/|$)" || true
+)"
+if [[ -n "$forbidden" ]]; then
+	echo 'error: ZIP contains development-only paths' >&2
+	printf '%s\n' "$forbidden" >&2
+	exit 1
+fi
+
+forbidden_files="$(
+	unzip -l "$OUTPUT" | awk '{print $4}' | grep -E "^${PLUGIN_SLUG}/(\.sec-project\.yaml|phpcs\.xml|phpunit\.xml|AGENTS\.md|CLAUDE\.md)$" || true
+)"
+if [[ -n "$forbidden_files" ]]; then
+	echo 'error: ZIP contains development-only files' >&2
+	printf '%s\n' "$forbidden_files" >&2
 	exit 1
 fi
 

--- a/bin/release-strip-dev.sh
+++ b/bin/release-strip-dev.sh
@@ -11,25 +11,42 @@ if [[ ! -f w3-total-cache.php ]]; then
 	exit 1
 fi
 
-# Development, CI, and editor trees — not required at runtime.
-rm -rf \
-	.claude \
-	.cursor \
-	.github \
-	qa \
-	ci \
-	policies \
-	rules \
-	tmp \
-	phpcs-rules \
+strip_dirs=(
+	.claude
+	.cursor
+	.github
+	qa
+	ci
+	policies
+	rules
+	tmp
+	phpcs-rules
 	tests
+)
 
-rm -f \
-	.jshintrc \
-	.sec-project.yaml \
-	AGENTS.md \
-	CLAUDE.md \
-	codecov \
-	coverage.xml \
-	phpcs.xml \
+strip_files=(
+	.jshintrc
+	.sec-project.yaml
+	AGENTS.md
+	CLAUDE.md
+	codecov
+	coverage.xml
+	phpcs.xml
 	phpunit.xml
+)
+
+rm -rf "${strip_dirs[@]}"
+rm -f "${strip_files[@]}"
+
+leftover=()
+for path in "${strip_dirs[@]}" "${strip_files[@]}"; do
+	if [[ -e "$path" ]]; then
+		leftover+=( "$path" )
+	fi
+done
+
+if [[ ${#leftover[@]} -gt 0 ]]; then
+	echo 'error: development-only paths still present after strip:' >&2
+	printf '%s\n' "${leftover[@]}" >&2
+	exit 1
+fi

--- a/bin/release-strip-dev.sh
+++ b/bin/release-strip-dev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Remove development-only files from the current directory (plugin root).
+# Intended for Travis release.sh and local bin/build-release-zip.sh staging.
+# Does not remove bin/, composer.*, or package.json (needed until after
+# @since replacement and POT generation).
+
+set -euo pipefail
+
+if [[ ! -f w3-total-cache.php ]]; then
+	echo 'error: run from the plugin root' >&2
+	exit 1
+fi
+
+# Development, CI, and editor trees — not required at runtime.
+rm -rf \
+	.claude \
+	.cursor \
+	.github \
+	qa \
+	ci \
+	policies \
+	rules \
+	tmp \
+	phpcs-rules \
+	tests
+
+rm -f \
+	.jshintrc \
+	.sec-project.yaml \
+	AGENTS.md \
+	CLAUDE.md \
+	codecov \
+	coverage.xml \
+	phpcs.xml \
+	phpunit.xml

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -8,8 +8,14 @@ echo 'Finding and deleting .git folders.'
 find vendor/ -name '.git' -type d -print -exec rm -rf {} +
 
 # Cleanup development and build contents (keep package.json until after yarn aliases).
-rm -f .jshintrc AGENTS.md CLAUDE.md codecov coverage.xml phpcs.xml
-rm -rf .claude .cursor .github qa
+bash bin/release-strip-dev.sh
+
+leftover="$(ls -d ci policies rules tmp phpcs-rules qa tests .claude .cursor .github 2>/dev/null || true)"
+if [[ -n "$leftover" ]]; then
+	echo 'error: development-only paths still present after strip:' >&2
+	printf '%s\n' "$leftover" >&2
+	exit 1
+fi
 
 # Find and replace symlinks in the "vendor" directory.
 for i in $(find vendor/ -type l); do \cp -f --remove-destination $(realpath $i) $i;done

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,13 +10,6 @@ find vendor/ -name '.git' -type d -print -exec rm -rf {} +
 # Cleanup development and build contents (keep package.json until after yarn aliases).
 bash bin/release-strip-dev.sh
 
-leftover="$(ls -d ci policies rules tmp phpcs-rules qa tests .claude .cursor .github 2>/dev/null || true)"
-if [[ -n "$leftover" ]]; then
-	echo 'error: development-only paths still present after strip:' >&2
-	printf '%s\n' "$leftover" >&2
-	exit 1
-fi
-
 # Find and replace symlinks in the "vendor" directory.
 for i in $(find vendor/ -type l); do \cp -f --remove-destination $(realpath $i) $i;done
 


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG3-884

## Summary
- Strip development-only paths from the Travis/wordpress-tag-sync release tree before the public ZIP is built.
- Share that list in `bin/release-strip-dev.sh` and fail if any listed path remains.
- Apply the same strip and ZIP checks in `bin/build-release-zip.sh`. The list only names paths that exist in this repo (plus Travis-generated `codecov` / `coverage.xml`).

## Test plan
- [ ] Confirm `bin/release-strip-dev.sh` removes `ci/`, `policies/`, `rules/`, `tmp/`, `phpcs-rules/`, `qa/`, `tests/`, and the listed tooling files, and keeps `inc/`, `lib/`, `pub/`, `ini/`, `languages/`, `wp-content/`, `vendor/`, and `extension-example/`.
- [ ] Run `yarn run build:release <version>` and confirm the ZIP does not contain those development paths.
- [ ] On the next tagged Travis build, confirm the GitHub Releases ZIP matches the same production tree.